### PR TITLE
Prevent bus stalling

### DIFF
--- a/src/i3c.sv
+++ b/src/i3c.sv
@@ -884,6 +884,7 @@ module i3c
   logic                          csr_tti_tx_desc_reg_rst;
   logic                          csr_tti_tx_desc_reg_rst_we;
   logic                          csr_tti_tx_desc_reg_rst_data;
+  logic                          csr_tti_tx_desc_full;
 
   // TTI RX data queue
   logic                          csr_tti_rx_data_req;
@@ -953,6 +954,7 @@ module i3c
       .tx_desc_queue_reg_rst_o     (csr_tti_tx_desc_reg_rst),
       .tx_desc_queue_reg_rst_we_i  (csr_tti_tx_desc_reg_rst_we),
       .tx_desc_queue_reg_rst_data_i(csr_tti_tx_desc_reg_rst_data),
+      .tx_desc_queue_full_i        (csr_tti_tx_desc_full),
 
       // TTI RX queue
       .rx_data_queue_req_o         (csr_tti_rx_data_req),
@@ -983,6 +985,7 @@ module i3c
       .tx_data_queue_full_i        (csr_tti_tx_data_full),
 
       // TTI In-band Interrupt (IBI) queue
+      .ibi_queue_full_i        (tti_ibi_full),
       .ibi_queue_req_o         (csr_tti_ibi_req),
       .ibi_queue_ack_i         (csr_tti_ibi_ack),
       .ibi_queue_data_o        (csr_tti_ibi_data),
@@ -1064,6 +1067,7 @@ module i3c
       .csr_tti_tx_desc_queue_reg_rst_i     (csr_tti_tx_desc_reg_rst),
       .csr_tti_tx_desc_queue_reg_rst_we_o  (csr_tti_tx_desc_reg_rst_we),
       .csr_tti_tx_desc_queue_reg_rst_data_o(csr_tti_tx_desc_reg_rst_data),
+      .csr_tti_tx_desc_queue_full_o        (csr_tti_tx_desc_full),
 
       // TTI RX queue
       .csr_tti_rx_data_queue_req_i         (csr_tti_rx_data_req),

--- a/src/recovery/recovery_handler.sv
+++ b/src/recovery/recovery_handler.sv
@@ -120,6 +120,7 @@ module recovery_handler
     output logic                          csr_tti_rx_desc_queue_ready_thld_trig_o,
 
     // TX Descriptor queue
+    output logic                          csr_tti_tx_desc_queue_full_o,
     input  logic                          csr_tti_tx_desc_queue_req_i,
     output logic                          csr_tti_tx_desc_queue_ack_o,
     input  logic [      CsrDataWidth-1:0] csr_tti_tx_desc_queue_data_i,
@@ -722,6 +723,7 @@ module recovery_handler
   // T1MUX disconnects this FIFO from TTI logic
   logic exec_tti_tx_desc_queue_clr;
 
+  assign csr_tti_tx_desc_queue_full_o = tti_tx_desc_queue_full;
   assign csr_tti_tx_desc_queue_ack_o = tti_tx_desc_queue_ack;
   assign csr_tti_tx_desc_queue_reg_rst_we_o = tti_tx_desc_queue_reg_rst_we;
   assign csr_tti_tx_desc_queue_reg_rst_data_o = tti_tx_desc_queue_reg_rst_data;

--- a/verification/cocotb/block/hci_queues_ahb/hci_queues_wrapper.sv
+++ b/verification/cocotb/block/hci_queues_ahb/hci_queues_wrapper.sv
@@ -470,6 +470,7 @@ module hci_queues_wrapper
       .rx_desc_queue_reg_rst_o     (csr_tti_rx_desc_queue_reg_rst),
       .rx_desc_queue_reg_rst_we_i  (csr_tti_rx_desc_queue_reg_rst_we),
       .rx_desc_queue_reg_rst_data_i(csr_tti_rx_desc_queue_reg_rst_data),
+      .rx_desc_queue_empty_i       (tti_rx_desc_empty_o),
 
       // TTI TX descriptors queue
       .tx_desc_queue_req_o         (csr_tti_tx_desc_queue_req),
@@ -480,6 +481,7 @@ module hci_queues_wrapper
       .tx_desc_queue_reg_rst_o     (csr_tti_tx_desc_queue_reg_rst),
       .tx_desc_queue_reg_rst_we_i  (csr_tti_tx_desc_queue_reg_rst_we),
       .tx_desc_queue_reg_rst_data_i(csr_tti_tx_desc_queue_reg_rst_data),
+      .tx_desc_queue_full_i        (tti_tx_desc_full_o),
 
       // TTI RX queue
       .rx_data_queue_req_o         (csr_tti_rx_data_queue_req),
@@ -491,6 +493,7 @@ module hci_queues_wrapper
       .rx_data_queue_reg_rst_o     (csr_tti_rx_data_queue_reg_rst),
       .rx_data_queue_reg_rst_we_i  (csr_tti_rx_data_queue_reg_rst_we),
       .rx_data_queue_reg_rst_data_i(csr_tti_rx_data_queue_reg_rst_data),
+      .rx_data_queue_empty_i       (tti_rx_empty_o),
 
       // TTI TX queue
       .tx_data_queue_req_o         (csr_tti_tx_data_queue_req),
@@ -512,6 +515,7 @@ module hci_queues_wrapper
       .ibi_queue_reg_rst_o     (csr_tti_ibi_queue_reg_rst),
       .ibi_queue_reg_rst_we_i  (csr_tti_ibi_queue_reg_rst_we),
       .ibi_queue_reg_rst_data_i(csr_tti_ibi_queue_reg_rst_data),
+      .ibi_queue_full_i        (tti_ibi_full_o),
 
       .bypass_i3c_core_i,
 

--- a/verification/cocotb/block/hci_queues_axi/hci_queues_wrapper.sv
+++ b/verification/cocotb/block/hci_queues_axi/hci_queues_wrapper.sv
@@ -542,6 +542,7 @@ module hci_queues_wrapper
       .rx_desc_queue_reg_rst_o     (csr_tti_rx_desc_queue_reg_rst),
       .rx_desc_queue_reg_rst_we_i  (csr_tti_rx_desc_queue_reg_rst_we),
       .rx_desc_queue_reg_rst_data_i(csr_tti_rx_desc_queue_reg_rst_data),
+      .rx_desc_queue_empty_i       (tti_rx_desc_empty_o),
 
       // TTI TX descriptors queue
       .tx_desc_queue_req_o         (csr_tti_tx_desc_queue_req),
@@ -552,6 +553,7 @@ module hci_queues_wrapper
       .tx_desc_queue_reg_rst_o     (csr_tti_tx_desc_queue_reg_rst),
       .tx_desc_queue_reg_rst_we_i  (csr_tti_tx_desc_queue_reg_rst_we),
       .tx_desc_queue_reg_rst_data_i(csr_tti_tx_desc_queue_reg_rst_data),
+      .tx_desc_queue_full_i        (tti_tx_desc_full_o),
 
       // TTI RX queue
       .rx_data_queue_req_o         (csr_tti_rx_data_queue_req),
@@ -563,6 +565,7 @@ module hci_queues_wrapper
       .rx_data_queue_reg_rst_o     (csr_tti_rx_data_queue_reg_rst),
       .rx_data_queue_reg_rst_we_i  (csr_tti_rx_data_queue_reg_rst_we),
       .rx_data_queue_reg_rst_data_i(csr_tti_rx_data_queue_reg_rst_data),
+      .rx_data_queue_empty_i       (tti_rx_empty_o),
 
       // TTI TX queue
       .tx_data_queue_req_o         (csr_tti_tx_data_queue_req),
@@ -584,6 +587,7 @@ module hci_queues_wrapper
       .ibi_queue_reg_rst_o     (csr_tti_ibi_queue_reg_rst),
       .ibi_queue_reg_rst_we_i  (csr_tti_ibi_queue_reg_rst_we),
       .ibi_queue_reg_rst_data_i(csr_tti_ibi_queue_reg_rst_data),
+      .ibi_queue_full_i        (tti_ibi_full_o),
 
       .bypass_i3c_core_i,
 

--- a/verification/cocotb/block/lib_hci_queues/test_read_write_ports.py
+++ b/verification/cocotb/block/lib_hci_queues/test_read_write_ports.py
@@ -254,26 +254,6 @@ async def write_read_tti_tx_desc_queue(dut: SimHandleBase):
     await ClockCycles(tb.clk, 10)
 
 
-@cocotb.test()
-async def overflow_tti_tx_desc_queue(dut: SimHandleBase):
-    """
-    Enqueue multiple transfers through COMMAND_PORT and verify
-    whether the data matches after fetching it from the controller
-    """
-    tb = TTIQueuesTestInterface(dut)
-    await tb.setup()
-
-    data = [randint(1, 2**32 - 1) for _ in range(QUEUE_SIZE + TEST_SIZE)]
-    await test_write(data[:-TEST_SIZE], tb.put_tx_desc)
-
-    write_coroutine = cocotb.start_soon(test_write(data[-TEST_SIZE:], tb.put_tx_desc))
-    await ClockCycles(tb.clk, 10)
-
-    read_coroutine = cocotb.start_soon(test_read(data, tb.get_tx_desc))
-
-    await Combine(write_coroutine, read_coroutine)
-    await ClockCycles(tb.clk, 10)
-
 
 @cocotb.test()
 async def underflow_tti_tx_desc_queue(dut: SimHandleBase):
@@ -304,27 +284,6 @@ async def write_read_tti_tx_queue(dut: SimHandleBase):
 
     tx_data = [randint(1, 2**32 - 1) for _ in range(TEST_SIZE)]
     await test_write_read(tx_data, tb.put_tx_data, tb.get_tx_data)
-    await ClockCycles(tb.clk, 10)
-
-
-@cocotb.test()
-async def overflow_tti_tx_queue(dut: SimHandleBase):
-    """
-    Place TX data through XFER_DATA_PORT (and overflow it) & verify it from the
-    other (controller's) side of the queue
-    """
-    tb = TTIQueuesTestInterface(dut)
-    await tb.setup()
-
-    tx_data = [randint(1, 2**32 - 1) for _ in range(QUEUE_SIZE + TEST_SIZE)]
-    await test_write(tx_data[:-TEST_SIZE], tb.put_tx_data)
-
-    write_coroutine = cocotb.start_soon(test_write(tx_data[-TEST_SIZE:], tb.put_tx_data))
-    await ClockCycles(tb.clk, 10)
-
-    read_coroutine = cocotb.start_soon(test_read(tx_data, tb.get_tx_data))
-
-    await Combine(write_coroutine, read_coroutine)
     await ClockCycles(tb.clk, 10)
 
 
@@ -380,24 +339,6 @@ async def overflow_tti_rx_queue(dut: SimHandleBase):
 
 
 @cocotb.test()
-async def underflow_tti_rx_queue(dut: SimHandleBase):
-    """
-    Fetch data from RX Queue to cause underflow and write the data to ensure
-    it's correct when available
-    """
-    tb = TTIQueuesTestInterface(dut)
-    await tb.setup()
-
-    rx_data = [randint(1, 2**32 - 1) for _ in range(TEST_SIZE)]
-    read_coroutine = cocotb.start_soon(test_read(rx_data, tb.get_rx_data))
-    await ClockCycles(tb.clk, 10)
-    write_coroutine = cocotb.start_soon(test_write(rx_data, tb.put_rx_data))
-
-    await Combine(write_coroutine, read_coroutine)
-    await ClockCycles(tb.clk, 10)
-
-
-@cocotb.test()
 async def fetch_response_from_tti_rx_desc_port(dut: SimHandleBase):
     """
     Put response into the response queue (from controller logic) & fetch it from
@@ -433,24 +374,6 @@ async def overflow_tti_rx_desc_queue(dut: SimHandleBase):
 
 
 @cocotb.test()
-async def underflow_tti_rx_desc_queue(dut: SimHandleBase):
-    """
-    Fetch data from Response Queue to cause underflow and write the data to ensure
-    it's correct when available
-    """
-    tb = TTIQueuesTestInterface(dut)
-    await tb.setup()
-
-    data = [randint(1, 2**32 - 1) for _ in range(TEST_SIZE)]
-    read_coroutine = cocotb.start_soon(test_read(data, tb.get_rx_desc))
-    await ClockCycles(tb.clk, 10)
-    write_coroutine = cocotb.start_soon(test_write(data, tb.put_rx_desc))
-
-    await Combine(write_coroutine, read_coroutine)
-    await ClockCycles(tb.clk, 10)
-
-
-@cocotb.test()
 async def write_read_ibi_queue(dut: SimHandleBase):
     """
     Put read data onto the IBI queue & fetch it through IBI_PORT
@@ -460,26 +383,6 @@ async def write_read_ibi_queue(dut: SimHandleBase):
 
     ibi_data = [randint(1, 2**32 - 1) for _ in range(TEST_SIZE)]
     await test_write_read(ibi_data, tb.put_ibi_data, tb.get_ibi_data)
-    await ClockCycles(tb.clk, 10)
-
-
-@cocotb.test()
-async def overflow_ibi_queue(dut: SimHandleBase):
-    """
-    Put read data onto the IBI queue (and overflow it) & fetch it through IBI_PORT
-    """
-    tb = HCIQueuesTestInterface(dut)
-    await tb.setup()
-
-    ibi_data = [randint(1, 2**32 - 1) for _ in range(QUEUE_SIZE + TEST_SIZE)]
-    await test_write(ibi_data[:-TEST_SIZE], tb.put_ibi_data)
-
-    write_coroutine = cocotb.start_soon(test_write(ibi_data[-TEST_SIZE:], tb.put_ibi_data))
-    await ClockCycles(tb.clk, 10)
-
-    read_coroutine = cocotb.start_soon(test_read(ibi_data, tb.get_ibi_data))
-
-    await Combine(write_coroutine, read_coroutine)
     await ClockCycles(tb.clk, 10)
 
 

--- a/verification/cocotb/block/lib_hci_queues/tti_queues.py
+++ b/verification/cocotb/block/lib_hci_queues/tti_queues.py
@@ -31,6 +31,9 @@ class TTIQueuesTestInterface(HCIBaseTestInterface):
         self.dut.tti_tx_flush_i.value = 0
         self.dut.bypass_i3c_core_i.value = 0
 
+        if hasattr(self.dut, "disable_id_filtering_i"):
+            self.dut.disable_id_filtering_i.value = 1
+
         await super()._setup(get_frontend_bus_if())
 
     async def reset(self):

--- a/verification/cocotb/top/lib_i3c_top/test_bus_stall.py
+++ b/verification/cocotb/top/lib_i3c_top/test_bus_stall.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+import random
+
+from bus2csr import dword2int, int2dword
+from interface import I3CTopTestInterface
+
+import cocotb
+from cocotb.triggers import Timer
+
+TRANSACTION_COUNT = 1024
+
+async def timeout_task(timeout):
+    await Timer(timeout, "us")
+    raise RuntimeError("Test timeout!")
+
+
+async def initialize(dut, fclk=100.0, timeout=50):
+    """
+    Common test initialization routine
+    """
+
+    cocotb.log.setLevel(logging.DEBUG)
+
+    # Start the background timeout task
+    await cocotb.start(timeout_task(timeout))
+
+    tb = I3CTopTestInterface(dut)
+    await tb.setup(fclk)
+    return tb
+
+
+async def test_read(tb, reg):
+    # try reading empty fifo multiple times
+    for _ in range(TRANSACTION_COUNT):
+        data = dword2int(
+            await tb.read_csr(reg, 4)
+        )
+        # we should not stall and the data should be read as zero
+        assert data == 0
+
+
+@cocotb.test()
+async def test_empty_rx_desc_read(dut):
+    tb = await initialize(dut)
+    await test_read(tb, tb.reg_map.I3C_EC.TTI.RX_DESC_QUEUE_PORT.base_addr)
+
+
+@cocotb.test()
+async def test_empty_rx_data_read(dut):
+    tb = await initialize(dut)
+    await test_read(tb, tb.reg_map.I3C_EC.TTI.RX_DATA_PORT.base_addr)
+
+
+@cocotb.test()
+async def test_empty_indirect_fifo_read(dut):
+    tb = await initialize(dut)
+    await test_read(tb, tb.reg_map.I3C_EC.SECFWRECOVERYIF.INDIRECT_FIFO_DATA.base_addr)
+
+@cocotb.test()
+async def test_full_tx_desc_write(dut):
+    tb = await initialize(dut)
+    for _ in range(TRANSACTION_COUNT):
+        await tb.write_csr(tb.reg_map.I3C_EC.TTI.TX_DESC_QUEUE_PORT.base_addr, int2dword(random.randint(0, 0xffffffff)), 4)
+
+@cocotb.test()
+async def test_full_tx_data_write(dut):
+    tb = await initialize(dut)
+    for _ in range(TRANSACTION_COUNT):
+        await tb.write_csr(tb.reg_map.I3C_EC.TTI.TX_DATA_PORT.base_addr, int2dword(random.randint(0, 0xffffffff)), 4)
+
+@cocotb.test()
+async def test_full_ibi_write(dut):
+    tb = await initialize(dut)
+    for _ in range(TRANSACTION_COUNT):
+        await tb.write_csr(tb.reg_map.I3C_EC.TTI.IBI_PORT.base_addr, int2dword(random.randint(0, 0xffffffff)), 4)


### PR DESCRIPTION
Do not stall bus on reading from empty FIFO or writing to full. Reads from empty FIFOs return 0, writes to full FIFOs are ignored.

Fixes #32 