### PR TITLE
v1p5 - tooling & docs improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,10 @@ __pycache__
 *.sym
 *.vcd
 *.vpd
+*.fst
+*.fsdb
+novas.*
+verdiLog
 *.xml
 build/
 configs/
@@ -29,6 +33,7 @@ program.hex
 questa_work/
 results.xml
 sim_build/
+**sim_build**
 sim/
 src/csr/html/
 src/csr/md/

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Antmicro <www.antmicro.com>
 # SPDX-License-Identifier: Apache-2.0
 
-SHELL = /bin/bash
+SHELL   = bash
 
 # Directory structure
 I3C_ROOT_DIR        := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))

--- a/Makefile
+++ b/Makefile
@@ -2,30 +2,32 @@
 # SPDX-License-Identifier: Apache-2.0
 
 SHELL   = bash
+PYTHON ?= python3
 
 # Directory structure
 I3C_ROOT_DIR        := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
-
-SRC_DIR             := $(I3C_ROOT_DIR)/src/
-VERIFICATION_DIR    := $(I3C_ROOT_DIR)/verification/
-THIRD_PARTY_DIR     := $(I3C_ROOT_DIR)/third_party/
+SRC_DIR             := $(I3C_ROOT_DIR)/src
+VERIFICATION_DIR    := $(I3C_ROOT_DIR)/verification
+THIRD_PARTY_DIR     := $(I3C_ROOT_DIR)/third_party
 
 COCOTB_VERIF_DIR    := $(VERIFICATION_DIR)/cocotb
 BLOCK_VERIF_DIR     := $(COCOTB_VERIF_DIR)/block
 TOP_VERIF_DIR       := $(COCOTB_VERIF_DIR)/top
-TOOL_VERIF_DIR      := $(VERIFICATION_DIR)/tools/
-UVM_VERIF_DIR       := $(VERIFICATION_DIR)/uvm_i3c/
+TOOL_VERIF_DIR      := $(VERIFICATION_DIR)/tools
+UVM_VERIF_DIR       := $(VERIFICATION_DIR)/uvm_i3c
 TESTPLAN_DIR        := $(VERIFICATION_DIR)/testplan
 
-TOOL_DIR            := $(I3C_ROOT_DIR)/tools/
-UVM_TOOL_DIR        := $(TOOL_DIR)/uvm/
-GENERIC_UVM_DIR     := $(UVM_TOOL_DIR)/generic/## Path: UVM installation directory
-VERILATOR_UVM_DIR   := $(UVM_TOOL_DIR)/verilator/## Path: UVM installation directory with Verilator patches
+TOOL_DIR            := $(I3C_ROOT_DIR)/tools
+UVM_TOOL_DIR        := $(TOOL_DIR)/uvm
+GENERIC_UVM_DIR     := $(UVM_TOOL_DIR)/generic## Path: UVM installation directory
+VERILATOR_UVM_DIR   := $(UVM_TOOL_DIR)/verilator## Path: UVM installation directory with Verilator patches
 
 CALIPTRA_ROOT       ?= $(THIRD_PARTY_DIR)/caliptra-rtl## Path: caliptra-rtl repository
+
 # TODO: Connect to version selection in tools/simulators/
 UVM_DIR             ?= $(VERILATOR_UVM_DIR)/## Select UVM version
 SIMULATOR           ?= verilator## Supported: verilator, dsim, questa, vcs
+
 REPO_URL            ?= https://github.com/chipsalliance/i3c-core/tree/main/
 
 # Path to directory with XMLs with tests' results
@@ -33,7 +35,17 @@ TESTS_RESULTS_DIR   ?= $(COCOTB_VERIF_DIR)
 # Base directory present in "file" entries in XMLs with cocotb results
 TESTS_XML_BASE_PATH ?= $(I3C_ROOT_DIR)
 
+NOX                 ?= $(PYTHON) -m nox $(NOX_COMMON_ARGS) $(NOX_EXTRA_ARGS)
+## The python environment is managed outside of Nox, so always pass these flags
+NOX_COMMON_ARGS     ?= -R --no-venv
+NOX_EXTRA_ARGS      ?=
+COCOTB_NOXFILE      := $(COCOTB_VERIF_DIR)/noxfile.py
+UVM_NOXFILE         := $(UVM_VERIF_DIR)/noxfile.py
+TOOL_NOXFILE        := $(TOOL_VERIF_DIR)/noxfile.py
+
+
 NUM_PROC            := $$(($$(nproc)-1))
+
 # Environment variables
 export I3C_ROOT_DIR
 export CALIPTRA_ROOT
@@ -49,17 +61,25 @@ ifeq ($(MAKECMDGOALS), test)
     endif
 endif
 
+################################################################################
 #
 # I3C configuration
 #
-CFG_FILE            ?= $(I3C_ROOT_DIR)/i3c_core_configs.yaml## Path: YAML file holding configuration of the I3C RTL
-CFG_NAME            ?= ahb## Valid configuration name from the YAML configuration file
-CFG_GEN              = $(TOOL_DIR)/i3c_config/i3c_core_config.py
+# - The 'config' target builds any output collateral needed for the selected configuration
+#   - This includes RTL headers files / defines and RDL
+#   - This should be run before any other operations, and may leave in-tree untracked files
+# - The 'config-print' target prints the selected config according to the variable selection
+
+## Configuration generator tool
+CFG_GEN   = $(TOOL_DIR)/i3c_config/i3c_core_config.py
+## YAML file holding valid configuration sets for the I3C RTL
+CFG_FILE ?= $(I3C_ROOT_DIR)/i3c_core_configs.yaml
+## Selected configuration to use from CFG_FILE
+CFG_NAME ?= ahb
 
 config: config-rtl config-rdl ## Generate RDL and RTL configuration files
 
-PYTHON ?= python3
-config-rtl: config-print ## Generate top I3C definitions svh file
+config-rtl: config-print ## Generate top I3C definitions .svh file
 	$(PYTHON) $(CFG_GEN) $(CFG_NAME) $(CFG_FILE) svh_file --output-file $(SRC_DIR)/i3c_defines.svh
 
 RDL_REGS    := $(SRC_DIR)/rdl/registers.rdl
@@ -69,23 +89,28 @@ RDL_ARGS    := $(shell $(PYTHON) $(CFG_GEN) $(CFG_NAME) $(CFG_FILE) reg_gen_opts
 config-rdl: config-print
 	$(PYTHON) $(TOOL_DIR)/reg_gen/reg_gen.py --input-file=$(RDL_REGS) --output-dir=$(RDL_GEN_DIR) $(RDL_ARGS) $(EXTRA_REG_GEN_ARGS)
 
-config-print: ## Print configuration name, filename and RDL arguments
-	@echo Using \'$(CFG_NAME)\' I3C configuration from \'$(CFG_FILE)\'.
-	@echo Using RDL options: $(RDL_ARGS).
+config-print:
+	@echo ""
+	@echo "I3C configuration:         $(CFG_NAME)"
+	@echo "I3C configuration file:    $(CFG_FILE)"
+	@echo "RDL options:               $(RDL_ARGS)"
+	@echo ""
 
+################################################################################
 #
-# Source code lint and format
+# Source code lint and formatting
 #
+
 lint: lint-rtl lint-tests ## Run RTL and tests lint
 
 lint-check: lint-rtl ## Run RTL lint and check lint on tests source code without fixing errors
-	cd $(COCOTB_VERIF_DIR) && $(PYTHON) -m nox -R -s test_lint --no-venv
+	$(NOX) -f $(COCOTB_NOXFILE) -s test_lint
 
 lint-rtl: ## Run lint on RTL source code
 	$(SHELL) $(TOOL_DIR)/verible-scripts/run.sh
 
 lint-tests: ## Run lint on tests source code
-	cd $(COCOTB_VERIF_DIR) && $(PYTHON) -m nox -R -s lint --no-venv
+	$(NOX) -f $(COCOTB_NOXFILE) -s lint
 
 lint-verilator:
 	verilator --timing -Wall --lint-only -f $(I3C_ROOT_DIR)/src/i3c.f
@@ -93,48 +118,10 @@ lint-verilator:
 build-verilator:
 	verilator --timing -Wall --binary -f $(I3C_ROOT_DIR)/src/i3c.f
 
+################################################################################
 #
-# Tests
+# Testplanning
 #
-test: config ## Run single module test (use `TEST=<test_name>` flag)
-	cd $(COCOTB_VERIF_DIR) && $(PYTHON) -m nox -R -s $(TEST)_verify --no-venv
-
-tests-axi: ## Run all verification/cocotb/* RTL tests for AXI bus configuration without coverage
-	$(MAKE) config CFG_NAME=axi
-	cd $(COCOTB_VERIF_DIR) && $(PYTHON) -m nox -R -t "axi" --no-venv --forcecolor
-
-tests-ahb: ## Run all verification/cocotb/* RTL tests for AHB bus configuration without coverage
-	$(MAKE) config CFG_NAME=ahb
-	cd $(COCOTB_VERIF_DIR) && $(PYTHON) -m nox -R -t "ahb" --no-venv --forcecolor
-
-tests: tests-axi tests-ahb ## Run all verification/cocotb/* RTL tests fro AHB and AXI bus configurations without coverage
-
-tests-i2c: ## Run all I2C tests without coverage
-	$(MAKE) config CFG_NAME=ahb
-	cd $(COCOTB_VERIF_DIR) && $(PYTHON) -m nox -R -t "i2c" --no-venv --forcecolor
-
-# TODO: Enable full coverage flow
-tests-coverage: ## Run all verification/block/* RTL tests with coverage
-	cd $(COCOTB_VERIF_DIR) && BLOCK_COVERAGE_ENABLE=1 $(PYTHON) -m nox -R -k "verify" --no-venv
-
-test-i3c-vip-uvm: config ## Run single I3C VIP UVM test with nox (use 'TEST=<i3c_driver|i3c_monitor>' flag)
-	cd $(UVM_VERIF_DIR) && $(PYTHON) -m nox -R -s $(TEST) --no-venv
-
-tests-i3c-vip-uvm: config ## Run all I3C VIP UVM tests with nox
-	cd $(UVM_VERIF_DIR) && $(PYTHON) -m nox -R -s "i3c_verify_uvm" --no-venv
-
-tests-i3c-vip-uvm-debug: config ## Run debugging I3C VIP UVM tests with nox
-	cd $(UVM_VERIF_DIR) && $(PYTHON) -m nox -R -t "uvm_debug_tests" --no-venv
-
-tests-uvm: config ## Run all I3C Core UVM tests with nox
-	cd $(UVM_VERIF_DIR) && $(PYTHON) -m nox -R -s "i3c_core_verify_uvm" --no-venv
-
-tests-uvm-debug: config ## Run debugging I3C Core UVM tests with nox
-	cd $(UVM_VERIF_DIR) && $(PYTHON) -m nox -R -s "i3c_core_uvm_debug_tests" --no-venv
-
-tests-tool: ## Run all tool tests
-	cd $(TOOL_VERIF_DIR) && $(PYTHON) -m nox -k "verify" --no-venv
-
 
 BLOCKS_VERIFICATION_PLANS = $(shell find $(TESTPLAN_DIR) -type f -name "*.hjson" ! -name "target*.hjson" | sort)
 CORE_VERIFICATION_PLANS = $(shell find $(TESTPLAN_DIR) -type f -name "*target*.hjson" | sort)
@@ -153,14 +140,83 @@ verification-docs-with-sim: cocotbxml-to-hjson-sim-results
 	testplanner $(BLOCKS_VERIFICATION_PLANS) -s $(BLOCKS_VERIFICATION_SIM_RESULTS) -ot $(TESTPLAN_DIR)/generated/testplans_blocks.md -os $(TESTPLAN_DIR)/generated/sim-results --output-summary-title "Tests for individual blocks" --output-summary $(TESTPLAN_DIR)/generated/sim-results/index-blocks.html --project-root $(I3C_ROOT_DIR) --testplan-file-map $(TESTPLAN_DIR)/source-maps.yml --source-url-prefix $(REPO_URL)
 	testplanner $(CORE_VERIFICATION_PLANS) -s $(CORE_VERIFICATION_SIM_RESULTS) -ot $(TESTPLAN_DIR)/generated/testplans_core.md -os $(TESTPLAN_DIR)/generated/sim-results --output-summary-title "Tests for the core" --output-summary $(TESTPLAN_DIR)/generated/sim-results/index-top.html --project-root $(I3C_ROOT_DIR) --testplan-file-map $(TESTPLAN_DIR)/source-maps.yml --source-url-prefix $(REPO_URL)
 	cat $(TESTPLAN_DIR)/generated/sim-results/index-blocks.html $(TESTPLAN_DIR)/generated/sim-results/index-top.html > $(TESTPLAN_DIR)/generated/sim-results/index.html
-#
-# Utilities
-#
-timings: ## Generate values for I2C/I3C timings
-	$(PYTHON) $(TOOL_DIR)/timing/timing.py
 
-deps: ## Install python dependencies
-	pip install -r $(I3C_ROOT_DIR)/requirements.txt
+################################################################################
+#
+# Tests
+#
+
+list-tests:
+	$(NOX) -f $(COCOTB_NOXFILE) --list
+	$(NOX) -f $(UVM_NOXFILE)    --list
+	$(NOX) -f $(TOOL_NOXFILE)  --list
+
+# COCOTB
+
+# All tests map to the testplan, and are implemented as a Nox session named "$(TEST)_verify"
+# Passing the testname as `TEST=<test_name>` will run all sub-testpoints associated with the test
+#
+test: config ## Run all testpoints for a single test (use `TEST=<test_name>` flag)
+	$(MAKE) config CFG_NAME=$(CFG_NAME)
+	$(NOX) -f $(COCOTB_NOXFILE) -s $(TEST)_verify
+
+test-s: config
+	$(MAKE) config CFG_NAME=$(CFG_NAME)
+	$(NOX) -f $(COCOTB_NOXFILE) -s $(TEST)
+
+tests: tests-axi tests-ahb ## Run all verification/cocotb/* RTL tests fro AHB and AXI bus configurations without coverage
+
+tests-axi: ## Run all verification/cocotb/* RTL tests for AXI bus configuration without coverage
+	$(MAKE) config CFG_NAME=axi
+	$(NOX) -f $(COCOTB_NOXFILE) -t "axi"
+
+tests-ahb: ## Run all verification/cocotb/* RTL tests for AHB bus configuration without coverage
+	$(MAKE) config CFG_NAME=ahb
+	$(NOX) -f $(COCOTB_NOXFILE) -t "ahb"
+
+tests-i2c: ## Run all I2C tests without coverage
+	$(MAKE) config CFG_NAME=ahb
+	$(NOX) -f $(COCOTB_NOXFILE) -t "i2c"
+
+# TODO: Enable full coverage flow
+tests-coverage: ## Run all verification/block/* RTL tests with coverage
+	cd $(COCOTB_VERIF_DIR) && BLOCK_COVERAGE_ENABLE=1 $(NOX) -k "verify"
+
+# UVM
+
+test-i3c-uvm-tag: config
+	$(NOX) -f $(UVM_NOXFILE) -t $(TAG)
+
+test-i3c-uvm-session: config
+	$(NOX) -f $(UVM_NOXFILE) -s $(TEST)
+
+test-i3c-vip-uvm: config ## Run single I3C VIP UVM test (use 'TEST=<i3c_driver|i3c_monitor>' flag)
+	$(NOX) -f $(UVM_NOXFILE) -s $(TEST)
+
+tests-i3c-vip-uvm: config ## Run all I3C VIP UVM tests
+	$(NOX) -f $(UVM_NOXFILE) -s "i3c_verify_uvm"
+
+tests-i3c-vip-uvm-debug: config ## Run debugging I3C VIP UVM tests
+	$(NOX) -f $(UVM_NOXFILE) -t "uvm_debug_tests"
+
+tests-uvm: config ## Run all I3C Core UVM tests
+	$(NOX) -f $(UVM_NOXFILE) -s "i3c_core_verify_uvm"
+
+tests-uvm-debug: config ## Run debugging I3C Core UVM tests
+	$(NOX) -f $(UVM_NOXFILE) -t "i3c_core_uvm_debug_tests"
+
+# Tools
+
+tests-tool: ## Run all tool tests
+	$(NOX) -f $(TOOL_NOXFILE) -k "verify"
+
+################################################################################
+#
+# Misc & Utilities
+#
+
+print-timings: ## Generate values for I2C/I3C timings
+	$(PYTHON) $(TOOL_DIR)/timing/timing.py
 
 install-uvm:
 	cd $(TOOL_DIR)/uvm/ && bash install-uvm.sh
@@ -168,7 +224,7 @@ install-uvm:
 clean: ## Clean all generated sources
 	rm -rf $(I3C_ROOT_DIR)/{dsim.env,dsim_work,sw,*.log,*.rpt,*.vcd}
 	rm -rf $(GENERIC_UVM_DIR) $(VERILATOR_UVM_DIR)
-	rm -rf {$(VERIFICATION_DIR),$(COCOTB_VERIF_DIR),$(BLOCK_VERIF_DIR),$(TOP_VERIF_DIR),$(UVM_VERIF_DIR)}/**/{.nox,obj_dir,__pycache__,report,sim_build,*.dat,*.info,*.json,*.log,*.vcd,*.xml}
+	rm -rf {$(VERIFICATION_DIR),$(COCOTB_VERIF_DIR),$(BLOCK_VERIF_DIR),$(TOP_VERIF_DIR),$(UVM_VERIF_DIR)}/**/{.nox,obj_dir,__pycache__,report,sim_build,*.dat,*.info,*.json,*.log,*.vpd,*.vcd,*.fsdb,*.fst,*.xml,ucli.key}
 	rm -rf $(TOOL_DIR)/**/{.nox,obj_dir,__pycache__,report,sim_build,*.dat,*.info,*.log,*.vcd,*.xml}
 
 .PHONY: lint lint-check lint-rtl lint-tests \

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ This repository is currently tested on Debian 12 and Ubuntu 22.04. In order to u
 
 ### Submodules
 
-Make sure submodules are checked out. Use the `--recursive` flag when cloning, or run
+Make sure submodules are checked out.
+Use the `--recursive` flag when cloning, or run the following:
 
 ```{bash}
 git submodule update --init --recursive
@@ -41,23 +42,26 @@ if you already cloned the repository.
 
 ### Python
 
-Python 3.11.0 is recommended for this project. A bootstrap script is provided:
+A bootstrap script is provided, runnable as `./install.sh` which will install `pyenv`.
+Then, you can install and activate a python environment with `. activate.sh`.
 
-```{bash}
-bash install.sh
-```
-
-This script installs `pyenv`. Then, you can activate the environment:
-
-```{bash}
-. activate.sh
-```
-
-Activate script creates a virtual environment with Python3.11 and installs python packages from the `requirements.txt`.
+The activation script creates a virtual environment with Python3.11 and installs python packages from the `requirements.txt` file.
+Python 3.11.0 is recommended and installed for this project.
 
 ## Verification
 
-Tools used for the core verification
+More details can be found in [`verification README`](./verification/README.md).
+Coverage data is available in [GitHub pages](https://chipsalliance.github.io/i3c-core/coverview.html?path=release-v2.0.zip).
+
+This core is verified with the following set of tests:
+
+* A set of rapid tests written in cocotb
+* Avery I3C VIP based tests
+* [Selected tests](doc/cts-list.md) from the Avery I3C Compliance Test Suite
+
+Running all the cocotb tests with `make tests` will check if the environment is properly configured.
+
+Tools used for the core verification are:
 
 * Simulation:
 
@@ -73,26 +77,13 @@ Tools used for the core verification
   * Spyglass VC Static U-2023.03-SP2-4
   * MeridianRDC 2022.A.P10.2.RDC for RHEL7.0-64, Rev 189206
 
-This core is verified with the following set of tests:
-* rapid tests written in cocotb
-* Avery I3C VIP based tests
-* [Selected tests](doc/cts-list.md) from the Avery I3C Compliance Test Suite
-
-To check if the environment is properly configured, run the cocotb tests:
-
-```{bash}
-make tests
-```
-
-More details can be found in [`verification README`](./verification/README.md).
-
-Coverage data is available in [GitHub pages](https://chipsalliance.github.io/i3c-core/coverview.html?path=release-v2.0.zip).
-
 ## Tools
 
-Tools developed for this project are located in `tools` directory. You can find more detailed information in README of each tool:
+Tools developed for this project are located in `tools` directory.
+You can find more detailed information in README of each tool:
 - [`i3c_config`](./tools/i3c_config/README.md) - manage configuration and produce header files
-- [`pyenv`](./tools/pyenv/README.md) - enable usage of pyenv in BASH
 - [`reg_gen`](./tools/reg_gen/README.md) - scripts to generate SystemVerilog description from the SystemRDL files
 - [`timing`](./tools/timing/README.md) - helper script to estimate timings on the bus
 - [`verible-scripts`](./tools/verible-scripts/README.md) - scripts to manage configuration and runs of Verible formatter and linter
+
+In the[`tools`](./verification/tools/) verification directory, a noxfile is provided to test [the I3C Core Configuration Tool](./tools/i3c_config/i3c_core_config.py).

--- a/activate.sh
+++ b/activate.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 export PYENV_ROOT="$HOME/.pyenv"
 [[ -d $PYENV_ROOT/bin ]] && export PATH="$PYENV_ROOT/bin:$PATH"

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,87 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "lowrisc-nix": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1767631699,
+        "narHash": "sha256-xnqoBGI+p/Kg3t+CVKhKVun6BlBBNr8aOrdtZ1Pqj/I=",
+        "owner": "lowRISC",
+        "repo": "lowrisc-nix",
+        "rev": "06a2330d819f5a568f9929d8a49df7db82b1cd24",
+        "type": "github"
+      },
+      "original": {
+        "owner": "lowRISC",
+        "repo": "lowrisc-nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1765838191,
+        "narHash": "sha256-m5KWt1nOm76ILk/JSCxBM4MfK3rYY7Wq9/TZIIeGnT8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c6f52ebd45e5925c188d1a20119978aa4ffd5ef6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": [
+          "lowrisc-nix",
+          "flake-utils"
+        ],
+        "lowrisc-nix": "lowrisc-nix",
+        "nixpkgs": [
+          "lowrisc-nix",
+          "nixpkgs"
+        ]
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,102 @@
+{
+  description = "Development environment for i3c-core.";
+
+  inputs = {
+    lowrisc-nix.url = "github:lowRISC/lowrisc-nix";
+    nixpkgs.follows = "lowrisc-nix/nixpkgs";
+    flake-utils.follows = "lowrisc-nix/flake-utils";
+  };
+
+  nixConfig = {
+    extra-substituters = ["https://nix-cache.lowrisc.org/public/"];
+    extra-trusted-public-keys = ["nix-cache.lowrisc.org-public-1:O6JLD0yXzaJDPiQW1meVu32JIDViuaPtGDfjlOopU7o="];
+  };
+
+  outputs = inputs: inputs.flake-utils.lib.eachDefaultSystem (system: let
+
+    pkgs = import inputs.nixpkgs {
+      inherit system;
+      overlays = [
+        (final: prev: {
+          buildFHSEnvOverlay = final.callPackage inputs.lowrisc-nix.lib.buildFHSEnvOverlay {};
+        })
+      ];
+    };
+
+    verilator' = pkgs.verilator.overrideAttrs rec {
+      version = "5.024";
+      src = pkgs.fetchFromGitHub {
+        owner = "verilator";
+        repo = "verilator";
+        rev = "v${version}";
+        sha256 = "sha256-It1PEhS36L/n2r6HsDrkrk/kuz86IXLxsIYhFk/VRGc=";
+      };
+      patches = [];
+      doCheck = false;
+    };
+
+    verilator-cond-coverage = pkgs.verilator.overrideAttrs rec {
+      version = "5.030-cond-coverage";
+      src = pkgs.fetchFromGitHub {
+        owner = "antmicro";
+        repo = "verilator";
+        rev = "f338b6f603f02a9ea9ceeb40ccd1ce14cbdf9e07";
+        sha256 = "sha256-hnsftIWubq0mzrjSPfXfxVlWqVXtQVNlVSq2kcwIMU4=";
+      };
+      patches = [];
+      doCheck = false;
+    };
+
+    activateEnvUV = ''
+      # Provision the python venv using UV (if it does not already exist), and activate it.
+      if [[ -f "pyproject.toml" ]]; then
+        [[ -d ".venv" ]] || (uv venv && uv sync)
+        [[ -d ".venv" ]] && . .venv/bin/activate
+      fi
+    '';
+
+    simPkgs = _ :
+      (with pkgs; [
+        # FOSS
+        gcc
+        zlib
+        uv
+        python311
+        verible
+        verilator'
+        gtkwave
+        surfer
+      ]);
+
+    covPkgs = _ :
+      (with pkgs; [
+        # FOSS
+        uv
+        python311
+        verilator-cond-coverage
+      ]);
+
+    mkShell = targetPkgs: (pkgs.buildFHSEnvOverlay {
+      pname = "caliptra-i3c";
+      version = "dev";
+      inherit targetPkgs;
+      extraOutputsToInstall = ["dev"];
+      profile = ''
+        ${activateEnvUV}
+      '';
+      runScript = "\${SHELL:-bash}";
+    }).env;
+
+
+  in
+
+    {
+      devShells = rec {
+         default = sim;
+         sim = mkShell simPkgs;
+         cov = mkShell covPkgs;
+      };
+    }
+
+  );
+}

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 if [ -d ~/.pyenv ]; then
     echo ":::Skipping installation, pyenv is already installed."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,130 @@
+###########
+# PROJECT #
+###########
+
+[project]
+name = "i3c-core"
+version = "0.1.0"
+requires-python = "~=3.11.0"
+dependencies = [
+    "antlr4-python3-runtime==4.13.1",
+    "argcomplete==3.4.0",
+    "asttokens==2.4.1",
+    "attrs==23.2.0",
+    "black==24.4.2",
+    "click==8.1.7",
+    "cocotb==1.9.0",
+    "cocotb-ahb",
+    "cocotb-bus==0.2.1",
+    "cocotb-coverage==1.2.0",
+    "cocotb-helpers",
+    "cocotb-test==0.2.5",
+    "cocotbext-axi==0.1.24",
+    "cocotbext-i2c",
+    "cocotbext-i3c",
+    "colorama==0.4.6",
+    "colorlog==6.8.2",
+    "comm==0.2.2",
+    "crc==7.0.0",
+    "debugpy==1.8.1",
+    "decorator==5.1.1",
+    "distlib==0.3.8",
+    "engineering-notation==0.10.0",
+    "executing==2.0.1",
+    "filelock==3.15.4",
+    "find-libpython==0.4.0",
+    "flake8>=7",
+    "git-me-the-url==2.1.0",
+    "gitdb==4.0.11",
+    "gitpython==3.1.43",
+    "info-process",
+    "iniconfig==2.0.0",
+    "ipykernel==6.29.4",
+    "ipython==8.25.0",
+    "isort>=5",
+    "jedi==0.19.1",
+    "jinja2==3.1.3",
+    "jsonschema==4.22.0",
+    "jsonschema-specifications==2023.12.1",
+    "jupyter-client==8.6.2",
+    "jupyter-core==5.7.2",
+    "markdown==3.6",
+    "markupsafe==2.1.5",
+    "matplotlib-inline==0.1.7",
+    "munch==4.0.0",
+    "mypy-extensions==1.0.0",
+    "nest-asyncio==1.6.0",
+    "nox==2023.4.22",
+    "nox-utils",
+    "numpy==2.0.0",
+    "packaging==24.0",
+    "parso==0.8.4",
+    "pathspec==0.12.1",
+    "peakrdl==1.1.0",
+    "peakrdl-cheader==1.0.0",
+    "peakrdl-cocotb",
+    "peakrdl-html==2.10.1",
+    "peakrdl-ipxact==3.4.4",
+    "peakrdl-markdown==1.0.0",
+    "peakrdl-regblock==0.23.0",
+    "peakrdl-systemrdl==0.3.0",
+    "peakrdl-uvm==2.3.0",
+    "pexpect==4.9.0",
+    "platformdirs==4.2.2",
+    "pluggy==1.4.0",
+    "prompt-toolkit==3.0.47",
+    "psutil==6.0.0",
+    "ptyprocess==0.7.0",
+    "pure-eval==0.2.2",
+    "py-markdown-table==0.3.3",
+    "pygments==2.18.0",
+    "pytest==8.1.1",
+    "pytest-html==4.1.1",
+    "pytest-md==0.2.0",
+    "pytest-metadata==3.1.1",
+    "pytest-timeout==2.3.1",
+    "python-constraint==1.4.0",
+    "python-dateutil==2.9.0.post0",
+    "python-markdown-math==0.8",
+    "pyuvm==2.9.1",
+    "pyyaml==6.0.1",
+    "pyzmq==26.0.3",
+    "referencing==0.35.1",
+    "rpds-py==0.18.1",
+    "six==1.16.0",
+    "smmap==5.0.1",
+    "stack-data==0.6.3",
+    "systemrdl-compiler==1.27.3",
+    "testplanner",
+    "tornado==6.4.1",
+    "traitlets==5.14.3",
+    "typing-extensions==4.12.2",
+    "vcd2pulseview",
+    "virtualenv==20.26.3",
+    "wcwidth==0.2.13",
+    "zstandard==0.23.0",
+]
+
+########
+# TOOL #
+########
+
+[tool.uv.workspace]
+members = [
+    "tools/peakrdl_cocotb",
+    "third_party/cocotbext-i3c",
+    "tools/nox_utils",
+    "tools/cocotb_helpers",
+    "tools/vcd2pulseview",
+]
+
+[tool.uv.sources]
+cocotb-ahb = { git = "https://github.com/antmicro/cocotb-ahb", rev = "964eca08f2b524e68af9e002e48812649bc9308c" }
+peakrdl-cocotb = { workspace = true }
+cocotbext-i2c = { git = "https://github.com/alexforencich/cocotbext-i2c", rev = "e5f4aa040e3c3ce2d7deced7caabfa91321d036a" }
+testplanner = { git = "https://github.com/antmicro/testplanner", rev = "54b6870a1b9c1518269beafe5dfd1465a9eddae6" }
+cocotbext-i3c = { workspace = true }
+nox-utils = { workspace = true }
+cocotb-helpers = { workspace = true }
+vcd2pulseview = { workspace = true }
+info-process = { git = "https://github.com/antmicro/info-process", rev = "d21fbe7e647fdad767d0b34b00f60415665921dc" }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,16 @@
+# local packages & submodules
+-e ${I3C_ROOT_DIR}/third_party/cocotbext-i3c
+-e ${I3C_ROOT_DIR}/tools/nox_utils
+-e ${I3C_ROOT_DIR}/tools/cocotb_helpers
+-e ${I3C_ROOT_DIR}/tools/vcd2pulseview
+${I3C_ROOT_DIR}/tools/peakrdl_cocotb
+
+# git repositories
+git+https://github.com/alexforencich/cocotbext-i2c@e5f4aa040e3c3ce2d7deced7caabfa91321d036a#egg=cocotbext_i2c
+git+https://github.com/antmicro/testplanner@54b6870a1b9c1518269beafe5dfd1465a9eddae6
+cocotb-AHB @ git+https://github.com/antmicro/cocotb-ahb@964eca08f2b524e68af9e002e48812649bc9308c
+
+# pypi
 antlr4-python3-runtime==4.13.1
 argcomplete==3.4.0
 asttokens==2.4.1
@@ -5,18 +18,10 @@ attrs==23.2.0
 black==24.4.2
 click==8.1.7
 cocotb==1.8.1
-cocotb-AHB @ git+https://github.com/antmicro/cocotb-ahb@964eca08f2b524e68af9e002e48812649bc9308c
 cocotb-bus==0.2.1
 cocotb-coverage==1.2.0
 cocotb-test==0.2.5
 cocotbext-axi==0.1.24
--e git+https://github.com/alexforencich/cocotbext-i2c@e5f4aa040e3c3ce2d7deced7caabfa91321d036a#egg=cocotbext_i2c
-git+https://github.com/antmicro/testplanner@54b6870a1b9c1518269beafe5dfd1465a9eddae6
--e ${I3C_ROOT_DIR}/third_party/cocotbext-i3c
--e ${I3C_ROOT_DIR}/tools/nox_utils
--e ${I3C_ROOT_DIR}/tools/cocotb_helpers
--e ${I3C_ROOT_DIR}/tools/vcd2pulseview
-${I3C_ROOT_DIR}/tools/peakrdl_cocotb
 colorama==0.4.6
 colorlog==6.8.2
 comm==0.2.2

--- a/scripts/process_code_coverage.sh
+++ b/scripts/process_code_coverage.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# Process all code-coverage metrics
+
+[[ -z "${I3C_ROOT_DIR}" ]] && echo "I3C_ROOT_DIR must be set!" && exit 1
+COVERAGE_DIR="${I3C_ROOT_DIR}/artifacts/coverage"
+mkdir -p "${COVERAGE_DIR}"
+
+process_cov_file () {
+    dat_file=$1
+    out_file="$(dirname "${dat_file}")/$(basename "${dat_file}" .dat)_verilator.info"
+
+    # N.B. this requires features from antmicro/verilator?ref=cond_coverage
+    verilator_coverage --skip-toggle --write-info        "${out_file}"                                            "${dat_file}"
+    verilator_coverage --toggle-only --write-info        "${out_file%%_all_verilator.info}_toggle_verilator.info" "${dat_file}"
+    info-process extract --coverage-type line --output   "${out_file%%_all_verilator.info}_line_verilator.info"   "${out_file}"
+    info-process extract --coverage-type cond --output   "${out_file%%_all_verilator.info}_cond_verilator.info"   "${out_file}"
+    info-process extract --coverage-type branch --output "${out_file%%_all_verilator.info}_branch_verilator.info" "${out_file}"
+
+    rm "${dat_file}" "${out_file}"
+}
+
+# Copy all *.dat coverage databases to a special 'artifacts/coverage' directory for post-processing
+pushd verification/cocotb
+find -name \*.dat -not -name Vtop\*.dat | xargs cp -Lrv --parents -t "${COVERAGE_DIR}"
+popd
+
+# Process each coverage database file to extract the different coverage metrics into individual files
+for cov in $(find "${COVERAGE_DIR}" -type f -name \*.dat); do
+    process_cov_file "${cov}"
+done
+
+# Post-process all coverage files to clean up the outputs and only show relevant data
+info_process_args=(
+    transform
+    --strip-file-prefix "^${I3C_ROOT_DIR}/" # Normalize all paths to the project root
+    --filter '^src/'                        # Remove files not under the src/ directory (e.g. third-party)
+)
+find "${COVERAGE_DIR}" -name '*.info' -exec info-process "${info_process_args[@]}" '{}' \;

--- a/tools/nox_utils/src/nox_utils.py
+++ b/tools/nox_utils/src/nox_utils.py
@@ -109,12 +109,16 @@ class VerificationTest:
         defaultNameCoverage = "coverage.dat"
         defaultTestNameLog = f"{self.testName}{pfx}.log"
         defaultNameVDB = f"{self.sim_build}/simv.vdb"
+        defaultNameFSDB = "dump.fsdb"
+        defaultNameFST = "dump.fst"
 
         testNameVCD = f"{self.testName}{pfx}.vcd"
         testNameXML = f"{self.testName}{pfx}.xml"
         testCoverageName = f"{self.testName}{pfx}_{coverage}.dat"
         testNameLog = f"{self.testName}{pfx}_{coverage}.log"
         testNameVDB = f"{self.testName}{pfx}.vdb"
+        testNameFSDB = f"{self.testName}{pfx}.fsdb"
+        testNameFST = f"{self.testName}{pfx}.fst"
 
         self.filenames = {
             "vcd_default": defaultNameVCD,
@@ -126,6 +130,10 @@ class VerificationTest:
             "cov": testCoverageName,
             "vdb_default": defaultNameVDB,
             "vdb": testNameVDB,
+            "fsdb_default": defaultNameFSDB,
+            "fsdb": testNameFSDB,
+            "fst_default": defaultNameFST,
+            "fst": testNameFST,
         }
 
         def get_path(name):
@@ -141,12 +149,16 @@ class VerificationTest:
             "cov": get_path(testCoverageName),
             "vdb_default": get_path(defaultNameVDB),
             "vdb": get_path(testNameVDB),
+            "fsdb_default": get_path(defaultNameFSDB),
+            "fsdb": get_path(testNameFSDB),
+            "fst_default": get_path(defaultNameFST),
+            "fst": get_path(testNameFST),
         }
 
     def rename_default(self, dest: str):
         source = self.paths[f"{dest}_default"]
         if (not os.path.isfile(source)) and (not os.path.isdir(source)):
-            print(f"Warning!  Can't find file to rename: {source}")
+            logging.info(f"Can't find file to rename: {source}")
             return
         os.rename(source, self.paths[dest])
 
@@ -158,6 +170,8 @@ class VerificationTest:
             else:
                 self.rename_default("cov")
         self.rename_default("vcd")
+        self.rename_default("fsdb")
+        self.rename_default("fst")
 
 
 def create_test_id(session_name: str, args: list[str]):

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,1560 @@
+version = 1
+revision = 3
+requires-python = "==3.11.*"
+
+[manifest]
+members = [
+    "cocotb-helpers",
+    "cocotbext-i3c",
+    "i3c-core",
+    "nox-utils",
+    "peakrdl-cocotb",
+    "vcd2pulseview",
+]
+
+[[package]]
+name = "antlr4-python3-runtime"
+version = "4.13.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/00/7f1cab9b44518ca225a03f4493ac9294aab5935a7a28486ba91a20ea29cf/antlr4-python3-runtime-4.13.1.tar.gz", hash = "sha256:3cd282f5ea7cfb841537fe01f143350fdb1c0b1ce7981443a2fa8513fddb6d1a", size = 117451, upload-time = "2023-09-04T22:17:42.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/09/0c2874e3e8c53250b40afa7399c70acf7d23cac80138f1792ea3797f7452/antlr4_python3_runtime-4.13.1-py3-none-any.whl", hash = "sha256:78ec57aad12c97ac039ca27403ad61cb98aaec8a3f9bb8144f889aa0fa28b943", size = 144460, upload-time = "2023-09-04T22:17:40.977Z" },
+]
+
+[[package]]
+name = "appnope"
+version = "0.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/35/5d/752690df9ef5b76e169e68d6a129fa6d08a7100ca7f754c89495db3c6019/appnope-0.1.4.tar.gz", hash = "sha256:1de3860566df9caf38f01f86f65e0e13e379af54f9e4bee1e66b48f2efffd1ee", size = 4170, upload-time = "2024-02-06T09:43:11.258Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/29/5ecc3a15d5a33e31b26c11426c45c501e439cb865d0bff96315d86443b78/appnope-0.1.4-py2.py3-none-any.whl", hash = "sha256:502575ee11cd7a28c0205f379b525beefebab9d161b7c964670864014ed7213c", size = 4321, upload-time = "2024-02-06T09:43:09.663Z" },
+]
+
+[[package]]
+name = "argcomplete"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/ca/45176b8362eb06b68f946c2bf1184b92fc98d739a3f8c790999a257db91f/argcomplete-3.4.0.tar.gz", hash = "sha256:c2abcdfe1be8ace47ba777d4fce319eb13bf8ad9dace8d085dcad6eded88057f", size = 82275, upload-time = "2024-06-16T07:07:07.674Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/29/cba741f3abc1700dda883c4a1dd83f4ae89e4e8654067929d89143df2c58/argcomplete-3.4.0-py3-none-any.whl", hash = "sha256:69a79e083a716173e5532e0fa3bef45f793f4e61096cf52b5a42c0211c8b8aa5", size = 42641, upload-time = "2024-06-16T07:07:05.039Z" },
+]
+
+[[package]]
+name = "asttokens"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/45/1d/f03bcb60c4a3212e15f99a56085d93093a497718adf828d050b9d675da81/asttokens-2.4.1.tar.gz", hash = "sha256:b03869718ba9a6eb027e134bfdf69f38a236d681c83c160d510768af11254ba0", size = 62284, upload-time = "2023-10-26T10:03:05.06Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/86/4736ac618d82a20d87d2f92ae19441ebc7ac9e7a581d7e58bbe79233b24a/asttokens-2.4.1-py2.py3-none-any.whl", hash = "sha256:051ed49c3dcae8913ea7cd08e46a606dba30b79993209636c4875bc1d637bc24", size = 27764, upload-time = "2023-10-26T10:03:01.789Z" },
+]
+
+[[package]]
+name = "attrs"
+version = "23.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e3/fc/f800d51204003fa8ae392c4e8278f256206e7a919b708eef054f5f4b650d/attrs-23.2.0.tar.gz", hash = "sha256:935dc3b529c262f6cf76e50877d35a4bd3c1de194fd41f47a2b7ae8f19971f30", size = 780820, upload-time = "2023-12-31T06:30:32.926Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/44/827b2a91a5816512fcaf3cc4ebc465ccd5d598c45cefa6703fcf4a79018f/attrs-23.2.0-py3-none-any.whl", hash = "sha256:99b87a485a5820b23b879f04c2305b44b951b502fd64be915879d77a7e8fc6f1", size = 60752, upload-time = "2023-12-31T06:30:30.772Z" },
+]
+
+[[package]]
+name = "beautifulsoup4"
+version = "4.14.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b0/1c6a16426d389813b48d95e26898aff79abbde42ad353958ad95cc8c9b21/beautifulsoup4-4.14.3.tar.gz", hash = "sha256:6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86", size = 627737, upload-time = "2025-11-30T15:08:26.084Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl", hash = "sha256:0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb", size = 107721, upload-time = "2025-11-30T15:08:24.087Z" },
+]
+
+[[package]]
+name = "black"
+version = "24.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "mypy-extensions" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "platformdirs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a2/47/c9997eb470a7f48f7aaddd3d9a828244a2e4199569e38128715c48059ac1/black-24.4.2.tar.gz", hash = "sha256:c872b53057f000085da66a19c55d68f6f8ddcac2642392ad3a355878406fbd4d", size = 642299, upload-time = "2024-04-26T00:32:15.305Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/f7/591d601c3046ceb65b97291dfe87fa25124cffac3d97aaaba89d0f0d7bdf/black-24.4.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:257d724c2c9b1660f353b36c802ccece186a30accc7742c176d29c146df6e474", size = 1615013, upload-time = "2024-04-26T00:39:49.415Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/17/5e0036b265bbf6bc44970d93d48febcbc03701b671db3c9603fd43ebc616/black-24.4.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:bdde6f877a18f24844e381d45e9947a49e97933573ac9d4345399be37621e26c", size = 1436163, upload-time = "2024-04-26T00:40:20.267Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/48/34176b522e8cff4620a5d96c2e323ff2413f574870eb25efa8025885e028/black-24.4.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e151054aa00bad1f4e1f04919542885f89f5f7d086b8a59e5000e6c616896ffb", size = 1803382, upload-time = "2024-04-26T00:34:38.665Z" },
+    { url = "https://files.pythonhosted.org/packages/74/ce/e8eec1a77edbfa982bee3b5460dcdd4fe0e4e3165fc15d8ec44d04da7776/black-24.4.2-cp311-cp311-win_amd64.whl", hash = "sha256:7e122b1c4fb252fd85df3ca93578732b4749d9be076593076ef4d07a0233c3e1", size = 1417802, upload-time = "2024-04-26T00:35:08.804Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/89/294c9a6b6c75a08da55e9d05321d0707e9418735e3062b12ef0f54c33474/black-24.4.2-py3-none-any.whl", hash = "sha256:d36ed1124bb81b32f8614555b34cc4259c3fbc7eec17870e8ff8ded335b58d8c", size = 205925, upload-time = "2024-04-26T00:32:12.495Z" },
+]
+
+[[package]]
+name = "bs4"
+version = "0.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beautifulsoup4" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c9/aa/4acaf814ff901145da37332e05bb510452ebed97bc9602695059dd46ef39/bs4-0.0.2.tar.gz", hash = "sha256:a48685c58f50fe127722417bae83fe6badf500d54b55f7e39ffe43b798653925", size = 698, upload-time = "2024-01-17T18:15:47.371Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/bb/bf7aab772a159614954d84aa832c129624ba6c32faa559dfb200a534e50b/bs4-0.0.2-py2.py3-none-any.whl", hash = "sha256:abf8742c0805ef7f662dce4b51cca104cffe52b835238afc169142ab9b3fbccc", size = 1189, upload-time = "2024-01-17T18:15:48.613Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/4a/3dfd5f7850cbf0d06dc84ba9aa00db766b52ca38d8b86e3a38314d52498c/cffi-2.0.0-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:b4c854ef3adc177950a8dfc81a86f5115d2abd545751a304c5bcf2c2c7283cfe", size = 184344, upload-time = "2025-09-08T23:22:26.456Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/8b/f0e4c441227ba756aafbe78f117485b25bb26b1c059d01f137fa6d14896b/cffi-2.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2de9a304e27f7596cd03d16f1b7c72219bd944e99cc52b84d0145aefb07cbd3c", size = 180560, upload-time = "2025-09-08T23:22:28.197Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/b7/1200d354378ef52ec227395d95c2576330fd22a869f7a70e88e1447eb234/cffi-2.0.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:baf5215e0ab74c16e2dd324e8ec067ef59e41125d3eade2b863d294fd5035c92", size = 209613, upload-time = "2025-09-08T23:22:29.475Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/56/6033f5e86e8cc9bb629f0077ba71679508bdf54a9a5e112a3c0b91870332/cffi-2.0.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:730cacb21e1bdff3ce90babf007d0a0917cc3e6492f336c2f0134101e0944f93", size = 216476, upload-time = "2025-09-08T23:22:31.063Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/7f/55fecd70f7ece178db2f26128ec41430d8720f2d12ca97bf8f0a628207d5/cffi-2.0.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6824f87845e3396029f3820c206e459ccc91760e8fa24422f8b0c3d1731cbec5", size = 203374, upload-time = "2025-09-08T23:22:32.507Z" },
+    { url = "https://files.pythonhosted.org/packages/84/ef/a7b77c8bdc0f77adc3b46888f1ad54be8f3b7821697a7b89126e829e676a/cffi-2.0.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9de40a7b0323d889cf8d23d1ef214f565ab154443c42737dfe52ff82cf857664", size = 202597, upload-time = "2025-09-08T23:22:34.132Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/91/500d892b2bf36529a75b77958edfcd5ad8e2ce4064ce2ecfeab2125d72d1/cffi-2.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8941aaadaf67246224cee8c3803777eed332a19d909b47e29c9842ef1e79ac26", size = 215574, upload-time = "2025-09-08T23:22:35.443Z" },
+    { url = "https://files.pythonhosted.org/packages/44/64/58f6255b62b101093d5df22dcb752596066c7e89dd725e0afaed242a61be/cffi-2.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a05d0c237b3349096d3981b727493e22147f934b20f6f125a3eba8f994bec4a9", size = 218971, upload-time = "2025-09-08T23:22:36.805Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/49/fa72cebe2fd8a55fbe14956f9970fe8eb1ac59e5df042f603ef7c8ba0adc/cffi-2.0.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:94698a9c5f91f9d138526b48fe26a199609544591f859c870d477351dc7b2414", size = 211972, upload-time = "2025-09-08T23:22:38.436Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/28/dd0967a76aab36731b6ebfe64dec4e981aff7e0608f60c2d46b46982607d/cffi-2.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5fed36fccc0612a53f1d4d9a816b50a36702c28a2aa880cb8a122b3466638743", size = 217078, upload-time = "2025-09-08T23:22:39.776Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/c0/015b25184413d7ab0a410775fdb4a50fca20f5589b5dab1dbbfa3baad8ce/cffi-2.0.0-cp311-cp311-win32.whl", hash = "sha256:c649e3a33450ec82378822b3dad03cc228b8f5963c0c12fc3b1e0ab940f768a5", size = 172076, upload-time = "2025-09-08T23:22:40.95Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/8f/dc5531155e7070361eb1b7e4c1a9d896d0cb21c49f807a6c03fd63fc877e/cffi-2.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:66f011380d0e49ed280c789fbd08ff0d40968ee7b665575489afa95c98196ab5", size = 182820, upload-time = "2025-09-08T23:22:42.463Z" },
+    { url = "https://files.pythonhosted.org/packages/95/5c/1b493356429f9aecfd56bc171285a4c4ac8697f76e9bbbbb105e537853a1/cffi-2.0.0-cp311-cp311-win_arm64.whl", hash = "sha256:c6638687455baf640e37344fe26d37c404db8b80d037c3d29f58fe8d1c3b194d", size = 177635, upload-time = "2025-09-08T23:22:43.623Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.1.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/96/d3/f04c7bfcf5c1862a2a5b845c6b2b360488cf47af55dfa79c98f6a6bf98b5/click-8.1.7.tar.gz", hash = "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de", size = 336121, upload-time = "2023-08-17T17:29:11.868Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/2e/d53fa4befbf2cfa713304affc7ca780ce4fc1fd8710527771b58311a3229/click-8.1.7-py3-none-any.whl", hash = "sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28", size = 97941, upload-time = "2023-08-17T17:29:10.08Z" },
+]
+
+[[package]]
+name = "cocotb"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "find-libpython" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a0/ed/3b2448071aee63c5265e203bdae3ff262400e4db306edb5b871038a20e07/cocotb-1.9.0.tar.gz", hash = "sha256:19b4e27b53a16e0b9c4cc5227c7f9d4dccac06e431a4f937e9f5513350196333", size = 300523, upload-time = "2024-07-15T07:48:21.481Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/06/aa26a73d0d456d500c418543fd531154ec6f9e01da69c1c3d0bf9722297c/cocotb-1.9.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:17556e3a23562f64d577d0eb117fe02e384aedee997b29497b5c395f5010ff82", size = 629042, upload-time = "2024-07-15T07:47:25.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/ab/515082de87e63b47896a0d6c4e85e4b40dc9ec9ba5686f5e30e5b4ef3938/cocotb-1.9.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1a0381ced5590a726032ba2265c6b70ac12cfb49edb152be86a081bb7d104751", size = 4210868, upload-time = "2024-07-15T07:47:27.53Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/2d/06c664162dcba1bb79e875afc43c6147ee2a00a4a57ad84f2f0a94e91ff7/cocotb-1.9.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:997dbca2a2cd933fd0a44d9fadeebc1e8a40701db15ea06f207811933dceb350", size = 4094101, upload-time = "2024-07-15T07:47:29.484Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/b5/dfd390d0f816d4ce2b6da9aba1404d035fca52cdec1204ff3636c9628b5d/cocotb-1.9.0-cp311-cp311-win32.whl", hash = "sha256:a7cea13cb2fe4f5ca735490846342885117778a73008a67ed9cac667aaaf3f0d", size = 491689, upload-time = "2024-07-15T07:47:31.276Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/22/31416700f55e0755918104d2b1a656f9abd1731666adb5f79dbe87f109e8/cocotb-1.9.0-cp311-cp311-win_amd64.whl", hash = "sha256:87a19d3012f505ba7fda37483b851ef0ca40290ad8a9b28a820b84f8574287bb", size = 523117, upload-time = "2024-07-15T07:47:33.089Z" },
+]
+
+[[package]]
+name = "cocotb-ahb"
+version = "0.2.0"
+source = { git = "https://github.com/antmicro/cocotb-ahb?rev=964eca08f2b524e68af9e002e48812649bc9308c#964eca08f2b524e68af9e002e48812649bc9308c" }
+dependencies = [
+    { name = "cocotb" },
+    { name = "cocotb-bus" },
+    { name = "numpy" },
+]
+
+[[package]]
+name = "cocotb-bus"
+version = "0.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cocotb" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b6/2b/71975ab8c15f9a2c4c4fe9da4a873ea164eb348449858358f2762b24c0be/cocotb-bus-0.2.1.tar.gz", hash = "sha256:a197aa4b0e0ad28469c8877b41b3fb2ec0206da9f491b9276d1578ce6dd8aa8d", size = 28461, upload-time = "2022-01-22T01:31:53.29Z" }
+
+[[package]]
+name = "cocotb-coverage"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cocotb" },
+    { name = "python-constraint" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2b/ec/c3db4c91faa759161aedeb26d38e41abca5e1d1a0eeef286fdda51c18959/cocotb-coverage-1.2.0.tar.gz", hash = "sha256:0ac0af59be97aca48eb852817442b15d642f0eb4905fba8fbd9ee3da6a40365c", size = 22336, upload-time = "2023-11-15T19:32:42.515Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/80/40db1aee3604803993b8f8c9832e7c981fa5ef811115a19860a84149010d/cocotb_coverage-1.2.0-py3-none-any.whl", hash = "sha256:831a12425e02cef9715cdd6b7122ea0c20ba184b11675d55ec3057194e07841c", size = 21420, upload-time = "2023-11-15T19:32:40.814Z" },
+]
+
+[[package]]
+name = "cocotb-helpers"
+version = "0.1.0"
+source = { editable = "tools/cocotb_helpers" }
+dependencies = [
+    { name = "cocotb" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "cocotb" }]
+
+[[package]]
+name = "cocotb-test"
+version = "0.2.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cocotb" },
+    { name = "find-libpython" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/56/27/5d18c8cc3095615925c112d194bb5c98999cc5e9429d5350b833400fa82e/cocotb-test-0.2.5.tar.gz", hash = "sha256:0f19d9cfc1b7f64fe25394ff5a5d5f788f2d5b4f04b0a742f1330c4b6ebf1343", size = 20560, upload-time = "2024-02-07T19:53:43.732Z" }
+
+[[package]]
+name = "cocotbext-axi"
+version = "0.1.24"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cocotb" },
+    { name = "cocotb-bus" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d3/1a/9404e927ae29608dee29717074a58ddb4999679e310de9a5ff661fd75d61/cocotbext-axi-0.1.24.tar.gz", hash = "sha256:3ed62dcaf9448833176826507c5bc5c346431c4846a731e409d87c862d960593", size = 49247, upload-time = "2023-03-24T18:05:59.784Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/31/7bc5f68f634d5e4e0f302ac073d38ae795242b9c27dd7104593a75d260de/cocotbext_axi-0.1.24-py3-none-any.whl", hash = "sha256:533ba6c7503c6302bdb9ef86e43a549ad5da876eafb1adce23d39751c54cced4", size = 51491, upload-time = "2023-03-24T18:05:57.109Z" },
+]
+
+[[package]]
+name = "cocotbext-i2c"
+version = "0.1.1"
+source = { git = "https://github.com/alexforencich/cocotbext-i2c?rev=e5f4aa040e3c3ce2d7deced7caabfa91321d036a#e5f4aa040e3c3ce2d7deced7caabfa91321d036a" }
+dependencies = [
+    { name = "cocotb" },
+]
+
+[[package]]
+name = "cocotbext-i3c"
+source = { editable = "third_party/cocotbext-i3c" }
+dependencies = [
+    { name = "black" },
+    { name = "cocotb" },
+    { name = "crc" },
+    { name = "flake8" },
+    { name = "isort" },
+    { name = "pyproject-flake8" },
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "black", specifier = ">=24.4.2" },
+    { name = "cocotb", specifier = ">=1.8.1,<2.0.0" },
+    { name = "crc", specifier = ">=7.0.0" },
+    { name = "flake8", specifier = ">=7.0.0" },
+    { name = "isort", specifier = ">=5.13.2" },
+    { name = "pyproject-flake8", specifier = ">=5.0.4" },
+    { name = "pytest", specifier = ">=7.4.0" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "colorlog"
+version = "6.8.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/38/2992ff192eaa7dd5a793f8b6570d6bbe887c4fbbf7e72702eb0a693a01c8/colorlog-6.8.2.tar.gz", hash = "sha256:3e3e079a41feb5a1b64f978b5ea4f46040a94f11f0e8bbb8261e3dbbeca64d44", size = 16529, upload-time = "2024-01-26T13:59:28.628Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/18/3e867ab37a24fdf073c1617b9c7830e06ec270b1ea4694a624038fc40a03/colorlog-6.8.2-py3-none-any.whl", hash = "sha256:4dcbb62368e2800cb3c5abd348da7e53f6c362dda502ec27c560b2e58a66bd33", size = 11357, upload-time = "2024-01-26T13:59:27.064Z" },
+]
+
+[[package]]
+name = "comm"
+version = "0.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/a8/fb783cb0abe2b5fded9f55e5703015cdf1c9c85b3669087c538dd15a6a86/comm-0.2.2.tar.gz", hash = "sha256:3fd7a84065306e07bea1773df6eb8282de51ba82f77c72f9c85716ab11fe980e", size = 6210, upload-time = "2024-03-12T16:53:41.133Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/75/49e5bfe642f71f272236b5b2d2691cf915a7283cc0ceda56357b61daa538/comm-0.2.2-py3-none-any.whl", hash = "sha256:e6fb86cb70ff661ee8c9c14e7d36d6de3b4066f1441be4063df9c5009f0a64d3", size = 7180, upload-time = "2024-03-12T16:53:39.226Z" },
+]
+
+[[package]]
+name = "crc"
+version = "7.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/39/7e3c6f9af03f0012d4f8ecdf29689fed1f27d57d0f965bf051da4905fa78/crc-7.0.0.tar.gz", hash = "sha256:b9fc521042167f2b59d9183ce27acc0897e4a17748421e8b304ccdf7ebf4280a", size = 9793, upload-time = "2024-04-19T16:26:30.381Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/4d/fc70b599df02a4baa2024564e474e3e9bec4075a6cd869e4983aff5d179a/crc-7.0.0-py3-none-any.whl", hash = "sha256:8b22f5534e9360bf61e169ce581d61143d3d0248a1fdc2c4b4f2175af3b2c2aa", size = 8729, upload-time = "2024-04-19T16:26:29.247Z" },
+]
+
+[[package]]
+name = "debugpy"
+version = "1.8.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/c7/a18e15ed2e53f86de2e1c4162a54ddf1c4f4cee5ca40270c14725ccdd8ff/debugpy-1.8.1.zip", hash = "sha256:f696d6be15be87aef621917585f9bb94b1dc9e8aced570db1b8a6fc14e8f9b42", size = 4619053, upload-time = "2024-02-08T22:57:03.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/04/ce7170a5094fe5943b11925d3e11ae7ee6c5c79166f0b0298420995ea9cc/debugpy-1.8.1-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:016a9fcfc2c6b57f939673c874310d8581d51a0fe0858e7fac4e240c5eb743cb", size = 1783713, upload-time = "2024-02-08T22:55:59.922Z" },
+    { url = "https://files.pythonhosted.org/packages/da/65/ec4d2e244ec7f9db0b5250649f3ae6fc6a9df7d4da2c4bcdc46778d9a674/debugpy-1.8.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd97ed11a4c7f6d042d320ce03d83b20c3fb40da892f994bc041bbc415d7a099", size = 2643137, upload-time = "2024-02-08T22:56:02.85Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/27/6dac9f0c3437c992b05375b2fa91d2136e50ea77c5923c58eef6a44e43aa/debugpy-1.8.1-cp311-cp311-win32.whl", hash = "sha256:0de56aba8249c28a300bdb0672a9b94785074eb82eb672db66c8144fff673146", size = 4708784, upload-time = "2024-02-08T22:56:07.055Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/0e/b6ca28f1a0c86c601c9253e71dbfc2f6acbda6930e53f3295b02911bd5ae/debugpy-1.8.1-cp311-cp311-win_amd64.whl", hash = "sha256:1a9fe0829c2b854757b4fd0a338d93bc17249a3bf69ecf765c61d4c522bb92a8", size = 4723449, upload-time = "2024-02-08T22:56:10.487Z" },
+    { url = "https://files.pythonhosted.org/packages/57/ab/6df7e24db51e1db642a5ea1759d44fb656251253995a27deb37af9b192ae/debugpy-1.8.1-py2.py3-none-any.whl", hash = "sha256:28acbe2241222b87e255260c76741e1fbf04fdc3b6d094fcf57b6c6f75ce1242", size = 4832569, upload-time = "2024-02-08T22:56:58.759Z" },
+]
+
+[[package]]
+name = "decorator"
+version = "5.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/0c/8d907af351aa16b42caae42f9d6aa37b900c67308052d10fdce809f8d952/decorator-5.1.1.tar.gz", hash = "sha256:637996211036b6385ef91435e4fae22989472f9d571faba8927ba8253acbc330", size = 35016, upload-time = "2022-01-07T08:20:05.666Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/50/83c593b07763e1161326b3b8c6686f0f4b0f24d5526546bee538c89837d6/decorator-5.1.1-py3-none-any.whl", hash = "sha256:b8c3f85900b9dc423225913c5aace94729fe1fa9763b38939a95226f02d37186", size = 9073, upload-time = "2022-01-07T08:20:03.734Z" },
+]
+
+[[package]]
+name = "distlib"
+version = "0.3.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c4/91/e2df406fb4efacdf46871c25cde65d3c6ee5e173b7e5a4547a47bae91920/distlib-0.3.8.tar.gz", hash = "sha256:1530ea13e350031b6312d8580ddb6b27a104275a31106523b8f123787f494f64", size = 609931, upload-time = "2023-12-12T07:14:03.091Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8e/41/9307e4f5f9976bc8b7fea0b66367734e8faf3ec84bc0d412d8cfabbb66cd/distlib-0.3.8-py2.py3-none-any.whl", hash = "sha256:034db59a0b96f8ca18035f36290806a9a6e6bd9d1ff91e45a7f172eb17e51784", size = 468850, upload-time = "2023-12-12T07:13:59.966Z" },
+]
+
+[[package]]
+name = "engineering-notation"
+version = "0.10.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/1e/cf61798657ff598417693ed1b4552afa9300203120e4fe84809ec1c3f157/engineering_notation-0.10.0-py3-none-any.whl", hash = "sha256:49ff22ba8377673c8cd5f45298b87c41946b5a84583806a4655760124e22c451", size = 6769, upload-time = "2023-10-11T10:34:59.434Z" },
+]
+
+[[package]]
+name = "executing"
+version = "2.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/41/85d2d28466fca93737592b7f3cc456d1cfd6bcd401beceeba17e8e792b50/executing-2.0.1.tar.gz", hash = "sha256:35afe2ce3affba8ee97f2d69927fa823b08b472b7b994e36a52a964b93d16147", size = 836501, upload-time = "2023-10-29T10:17:13.532Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/03/6ea8b1b2a5ab40a7a60dc464d3daa7aa546e0a74d74a9f8ff551ea7905db/executing-2.0.1-py2.py3-none-any.whl", hash = "sha256:eac49ca94516ccc753f9fb5ce82603156e590b27525a8bc32cce8ae302eb61bc", size = 24922, upload-time = "2023-10-29T10:17:10.229Z" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.15.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/dd/49e06f09b6645156550fb9aee9cc1e59aba7efbc972d665a1bd6ae0435d4/filelock-3.15.4.tar.gz", hash = "sha256:2207938cbc1844345cb01a5a95524dae30f0ce089eba5b00378295a17e3e90cb", size = 18007, upload-time = "2024-06-22T15:59:14.749Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/f0/48285f0262fe47103a4a45972ed2f9b93e4c80b8fd609fa98da78b2a5706/filelock-3.15.4-py3-none-any.whl", hash = "sha256:6ca1fffae96225dab4c6eaf1c4f4f28cd2568d3ec2a44e15a08520504de468e7", size = 16159, upload-time = "2024-06-22T15:59:12.695Z" },
+]
+
+[[package]]
+name = "find-libpython"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/86/b1d3a9c49d907cac74f9d8bcead2c8e807a878c0e218d8ef1d38e6a4f59a/find_libpython-0.4.0.tar.gz", hash = "sha256:46f9cdcd397ddb563b2d7592ded3796a41c1df5222443bd9d981721c906c03e6", size = 8979, upload-time = "2024-03-13T17:01:10.727Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/89/6b4624122d5c61a86e8aebcebd377866338b705ce4f115c45b046dc09b99/find_libpython-0.4.0-py3-none-any.whl", hash = "sha256:034a4253bd57da3408aefc59aeac1650150f6c1f42e10fdd31615cf1df0842e3", size = 8670, upload-time = "2024-03-13T17:01:09.712Z" },
+]
+
+[[package]]
+name = "flake8"
+version = "7.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mccabe" },
+    { name = "pycodestyle" },
+    { name = "pyflakes" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/40/3c/3464b567aa367b221fa610bbbcce8015bf953977d21e52f2d711b526fb48/flake8-7.0.0.tar.gz", hash = "sha256:33f96621059e65eec474169085dc92bf26e7b2d47366b70be2f67ab80dc25132", size = 48219, upload-time = "2024-01-05T00:41:52.142Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/01/cc8cdec7b61db0315c2ab62d80677a138ef06832ec17f04d87e6ef858f7f/flake8-7.0.0-py2.py3-none-any.whl", hash = "sha256:a6dfbb75e03252917f2473ea9653f7cd799c3064e54d4c8140044c5c065f53c3", size = 57570, upload-time = "2024-01-05T00:41:49.837Z" },
+]
+
+[[package]]
+name = "git-me-the-url"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gitpython" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b6/bb/5f894e0d740b6094f2fc7c3c00f9bf97eeb1778af8f8c470326f6284d716/git-me-the-url-2.1.0.tar.gz", hash = "sha256:abf8f4b10de393fe869225e0cd66f40de1864806cd1da2974026b9e91112c038", size = 19768, upload-time = "2023-03-13T00:42:30.462Z" }
+
+[[package]]
+name = "gitdb"
+version = "4.0.11"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "smmap" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/0d/bbb5b5ee188dec84647a4664f3e11b06ade2bde568dbd489d9d64adef8ed/gitdb-4.0.11.tar.gz", hash = "sha256:bf5421126136d6d0af55bc1e7c1af1c397a34f5b7bd79e776cd3e89785c2b04b", size = 394469, upload-time = "2023-10-20T07:43:19.146Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/5b/8f0c4a5bb9fd491c277c21eff7ccae71b47d43c4446c9d0c6cff2fe8c2c4/gitdb-4.0.11-py3-none-any.whl", hash = "sha256:81a3407ddd2ee8df444cbacea00e2d038e40150acfa3001696fe0dcf1d3adfa4", size = 62721, upload-time = "2023-10-20T07:43:16.712Z" },
+]
+
+[[package]]
+name = "gitpython"
+version = "3.1.43"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gitdb" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b6/a1/106fd9fa2dd989b6fb36e5893961f82992cf676381707253e0bf93eb1662/GitPython-3.1.43.tar.gz", hash = "sha256:35f314a9f878467f5453cc1fee295c3e18e52f1b99f10f6cf5b1682e968a9e7c", size = 214149, upload-time = "2024-03-31T08:07:34.154Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/bd/cc3a402a6439c15c3d4294333e13042b915bbeab54edc457c723931fed3f/GitPython-3.1.43-py3-none-any.whl", hash = "sha256:eec7ec56b92aad751f9912a73404bc02ba212a23adb2c7098ee668417051a1ff", size = 207337, upload-time = "2024-03-31T08:07:31.194Z" },
+]
+
+[[package]]
+name = "hjson"
+version = "3.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/e5/0b56d723a76ca67abadbf7fb71609fb0ea7e6926e94fcca6c65a85b36a0e/hjson-3.1.0.tar.gz", hash = "sha256:55af475a27cf83a7969c808399d7bccdec8fb836a07ddbd574587593b9cdcf75", size = 40541, upload-time = "2022-08-13T02:53:01.919Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1f/7f/13cd798d180af4bf4c0ceddeefba2b864a63c71645abc0308b768d67bb81/hjson-3.1.0-py3-none-any.whl", hash = "sha256:65713cdcf13214fb554eb8b4ef803419733f4f5e551047c9b711098ab7186b89", size = 54018, upload-time = "2022-08-13T02:52:59.899Z" },
+]
+
+[[package]]
+name = "i3c-core"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "antlr4-python3-runtime" },
+    { name = "argcomplete" },
+    { name = "asttokens" },
+    { name = "attrs" },
+    { name = "black" },
+    { name = "click" },
+    { name = "cocotb" },
+    { name = "cocotb-ahb" },
+    { name = "cocotb-bus" },
+    { name = "cocotb-coverage" },
+    { name = "cocotb-helpers" },
+    { name = "cocotb-test" },
+    { name = "cocotbext-axi" },
+    { name = "cocotbext-i2c" },
+    { name = "cocotbext-i3c" },
+    { name = "colorama" },
+    { name = "colorlog" },
+    { name = "comm" },
+    { name = "crc" },
+    { name = "debugpy" },
+    { name = "decorator" },
+    { name = "distlib" },
+    { name = "engineering-notation" },
+    { name = "executing" },
+    { name = "filelock" },
+    { name = "find-libpython" },
+    { name = "flake8" },
+    { name = "git-me-the-url" },
+    { name = "gitdb" },
+    { name = "gitpython" },
+    { name = "info-process" },
+    { name = "iniconfig" },
+    { name = "ipykernel" },
+    { name = "ipython" },
+    { name = "isort" },
+    { name = "jedi" },
+    { name = "jinja2" },
+    { name = "jsonschema" },
+    { name = "jsonschema-specifications" },
+    { name = "jupyter-client" },
+    { name = "jupyter-core" },
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "matplotlib-inline" },
+    { name = "munch" },
+    { name = "mypy-extensions" },
+    { name = "nest-asyncio" },
+    { name = "nox" },
+    { name = "nox-utils" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "parso" },
+    { name = "pathspec" },
+    { name = "peakrdl" },
+    { name = "peakrdl-cheader" },
+    { name = "peakrdl-cocotb" },
+    { name = "peakrdl-html" },
+    { name = "peakrdl-ipxact" },
+    { name = "peakrdl-markdown" },
+    { name = "peakrdl-regblock" },
+    { name = "peakrdl-systemrdl" },
+    { name = "peakrdl-uvm" },
+    { name = "pexpect" },
+    { name = "platformdirs" },
+    { name = "pluggy" },
+    { name = "prompt-toolkit" },
+    { name = "psutil" },
+    { name = "ptyprocess" },
+    { name = "pure-eval" },
+    { name = "py-markdown-table" },
+    { name = "pygments" },
+    { name = "pytest" },
+    { name = "pytest-html" },
+    { name = "pytest-md" },
+    { name = "pytest-metadata" },
+    { name = "pytest-timeout" },
+    { name = "python-constraint" },
+    { name = "python-dateutil" },
+    { name = "python-markdown-math" },
+    { name = "pyuvm" },
+    { name = "pyyaml" },
+    { name = "pyzmq" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+    { name = "six" },
+    { name = "smmap" },
+    { name = "stack-data" },
+    { name = "systemrdl-compiler" },
+    { name = "testplanner" },
+    { name = "tornado" },
+    { name = "traitlets" },
+    { name = "typing-extensions" },
+    { name = "vcd2pulseview" },
+    { name = "virtualenv" },
+    { name = "wcwidth" },
+    { name = "zstandard" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "antlr4-python3-runtime", specifier = "==4.13.1" },
+    { name = "argcomplete", specifier = "==3.4.0" },
+    { name = "asttokens", specifier = "==2.4.1" },
+    { name = "attrs", specifier = "==23.2.0" },
+    { name = "black", specifier = "==24.4.2" },
+    { name = "click", specifier = "==8.1.7" },
+    { name = "cocotb", specifier = "==1.9.0" },
+    { name = "cocotb-ahb", git = "https://github.com/antmicro/cocotb-ahb?rev=964eca08f2b524e68af9e002e48812649bc9308c" },
+    { name = "cocotb-bus", specifier = "==0.2.1" },
+    { name = "cocotb-coverage", specifier = "==1.2.0" },
+    { name = "cocotb-helpers", editable = "tools/cocotb_helpers" },
+    { name = "cocotb-test", specifier = "==0.2.5" },
+    { name = "cocotbext-axi", specifier = "==0.1.24" },
+    { name = "cocotbext-i2c", git = "https://github.com/alexforencich/cocotbext-i2c?rev=e5f4aa040e3c3ce2d7deced7caabfa91321d036a" },
+    { name = "cocotbext-i3c", editable = "third_party/cocotbext-i3c" },
+    { name = "colorama", specifier = "==0.4.6" },
+    { name = "colorlog", specifier = "==6.8.2" },
+    { name = "comm", specifier = "==0.2.2" },
+    { name = "crc", specifier = "==7.0.0" },
+    { name = "debugpy", specifier = "==1.8.1" },
+    { name = "decorator", specifier = "==5.1.1" },
+    { name = "distlib", specifier = "==0.3.8" },
+    { name = "engineering-notation", specifier = "==0.10.0" },
+    { name = "executing", specifier = "==2.0.1" },
+    { name = "filelock", specifier = "==3.15.4" },
+    { name = "find-libpython", specifier = "==0.4.0" },
+    { name = "flake8", specifier = ">=7" },
+    { name = "git-me-the-url", specifier = "==2.1.0" },
+    { name = "gitdb", specifier = "==4.0.11" },
+    { name = "gitpython", specifier = "==3.1.43" },
+    { name = "info-process", git = "https://github.com/antmicro/info-process?rev=d21fbe7e647fdad767d0b34b00f60415665921dc" },
+    { name = "iniconfig", specifier = "==2.0.0" },
+    { name = "ipykernel", specifier = "==6.29.4" },
+    { name = "ipython", specifier = "==8.25.0" },
+    { name = "isort", specifier = ">=5" },
+    { name = "jedi", specifier = "==0.19.1" },
+    { name = "jinja2", specifier = "==3.1.3" },
+    { name = "jsonschema", specifier = "==4.22.0" },
+    { name = "jsonschema-specifications", specifier = "==2023.12.1" },
+    { name = "jupyter-client", specifier = "==8.6.2" },
+    { name = "jupyter-core", specifier = "==5.7.2" },
+    { name = "markdown", specifier = "==3.6" },
+    { name = "markupsafe", specifier = "==2.1.5" },
+    { name = "matplotlib-inline", specifier = "==0.1.7" },
+    { name = "munch", specifier = "==4.0.0" },
+    { name = "mypy-extensions", specifier = "==1.0.0" },
+    { name = "nest-asyncio", specifier = "==1.6.0" },
+    { name = "nox", specifier = "==2023.4.22" },
+    { name = "nox-utils", editable = "tools/nox_utils" },
+    { name = "numpy", specifier = "==2.0.0" },
+    { name = "packaging", specifier = "==24.0" },
+    { name = "parso", specifier = "==0.8.4" },
+    { name = "pathspec", specifier = "==0.12.1" },
+    { name = "peakrdl", specifier = "==1.1.0" },
+    { name = "peakrdl-cheader", specifier = "==1.0.0" },
+    { name = "peakrdl-cocotb", editable = "tools/peakrdl_cocotb" },
+    { name = "peakrdl-html", specifier = "==2.10.1" },
+    { name = "peakrdl-ipxact", specifier = "==3.4.4" },
+    { name = "peakrdl-markdown", specifier = "==1.0.0" },
+    { name = "peakrdl-regblock", specifier = "==0.23.0" },
+    { name = "peakrdl-systemrdl", specifier = "==0.3.0" },
+    { name = "peakrdl-uvm", specifier = "==2.3.0" },
+    { name = "pexpect", specifier = "==4.9.0" },
+    { name = "platformdirs", specifier = "==4.2.2" },
+    { name = "pluggy", specifier = "==1.4.0" },
+    { name = "prompt-toolkit", specifier = "==3.0.47" },
+    { name = "psutil", specifier = "==6.0.0" },
+    { name = "ptyprocess", specifier = "==0.7.0" },
+    { name = "pure-eval", specifier = "==0.2.2" },
+    { name = "py-markdown-table", specifier = "==0.3.3" },
+    { name = "pygments", specifier = "==2.18.0" },
+    { name = "pytest", specifier = "==8.1.1" },
+    { name = "pytest-html", specifier = "==4.1.1" },
+    { name = "pytest-md", specifier = "==0.2.0" },
+    { name = "pytest-metadata", specifier = "==3.1.1" },
+    { name = "pytest-timeout", specifier = "==2.3.1" },
+    { name = "python-constraint", specifier = "==1.4.0" },
+    { name = "python-dateutil", specifier = "==2.9.0.post0" },
+    { name = "python-markdown-math", specifier = "==0.8" },
+    { name = "pyuvm", specifier = "==2.9.1" },
+    { name = "pyyaml", specifier = "==6.0.1" },
+    { name = "pyzmq", specifier = "==26.0.3" },
+    { name = "referencing", specifier = "==0.35.1" },
+    { name = "rpds-py", specifier = "==0.18.1" },
+    { name = "six", specifier = "==1.16.0" },
+    { name = "smmap", specifier = "==5.0.1" },
+    { name = "stack-data", specifier = "==0.6.3" },
+    { name = "systemrdl-compiler", specifier = "==1.27.3" },
+    { name = "testplanner", git = "https://github.com/antmicro/testplanner?rev=54b6870a1b9c1518269beafe5dfd1465a9eddae6" },
+    { name = "tornado", specifier = "==6.4.1" },
+    { name = "traitlets", specifier = "==5.14.3" },
+    { name = "typing-extensions", specifier = "==4.12.2" },
+    { name = "vcd2pulseview", editable = "tools/vcd2pulseview" },
+    { name = "virtualenv", specifier = "==20.26.3" },
+    { name = "wcwidth", specifier = "==0.2.13" },
+    { name = "zstandard", specifier = "==0.23.0" },
+]
+
+[[package]]
+name = "info-process"
+version = "0.0.0"
+source = { git = "https://github.com/antmicro/info-process?rev=d21fbe7e647fdad767d0b34b00f60415665921dc#d21fbe7e647fdad767d0b34b00f60415665921dc" }
+dependencies = [
+    { name = "colorama" },
+    { name = "tabulate" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3", size = 4646, upload-time = "2023-01-07T11:08:11.254Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374", size = 5892, upload-time = "2023-01-07T11:08:09.864Z" },
+]
+
+[[package]]
+name = "ipykernel"
+version = "6.29.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "appnope", marker = "sys_platform == 'darwin'" },
+    { name = "comm" },
+    { name = "debugpy" },
+    { name = "ipython" },
+    { name = "jupyter-client" },
+    { name = "jupyter-core" },
+    { name = "matplotlib-inline" },
+    { name = "nest-asyncio" },
+    { name = "packaging" },
+    { name = "psutil" },
+    { name = "pyzmq" },
+    { name = "tornado" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8f/d8/6300fbbc6c211f51c833a0b8def7df9904eec315a2880f204e54dc117304/ipykernel-6.29.4.tar.gz", hash = "sha256:3d44070060f9475ac2092b760123fadf105d2e2493c24848b6691a7c4f42af5c", size = 162958, upload-time = "2024-03-27T22:25:45.577Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/53/9d/40d5207db523363d9b5698f33778c18b0d591e3fdb6e0116b894b2a2491c/ipykernel-6.29.4-py3-none-any.whl", hash = "sha256:1181e653d95c6808039c509ef8e67c4126b3b3af7781496c7cbfb5ed938a27da", size = 117131, upload-time = "2024-03-27T22:25:41.903Z" },
+]
+
+[[package]]
+name = "ipython"
+version = "8.25.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/5a/facbb5a0650e68b16134ce787b0990ee47f8b67316b0d844d9b183f212e6/ipython-8.25.0.tar.gz", hash = "sha256:c6ed726a140b6e725b911528f80439c534fac915246af3efc39440a6b0f9d716", size = 5492936, upload-time = "2024-05-31T13:24:48.851Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/78/fae11aa2dd7e948fbf6283f8abaff267b37a4a3cba531d0aa4274137e793/ipython-8.25.0-py3-none-any.whl", hash = "sha256:53eee7ad44df903a06655871cbab66d156a051fd86f3ec6750470ac9604ac1ab", size = 817329, upload-time = "2024-05-31T13:24:24.818Z" },
+]
+
+[[package]]
+name = "isort"
+version = "7.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/53/4f3c058e3bace40282876f9b553343376ee687f3c35a525dc79dbd450f88/isort-7.0.0.tar.gz", hash = "sha256:5513527951aadb3ac4292a41a16cbc50dd1642432f5e8c20057d414bdafb4187", size = 805049, upload-time = "2025-10-11T13:30:59.107Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/ed/e3705d6d02b4f7aea715a353c8ce193efd0b5db13e204df895d38734c244/isort-7.0.0-py3-none-any.whl", hash = "sha256:1bcabac8bc3c36c7fb7b98a76c8abb18e0f841a3ba81decac7691008592499c1", size = 94672, upload-time = "2025-10-11T13:30:57.665Z" },
+]
+
+[[package]]
+name = "jedi"
+version = "0.19.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "parso" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d6/99/99b493cec4bf43176b678de30f81ed003fd6a647a301b9c927280c600f0a/jedi-0.19.1.tar.gz", hash = "sha256:cf0496f3651bc65d7174ac1b7d043eff454892c708a87d1b683e57b569927ffd", size = 1227821, upload-time = "2023-10-02T09:20:39.728Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/9f/bc63f0f0737ad7a60800bfd472a4836661adae21f9c2535f3957b1e54ceb/jedi-0.19.1-py2.py3-none-any.whl", hash = "sha256:e983c654fe5c02867aef4cdfce5a2fbb4a50adc0af145f70504238f18ef5e7e0", size = 1569361, upload-time = "2023-10-02T09:20:35.754Z" },
+]
+
+[[package]]
+name = "jinja2"
+version = "3.1.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b2/5e/3a21abf3cd467d7876045335e681d276ac32492febe6d98ad89562d1a7e1/Jinja2-3.1.3.tar.gz", hash = "sha256:ac8bd6544d4bb2c9792bf3a159e80bba8fda7f07e81bc3aed565432d5925ba90", size = 268261, upload-time = "2024-01-10T23:12:21.133Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/6d/6de6be2d02603ab56e72997708809e8a5b0fbfee080735109b40a3564843/Jinja2-3.1.3-py3-none-any.whl", hash = "sha256:7d6d50dd97d52cbc355597bd845fabfbac3f551e1f99619e39a35ce8c370b5fa", size = 133236, upload-time = "2024-01-10T23:12:19.504Z" },
+]
+
+[[package]]
+name = "jsonschema"
+version = "4.22.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/f1/1c1dc0f6b3bf9e76f7526562d29c320fa7d6a2f35b37a1392cc0acd58263/jsonschema-4.22.0.tar.gz", hash = "sha256:5b22d434a45935119af990552c862e5d6d564e8f6601206b305a61fdf661a2b7", size = 325490, upload-time = "2024-04-30T19:44:37.487Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/2f/324fab4be6fe37fb7b521546e8a557e6cf08c1c1b3d0b4839a00f589d9ef/jsonschema-4.22.0-py3-none-any.whl", hash = "sha256:ff4cfd6b1367a40e7bc6411caec72effadd3db0bbe5017de188f2d6108335802", size = 88316, upload-time = "2024-04-30T19:44:34.97Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2023.12.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f8/b9/cc0cc592e7c195fb8a650c1d5990b10175cf13b4c97465c72ec841de9e4b/jsonschema_specifications-2023.12.1.tar.gz", hash = "sha256:48a76787b3e70f5ed53f1160d2b81f586e4ca6d1548c5de7085d1682674764cc", size = 13983, upload-time = "2023-12-25T15:16:53.63Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ee/07/44bd408781594c4d0a027666ef27fab1e441b109dc3b76b4f836f8fd04fe/jsonschema_specifications-2023.12.1-py3-none-any.whl", hash = "sha256:87e4fdf3a94858b8a2ba2778d9ba57d8a9cafca7c7489c46ba0d30a8bc6a9c3c", size = 18482, upload-time = "2023-12-25T15:16:51.997Z" },
+]
+
+[[package]]
+name = "jupyter-client"
+version = "8.6.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jupyter-core" },
+    { name = "python-dateutil" },
+    { name = "pyzmq" },
+    { name = "tornado" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ff/61/3cd51dea7878691919adc34ff6ad180f13bfe25fb8c7662a9ee6dc64e643/jupyter_client-8.6.2.tar.gz", hash = "sha256:2bda14d55ee5ba58552a8c53ae43d215ad9868853489213f37da060ced54d8df", size = 341102, upload-time = "2024-05-23T01:28:04.312Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cf/d3/c4bb02580bc0db807edb9a29b2d0c56031be1ef0d804336deb2699a470f6/jupyter_client-8.6.2-py3-none-any.whl", hash = "sha256:50cbc5c66fd1b8f65ecb66bc490ab73217993632809b6e505687de18e9dea39f", size = 105901, upload-time = "2024-05-23T01:28:00.817Z" },
+]
+
+[[package]]
+name = "jupyter-core"
+version = "5.7.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "platformdirs" },
+    { name = "pywin32", marker = "platform_python_implementation != 'PyPy' and sys_platform == 'win32'" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/00/11/b56381fa6c3f4cc5d2cf54a7dbf98ad9aa0b339ef7a601d6053538b079a7/jupyter_core-5.7.2.tar.gz", hash = "sha256:aa5f8d32bbf6b431ac830496da7392035d6f61b4f54872f15c4bd2a9c3f536d9", size = 87629, upload-time = "2024-03-12T12:37:35.652Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/fb/108ecd1fe961941959ad0ee4e12ee7b8b1477247f30b1fdfd83ceaf017f0/jupyter_core-5.7.2-py3-none-any.whl", hash = "sha256:4f7315d2f6b4bcf2e3e7cb6e46772eba760ae459cd1f59d29eb57b0a01bd7409", size = 28965, upload-time = "2024-03-12T12:37:32.36Z" },
+]
+
+[[package]]
+name = "markdown"
+version = "3.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/02/4785861427848cc11e452cc62bb541006a1087cf04a1de83aedd5530b948/Markdown-3.6.tar.gz", hash = "sha256:ed4f41f6daecbeeb96e576ce414c41d2d876daa9a16cb35fa8ed8c2ddfad0224", size = 354715, upload-time = "2024-03-14T15:37:59.775Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/b3/0c0c994fe49cd661084f8d5dc06562af53818cc0abefaca35bdc894577c3/Markdown-3.6-py3-none-any.whl", hash = "sha256:48f276f4d8cfb8ce6527c8f79e2ee29708508bf4d40aa410fbc3b4ee832c850f", size = 105381, upload-time = "2024-03-14T15:37:57.457Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "2.1.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/87/5b/aae44c6655f3801e81aa3eef09dbbf012431987ba564d7231722f68df02d/MarkupSafe-2.1.5.tar.gz", hash = "sha256:d283d37a890ba4c1ae73ffadf8046435c76e7bc2247bbb63c00bd1a709c6544b", size = 19384, upload-time = "2024-02-02T16:31:22.863Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/e7/291e55127bb2ae67c64d66cef01432b5933859dfb7d6949daa721b89d0b3/MarkupSafe-2.1.5-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:629ddd2ca402ae6dbedfceeba9c46d5f7b2a61d9749597d4307f943ef198fc1f", size = 18219, upload-time = "2024-02-02T16:30:19.988Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/cb/aed7a284c00dfa7c0682d14df85ad4955a350a21d2e3b06d8240497359bf/MarkupSafe-2.1.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5b7b716f97b52c5a14bffdf688f971b2d5ef4029127f1ad7a513973cfd818df2", size = 14098, upload-time = "2024-02-02T16:30:21.063Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/cf/35fe557e53709e93feb65575c93927942087e9b97213eabc3fe9d5b25a55/MarkupSafe-2.1.5-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6ec585f69cec0aa07d945b20805be741395e28ac1627333b1c5b0105962ffced", size = 29014, upload-time = "2024-02-02T16:30:22.926Z" },
+    { url = "https://files.pythonhosted.org/packages/97/18/c30da5e7a0e7f4603abfc6780574131221d9148f323752c2755d48abad30/MarkupSafe-2.1.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b91c037585eba9095565a3556f611e3cbfaa42ca1e865f7b8015fe5c7336d5a5", size = 28220, upload-time = "2024-02-02T16:30:24.76Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/40/2e73e7d532d030b1e41180807a80d564eda53babaf04d65e15c1cf897e40/MarkupSafe-2.1.5-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7502934a33b54030eaf1194c21c692a534196063db72176b0c4028e140f8f32c", size = 27756, upload-time = "2024-02-02T16:30:25.877Z" },
+    { url = "https://files.pythonhosted.org/packages/18/46/5dca760547e8c59c5311b332f70605d24c99d1303dd9a6e1fc3ed0d73561/MarkupSafe-2.1.5-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:0e397ac966fdf721b2c528cf028494e86172b4feba51d65f81ffd65c63798f3f", size = 33988, upload-time = "2024-02-02T16:30:26.935Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/c5/27febe918ac36397919cd4a67d5579cbbfa8da027fa1238af6285bb368ea/MarkupSafe-2.1.5-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:c061bb86a71b42465156a3ee7bd58c8c2ceacdbeb95d05a99893e08b8467359a", size = 32718, upload-time = "2024-02-02T16:30:28.111Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/81/56e567126a2c2bc2684d6391332e357589a96a76cb9f8e5052d85cb0ead8/MarkupSafe-2.1.5-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:3a57fdd7ce31c7ff06cdfbf31dafa96cc533c21e443d57f5b1ecc6cdc668ec7f", size = 33317, upload-time = "2024-02-02T16:30:29.214Z" },
+    { url = "https://files.pythonhosted.org/packages/00/0b/23f4b2470accb53285c613a3ab9ec19dc944eaf53592cb6d9e2af8aa24cc/MarkupSafe-2.1.5-cp311-cp311-win32.whl", hash = "sha256:397081c1a0bfb5124355710fe79478cdbeb39626492b15d399526ae53422b906", size = 16670, upload-time = "2024-02-02T16:30:30.915Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/a2/c78a06a9ec6d04b3445a949615c4c7ed86a0b2eb68e44e7541b9d57067cc/MarkupSafe-2.1.5-cp311-cp311-win_amd64.whl", hash = "sha256:2b7c57a4dfc4f16f7142221afe5ba4e093e09e728ca65c51f5620c9aaeb9a617", size = 17224, upload-time = "2024-02-02T16:30:32.09Z" },
+]
+
+[[package]]
+name = "matplotlib-inline"
+version = "0.1.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/99/5b/a36a337438a14116b16480db471ad061c36c3694df7c2084a0da7ba538b7/matplotlib_inline-0.1.7.tar.gz", hash = "sha256:8423b23ec666be3d16e16b60bdd8ac4e86e840ebd1dd11a30b9f117f2fa0ab90", size = 8159, upload-time = "2024-04-15T13:44:44.803Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/8e/9ad090d3553c280a8060fbf6e24dc1c0c29704ee7d1c372f0c174aa59285/matplotlib_inline-0.1.7-py3-none-any.whl", hash = "sha256:df192d39a4ff8f21b1895d72e6a13f5fcc5099f00fa84384e0ea28c2cc0653ca", size = 9899, upload-time = "2024-04-15T13:44:43.265Z" },
+]
+
+[[package]]
+name = "mccabe"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/ff/0ffefdcac38932a54d2b5eed4e0ba8a408f215002cd178ad1df0f2806ff8/mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325", size = 9658, upload-time = "2022-01-24T01:14:51.113Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e", size = 7350, upload-time = "2022-01-24T01:14:49.62Z" },
+]
+
+[[package]]
+name = "mistletoe"
+version = "1.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/31/ae/d33647e2a26a8899224f36afc5e7b7a670af30f1fd87231e9f07ca19d673/mistletoe-1.5.1.tar.gz", hash = "sha256:c5571ce6ca9cfdc7ce9151c3ae79acb418e067812000907616427197648030a3", size = 111769, upload-time = "2025-12-07T16:19:01.066Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/60/0980fefdc4d12c18c1bbab9d62852f27aded8839233c7b0a9827aaf395f5/mistletoe-1.5.1-py3-none-any.whl", hash = "sha256:d3e97664798261503f685f6a6281b092628367cf3128fc68a015a993b0c4feb3", size = 55331, upload-time = "2025-12-07T16:18:59.65Z" },
+]
+
+[[package]]
+name = "munch"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/2b/45098135b5f9f13221820d90f9e0516e11a2a0f55012c13b081d202b782a/munch-4.0.0.tar.gz", hash = "sha256:542cb151461263216a4e37c3fd9afc425feeaf38aaa3025cd2a981fadb422235", size = 19089, upload-time = "2023-07-01T09:49:35.98Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/b3/7c69b37f03260a061883bec0e7b05be7117c1b1c85f5212c72c8c2bc3c8c/munch-4.0.0-py2.py3-none-any.whl", hash = "sha256:71033c45db9fb677a0b7eb517a4ce70ae09258490e419b0e7f00d1e386ecb1b4", size = 9950, upload-time = "2023-07-01T09:49:34.472Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/a4/1ab47638b92648243faf97a5aeb6ea83059cc3624972ab6b8d2316078d3f/mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782", size = 4433, upload-time = "2023-02-04T12:11:27.157Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/e2/5d3f6ada4297caebe1a2add3b126fe800c96f56dbe5d1988a2cbe0b267aa/mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d", size = 4695, upload-time = "2023-02-04T12:11:25.002Z" },
+]
+
+[[package]]
+name = "nest-asyncio"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/83/f8/51569ac65d696c8ecbee95938f89d4abf00f47d58d48f6fbabfe8f0baefe/nest_asyncio-1.6.0.tar.gz", hash = "sha256:6f172d5449aca15afd6c646851f4e31e02c598d553a667e38cafa997cfec55fe", size = 7418, upload-time = "2024-01-21T14:25:19.227Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl", hash = "sha256:87af6efd6b5e897c81050477ef65c62e2b2f35d51703cae01aff2905b1852e1c", size = 5195, upload-time = "2024-01-21T14:25:17.223Z" },
+]
+
+[[package]]
+name = "nox"
+version = "2023.4.22"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "argcomplete" },
+    { name = "colorlog" },
+    { name = "packaging" },
+    { name = "virtualenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e7/3b/529fa8920b18b92085ed5923caee4aee112c65a7af99b34bd5a868b82e3e/nox-2023.4.22.tar.gz", hash = "sha256:46c0560b0dc609d7d967dc99e22cb463d3c4caf54a5fda735d6c11b5177e3a9f", size = 3984546, upload-time = "2023-04-23T03:13:02.285Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/c8/6e8e7412cb690fbfc993fb00e75b438e6982d2a247f29645d7daf75d013a/nox-2023.4.22-py3-none-any.whl", hash = "sha256:0b1adc619c58ab4fa57d6ab2e7823fe47a32e70202f287d78474adcc7bda1891", size = 54093, upload-time = "2023-04-23T03:12:57.08Z" },
+]
+
+[[package]]
+name = "nox-utils"
+version = "0.1.0"
+source = { editable = "tools/nox_utils" }
+dependencies = [
+    { name = "nox" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "nox" }]
+
+[[package]]
+name = "numpy"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/35/fb1ada118002df3fe91b5c3b28bc0d90f879b881a5d8f68b1f9b79c44bfe/numpy-2.0.0.tar.gz", hash = "sha256:cf5d1c9e6837f8af9f92b6bd3e86d513cdc11f60fd62185cc49ec7d1aba34864", size = 18326228, upload-time = "2024-06-16T13:24:44.066Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/52/a1aea658c7134ea0977542fc4d1aa6f1f9876c6a14ffeecd9394d839bc16/numpy-2.0.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ad0c86f3455fbd0de6c31a3056eb822fc939f81b1618f10ff3406971893b62a5", size = 21218342, upload-time = "2024-06-16T13:10:21.975Z" },
+    { url = "https://files.pythonhosted.org/packages/77/4d/ba4a60298c55478b34f13c97a0ac2cf8d225320322976252a250ed04040a/numpy-2.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e7f387600d424f91576af20518334df3d97bc76a300a755f9a8d6e4f5cadd289", size = 13272871, upload-time = "2024-06-16T13:10:42.58Z" },
+    { url = "https://files.pythonhosted.org/packages/01/4a/611a907421d8098d5edc8c2b10c3583796ee8da4156f8f7de52c2f4c9d90/numpy-2.0.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:34f003cb88b1ba38cb9a9a4a3161c1604973d7f9d5552c38bc2f04f829536609", size = 5237037, upload-time = "2024-06-16T13:10:52.937Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/c1/42d1789f1dff7b65f2d3237eb88db258a5a7fdfb981b895509887c92838d/numpy-2.0.0-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:b6f6a8f45d0313db07d6d1d37bd0b112f887e1369758a5419c0370ba915b3871", size = 6886342, upload-time = "2024-06-16T13:11:04.274Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/37/595f27a95ff976e8086bc4be1ede21ed24ca4bc127588da59197a65d066f/numpy-2.0.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5f64641b42b2429f56ee08b4f427a4d2daf916ec59686061de751a55aafa22e4", size = 13913798, upload-time = "2024-06-16T13:11:25.588Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/27/2a7bd6855dc717aeec5f553073a3c426b9c816126555f8e616392eab856b/numpy-2.0.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a7039a136017eaa92c1848152827e1424701532ca8e8967fe480fe1569dae581", size = 19292279, upload-time = "2024-06-16T13:11:54.793Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/54/966a3f5a93d709672ad851f6db52461c0584bab52f2230cf76be482302c6/numpy-2.0.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:46e161722e0f619749d1cd892167039015b2c2817296104487cd03ed4a955995", size = 19709770, upload-time = "2024-06-16T13:12:24.3Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/8b/9340ac45b6cd8bb92a03f797dbe9b7949f5b3789482e1d824cbebc80fda7/numpy-2.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:0e50842b2295ba8414c8c1d9d957083d5dfe9e16828b37de883f51fc53c4016f", size = 14417906, upload-time = "2024-06-16T13:12:47.027Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/46/614507d78ca8ce1567ac2c3bf7a79bfd413d6fc96dc6b415abaeb3734c0a/numpy-2.0.0-cp311-cp311-win32.whl", hash = "sha256:2ce46fd0b8a0c947ae047d222f7136fc4d55538741373107574271bc00e20e8f", size = 6357084, upload-time = "2024-06-16T13:12:58.711Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/0f/022ca4783b6e6239a53b988a4d315d67f9ae7126227fb2255054a558bd72/numpy-2.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:fbd6acc766814ea6443628f4e6751d0da6593dae29c08c0b2606164db026970c", size = 16511678, upload-time = "2024-06-16T13:13:23.583Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "24.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/b5/b43a27ac7472e1818c4bafd44430e69605baefe1f34440593e0332ec8b4d/packaging-24.0.tar.gz", hash = "sha256:eb82c5e3e56209074766e6885bb04b8c38a0c015d0a30036ebe7ece34c9989e9", size = 147882, upload-time = "2024-03-10T09:39:28.33Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/df/1fceb2f8900f8639e278b056416d49134fb8d84c5942ffaa01ad34782422/packaging-24.0-py3-none-any.whl", hash = "sha256:2ddfb553fdf02fb784c234c7ba6ccc288296ceabec964ad2eae3777778130bc5", size = 53488, upload-time = "2024-03-10T09:39:25.947Z" },
+]
+
+[[package]]
+name = "parso"
+version = "0.8.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/94/68e2e17afaa9169cf6412ab0f28623903be73d1b32e208d9e8e541bb086d/parso-0.8.4.tar.gz", hash = "sha256:eb3a7b58240fb99099a345571deecc0f9540ea5f4dd2fe14c2a99d6b281ab92d", size = 400609, upload-time = "2024-04-05T09:43:55.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c6/ac/dac4a63f978e4dcb3c6d3a78c4d8e0192a113d288502a1216950c41b1027/parso-0.8.4-py2.py3-none-any.whl", hash = "sha256:a418670a20291dacd2dddc80c377c5c3791378ee1e8d12bffc35420643d43f18", size = 103650, upload-time = "2024-04-05T09:43:53.299Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "0.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/bc/f35b8446f4531a7cb215605d100cd88b7ac6f44ab3fc94870c120ab3adbf/pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712", size = 51043, upload-time = "2023-12-10T22:30:45Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cc/20/ff623b09d963f88bfde16306a54e12ee5ea43e9b597108672ff3a408aad6/pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08", size = 31191, upload-time = "2023-12-10T22:30:43.14Z" },
+]
+
+[[package]]
+name = "peakrdl"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "peakrdl-cheader" },
+    { name = "peakrdl-html" },
+    { name = "peakrdl-ipxact" },
+    { name = "peakrdl-regblock" },
+    { name = "peakrdl-systemrdl" },
+    { name = "peakrdl-uvm" },
+    { name = "systemrdl-compiler" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/33/3e/6e38399e21b975b723cdecf637f1cbdaae7353600e2e67cc796bc2ab3aeb/peakrdl-1.1.0.tar.gz", hash = "sha256:662a9d5ce6a8bc59ceca6bd442f4fbe8e4b01e53fe14b9bf7ee8f91ff6d8d74c", size = 84572, upload-time = "2023-10-26T04:34:44.533Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/63/f75088887abcf995cca53db68bda4e19afe9e20125866ee37aeabc3ff7c1/peakrdl-1.1.0-py3-none-any.whl", hash = "sha256:aa8832413782049d6153895fae11969d7ba3f4bc28efb8e96fdde5db1cdc8f56", size = 44227, upload-time = "2023-10-26T04:34:42.433Z" },
+]
+
+[[package]]
+name = "peakrdl-cheader"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "systemrdl-compiler" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/db/ccaa561509f7df5970e2364188ea8b49bf77e510db5eb04701ab8adf943e/peakrdl-cheader-1.0.0.tar.gz", hash = "sha256:c0a27950f30bbe53701b59963802def14ae876eda4415278ad358411a563e4c8", size = 64311, upload-time = "2023-10-17T03:45:23.226Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/e9/3a1c6075a6146b4506937bbbd2719567266c8f01cf6f5a84499f9f610eb4/peakrdl_cheader-1.0.0-py3-none-any.whl", hash = "sha256:8a5da6f29fde7e999cfb9ef530a483ce81499280a1d08273c223449d90b55221", size = 41283, upload-time = "2023-10-17T03:45:21.579Z" },
+]
+
+[[package]]
+name = "peakrdl-cocotb"
+version = "0.1.0"
+source = { editable = "tools/peakrdl_cocotb" }
+dependencies = [
+    { name = "munch" },
+    { name = "systemrdl-compiler" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "munch", specifier = "==4.0.0" },
+    { name = "systemrdl-compiler", specifier = ">=1.21.0,<2" },
+]
+
+[[package]]
+name = "peakrdl-html"
+version = "2.10.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "git-me-the-url" },
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "python-markdown-math" },
+    { name = "systemrdl-compiler" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5a/dc/1b82395b9659c70ed138444d9c2d98a802fa3b56a1288d2cf00609ce1aec/peakrdl-html-2.10.1.tar.gz", hash = "sha256:955eb1c575308d35293622df3aaec26355ce8e5cdf6c88fb6a8fde216ac82f1c", size = 5586179, upload-time = "2023-06-02T06:19:23.423Z" }
+
+[[package]]
+name = "peakrdl-ipxact"
+version = "3.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "systemrdl-compiler" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6e/18/81a9c05d15100a71f6537659b99b439354febf1481269e6b3aa530f87791/peakrdl-ipxact-3.4.4.tar.gz", hash = "sha256:2ba1431b2eef21e30128e2cfa2e5213990dabb2e0c836b829b66b841f1283b97", size = 71387, upload-time = "2024-03-30T06:04:08.806Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/54/13de344d38551232ad62a1feaa74c0458cde94ca29381e5e876ca4bcb03e/peakrdl_ipxact-3.4.4-py3-none-any.whl", hash = "sha256:ce54edfa95a0b6550c9143f61e6c8c189c1bd5fe8579d0b5cc17726d0238fe62", size = 40742, upload-time = "2024-03-30T06:04:06.692Z" },
+]
+
+[[package]]
+name = "peakrdl-markdown"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gitpython" },
+    { name = "jinja2" },
+    { name = "peakrdl" },
+    { name = "py-markdown-table" },
+    { name = "pygments" },
+    { name = "setuptools" },
+    { name = "systemrdl-compiler" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/86/f1/96a84f0dc01214b6cb6916d8687784d8fa9a6d4620d44aea616fa7aabff6/peakrdl_markdown-1.0.0.tar.gz", hash = "sha256:14fef4bb76de9b50dac691fafc9027a8646d5ee7faf27eb9c4743410d1d164d1", size = 17843, upload-time = "2024-04-16T19:20:07.763Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/14/205059a3510d01da649c551c3ce5223400fdd1bfd48f947b66081f9bb9e8/peakrdl_markdown-1.0.0-py3-none-any.whl", hash = "sha256:197272e96c0ae3986c2404f478307b09763d2ea4952f90904eab2c799b29049a", size = 18859, upload-time = "2024-04-16T19:20:05.869Z" },
+]
+
+[[package]]
+name = "peakrdl-regblock"
+version = "0.23.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "systemrdl-compiler" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c3/81/be1e7f8850b3e66846cc957e9a651a754bc2de9c986f074d106be7acacf6/peakrdl_regblock-0.23.0.tar.gz", hash = "sha256:480cda4cb3451b58a032f8d5511a8176cd4c24201ce0ec861f3460a1c97f6207", size = 583407, upload-time = "2024-12-20T06:06:20.682Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/e1/46e199d6ad594a68514c93113d4681c8f97005b44d24dad93366e6970e1f/peakrdl_regblock-0.23.0-py3-none-any.whl", hash = "sha256:cd487e93cd6651a3eef4d1cf772fd35ec8bae3648e9144dc590a9c3273aee9a5", size = 83435, upload-time = "2024-12-20T06:06:17.927Z" },
+]
+
+[[package]]
+name = "peakrdl-systemrdl"
+version = "0.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "systemrdl-compiler" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f1/73/bbd37e67f54a5b41ced47133f70f68e5d3aacdbd9a5747be230f4e5f5284/peakrdl-systemrdl-0.3.0.tar.gz", hash = "sha256:a20369b70b00920a132327f9e49eaab6732a6ecd701e98ecb6ecbf2ab570457e", size = 17684, upload-time = "2023-04-12T04:34:58.578Z" }
+
+[[package]]
+name = "peakrdl-uvm"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "systemrdl-compiler" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/2b/47e2a27147ae1117e9248e926a7d478b6b2e229b30fb2a0bca01870d5ebe/peakrdl-uvm-2.3.0.tar.gz", hash = "sha256:ec18a4fc87d0201fe03ebe0de259a6b7f22be3de1d6908f80bce1e1416bc9cf2", size = 23518, upload-time = "2023-03-12T06:27:53.669Z" }
+
+[[package]]
+name = "pexpect"
+version = "4.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ptyprocess" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/c3/059298687310d527a58bb01f3b1965787ee3b40dce76752eda8b44e9a2c5/pexpect-4.9.0-py2.py3-none-any.whl", hash = "sha256:7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523", size = 63772, upload-time = "2023-11-25T06:56:14.81Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f5/52/0763d1d976d5c262df53ddda8d8d4719eedf9594d046f117c25a27261a19/platformdirs-4.2.2.tar.gz", hash = "sha256:38b7b51f512eed9e84a22788b4bce1de17c0adb134d6becb09836e37d8654cd3", size = 20916, upload-time = "2024-05-15T03:18:23.372Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/13/2aa1f0e1364feb2c9ef45302f387ac0bd81484e9c9a4c5688a322fbdfd08/platformdirs-4.2.2-py3-none-any.whl", hash = "sha256:2d7a1657e36a80ea911db832a8a6ece5ee53d8de21edd5cc5879af6530b1bfee", size = 18146, upload-time = "2024-05-15T03:18:21.209Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/c6/43f9d44d92aed815e781ca25ba8c174257e27253a94630d21be8725a2b59/pluggy-1.4.0.tar.gz", hash = "sha256:8c85c2876142a764e5b7548e7d9a0e0ddb46f5185161049a79b7e974454223be", size = 65812, upload-time = "2024-01-24T13:45:15.875Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/5b/0cc789b59e8cc1bf288b38111d002d8c5917123194d45b29dcdac64723cc/pluggy-1.4.0-py3-none-any.whl", hash = "sha256:7db9f7b503d67d1c5b95f59773ebb58a8c1c288129a88665838012cfb07b8981", size = 20120, upload-time = "2024-01-24T13:45:14.227Z" },
+]
+
+[[package]]
+name = "prompt-toolkit"
+version = "3.0.47"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/47/6d/0279b119dafc74c1220420028d490c4399b790fc1256998666e3a341879f/prompt_toolkit-3.0.47.tar.gz", hash = "sha256:1e1b29cb58080b1e69f207c893a1a7bf16d127a5c30c9d17a25a5d77792e5360", size = 425859, upload-time = "2024-06-10T11:02:14.045Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/23/22750c4b768f09386d1c3cc4337953e8936f48a888fa6dddfb669b2c9088/prompt_toolkit-3.0.47-py3-none-any.whl", hash = "sha256:0d7bfa67001d5e39d02c224b663abc33687405033a8c422d0d675a5a13361d10", size = 386411, upload-time = "2024-06-10T11:02:10.477Z" },
+]
+
+[[package]]
+name = "psutil"
+version = "6.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/c7/8c6872f7372eb6a6b2e4708b88419fb46b857f7a2e1892966b851cc79fc9/psutil-6.0.0.tar.gz", hash = "sha256:8faae4f310b6d969fa26ca0545338b21f73c6b15db7c4a8d934a5482faa818f2", size = 508067, upload-time = "2024-06-18T21:40:10.559Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/37/f8da2fbd29690b3557cca414c1949f92162981920699cd62095a984983bf/psutil-6.0.0-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:c588a7e9b1173b6e866756dde596fd4cad94f9399daf99ad8c3258b3cb2b47a0", size = 250961, upload-time = "2024-06-18T21:41:11.662Z" },
+    { url = "https://files.pythonhosted.org/packages/35/56/72f86175e81c656a01c4401cd3b1c923f891b31fbcebe98985894176d7c9/psutil-6.0.0-cp36-abi3-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6ed2440ada7ef7d0d608f20ad89a04ec47d2d3ab7190896cd62ca5fc4fe08bf0", size = 287478, upload-time = "2024-06-18T21:41:16.18Z" },
+    { url = "https://files.pythonhosted.org/packages/19/74/f59e7e0d392bc1070e9a70e2f9190d652487ac115bb16e2eff6b22ad1d24/psutil-6.0.0-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5fd9a97c8e94059b0ef54a7d4baf13b405011176c3b6ff257c247cae0d560ecd", size = 290455, upload-time = "2024-06-18T21:41:29.048Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/5f/60038e277ff0a9cc8f0c9ea3d0c5eb6ee1d2470ea3f9389d776432888e47/psutil-6.0.0-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e2e8d0054fc88153ca0544f5c4d554d42e33df2e009c4ff42284ac9ebdef4132", size = 292046, upload-time = "2024-06-18T21:41:33.53Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/20/2ff69ad9c35c3df1858ac4e094f20bd2374d33c8643cf41da8fd7cdcb78b/psutil-6.0.0-cp37-abi3-win32.whl", hash = "sha256:a495580d6bae27291324fe60cea0b5a7c23fa36a7cd35035a16d93bdcf076b9d", size = 253560, upload-time = "2024-06-18T21:41:46.067Z" },
+    { url = "https://files.pythonhosted.org/packages/73/44/561092313ae925f3acfaace6f9ddc4f6a9c748704317bad9c8c8f8a36a79/psutil-6.0.0-cp37-abi3-win_amd64.whl", hash = "sha256:33ea5e1c975250a720b3a6609c490db40dae5d83a4eb315170c4fe0d8b1f34b3", size = 257399, upload-time = "2024-06-18T21:41:52.1Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/06/63872a64c312a24fb9b4af123ee7007a306617da63ff13bcc1432386ead7/psutil-6.0.0-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:ffe7fc9b6b36beadc8c322f84e1caff51e8703b88eee1da46d1e3a6ae11b4fd0", size = 251988, upload-time = "2024-06-18T21:41:57.337Z" },
+]
+
+[[package]]
+name = "ptyprocess"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/e5/16ff212c1e452235a90aeb09066144d0c5a6a8c0834397e03f5224495c4e/ptyprocess-0.7.0.tar.gz", hash = "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220", size = 70762, upload-time = "2020-12-28T15:15:30.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/a6/858897256d0deac81a172289110f31629fc4cee19b6f01283303e18c8db3/ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35", size = 13993, upload-time = "2020-12-28T15:15:28.35Z" },
+]
+
+[[package]]
+name = "pure-eval"
+version = "0.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/97/5a/0bc937c25d3ce4e0a74335222aee05455d6afa2888032185f8ab50cdf6fd/pure_eval-0.2.2.tar.gz", hash = "sha256:2b45320af6dfaa1750f543d714b6d1c520a1688dec6fd24d339063ce0aaa9ac3", size = 19395, upload-time = "2022-01-22T15:41:29.465Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2b/27/77f9d5684e6bce929f5cfe18d6cfbe5133013c06cb2fbf5933670e60761d/pure_eval-0.2.2-py3-none-any.whl", hash = "sha256:01eaab343580944bc56080ebe0a674b39ec44a945e6d09ba7db3cb8cec289350", size = 11693, upload-time = "2022-01-22T15:41:27.814Z" },
+]
+
+[[package]]
+name = "py-markdown-table"
+version = "0.3.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/e7/93b4f8d735f4a62a40187f9672e16827ca4c58a5a0a2484f3ccfb1bd1a72/py-markdown-table-0.3.3.tar.gz", hash = "sha256:a82b7fb481729a6ac612c611c29b0ce84ad0bc96b6d09a9bb777f543f9c8c917", size = 6581, upload-time = "2022-08-17T19:51:18.769Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/40/0deab610aa500528ade4ca2752fde1a62880dc3892ff49b4ec250efd1e62/py_markdown_table-0.3.3-py3-none-any.whl", hash = "sha256:fefa8aeb1ce7a89971e633dde89e3890aecf5f7206a6b8c8279820b6fa62d815", size = 7330, upload-time = "2022-08-17T19:51:17.62Z" },
+]
+
+[[package]]
+name = "pycodestyle"
+version = "2.11.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/8f/fa09ae2acc737b9507b5734a9aec9a2b35fa73409982f57db1b42f8c3c65/pycodestyle-2.11.1.tar.gz", hash = "sha256:41ba0e7afc9752dfb53ced5489e89f8186be00e599e712660695b7a75ff2663f", size = 38974, upload-time = "2023-10-12T23:39:39.762Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b1/90/a998c550d0ddd07e38605bb5c455d00fcc177a800ff9cc3dafdcb3dd7b56/pycodestyle-2.11.1-py2.py3-none-any.whl", hash = "sha256:44fe31000b2d866f2e41841b18528a505fbd7fef9017b04eff4e2648a0fadc67", size = 31132, upload-time = "2023-10-12T23:39:38.242Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "2.23"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/cf/d2d3b9f5699fb1e4615c8e32ff220203e43b248e1dfcc6736ad9057731ca/pycparser-2.23.tar.gz", hash = "sha256:78816d4f24add8f10a06d6f05b4d424ad9e96cfebf68a4ddc99c65c0720d00c2", size = 173734, upload-time = "2025-09-09T13:23:47.91Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/e3/59cd50310fc9b59512193629e1984c1f95e5c8ae6e5d8c69532ccc65a7fe/pycparser-2.23-py3-none-any.whl", hash = "sha256:e5c6e8d3fbad53479cab09ac03729e0a9faf2bee3db8208a550daf5af81a5934", size = 118140, upload-time = "2025-09-09T13:23:46.651Z" },
+]
+
+[[package]]
+name = "pyflakes"
+version = "3.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/f9/669d8c9c86613c9d568757c7f5824bd3197d7b1c6c27553bc5618a27cce2/pyflakes-3.2.0.tar.gz", hash = "sha256:1c61603ff154621fb2a9172037d84dca3500def8c8b630657d1701f026f8af3f", size = 63788, upload-time = "2024-01-05T00:28:47.703Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/d7/f1b7db88d8e4417c5d47adad627a93547f44bdc9028372dbd2313f34a855/pyflakes-3.2.0-py2.py3-none-any.whl", hash = "sha256:84b5be138a2dfbb40689ca07e2152deb896a65c3a3e24c251c5c62489568074a", size = 62725, upload-time = "2024-01-05T00:28:45.903Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/62/8336eff65bcbc8e4cb5d05b55faf041285951b6e80f33e2bff2024788f31/pygments-2.18.0.tar.gz", hash = "sha256:786ff802f32e91311bff3889f6e9a86e81505fe99f2735bb6d60ae0c5004f199", size = 4891905, upload-time = "2024-05-04T13:42:02.013Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/3f/01c8b82017c199075f8f788d0d906b9ffbbc5a47dc9918a945e13d5a2bda/pygments-2.18.0-py3-none-any.whl", hash = "sha256:b8e6aca0523f3ab76fee51799c488e38782ac06eafcf95e7ba832985c8e7b13a", size = 1205513, upload-time = "2024-05-04T13:41:57.345Z" },
+]
+
+[[package]]
+name = "pyproject-flake8"
+version = "7.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "flake8" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/51/c3/619735aa5097b41e2af1a7e067e8859dea59689386b00c2efb7a8b7dc401/pyproject_flake8-7.0.0.tar.gz", hash = "sha256:5b953592336bc04d86e8942fdca1014256044a3445c8b6ca9467d08636749158", size = 4629, upload-time = "2024-04-09T22:10:33.642Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/49/34cb28f055739c442383cffe72f57d5eb924a9535ffc9c80edacff0f37f7/pyproject_flake8-7.0.0-py3-none-any.whl", hash = "sha256:611e91b49916e6d0685f88423ad4baff490888278a258975403c0dee6eb6072e", size = 5481, upload-time = "2024-04-09T22:10:29.949Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "8.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/30/b7/7d44bbc04c531dcc753056920e0988032e5871ac674b5a84cb979de6e7af/pytest-8.1.1.tar.gz", hash = "sha256:ac978141a75948948817d360297b7aae0fcb9d6ff6bc9ec6d514b85d5a65c044", size = 1409703, upload-time = "2024-03-09T11:51:08.012Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/7e/c79cecfdb6aa85c6c2e3cf63afc56d0f165f24f5c66c03c695c4d9b84756/pytest-8.1.1-py3-none-any.whl", hash = "sha256:2a8386cfc11fa9d2c50ee7b2a57e7d898ef90470a7a34c4b949ff59662bb78b7", size = 337359, upload-time = "2024-03-09T11:51:04.858Z" },
+]
+
+[[package]]
+name = "pytest-html"
+version = "4.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "pytest" },
+    { name = "pytest-metadata" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/ab/4862dcb5a8a514bd87747e06b8d55483c0c9e987e1b66972336946e49b49/pytest_html-4.1.1.tar.gz", hash = "sha256:70a01e8ae5800f4a074b56a4cb1025c8f4f9b038bba5fe31e3c98eb996686f07", size = 150773, upload-time = "2023-11-07T15:44:28.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/c7/c160021cbecd956cc1a6f79e5fe155f7868b2e5b848f1320dad0b3e3122f/pytest_html-4.1.1-py3-none-any.whl", hash = "sha256:c8152cea03bd4e9bee6d525573b67bbc6622967b72b9628dda0ea3e2a0b5dd71", size = 23491, upload-time = "2023-11-07T15:44:27.149Z" },
+]
+
+[[package]]
+name = "pytest-md"
+version = "0.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/55/1d4248f08a97255abb23b05d8ba07586333194fadb17beda96b707aebecd/pytest-md-0.2.0.tar.gz", hash = "sha256:3b248d5b360ea5198e05b4f49c7442234812809a63137ec6cdd3643a40cf0112", size = 5985, upload-time = "2019-07-11T08:15:59.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/71/23d03f57c18116c6770141478e33b3500c4e92500cf4b49a396e9226733f/pytest_md-0.2.0-py3-none-any.whl", hash = "sha256:4c4cd16fea6d1485e87ee254558712c804a96d2aa9674b780e7eb8fb6526e1d1", size = 6117, upload-time = "2019-07-11T08:15:57.829Z" },
+]
+
+[[package]]
+name = "pytest-metadata"
+version = "3.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a6/85/8c969f8bec4e559f8f2b958a15229a35495f5b4ce499f6b865eac54b878d/pytest_metadata-3.1.1.tar.gz", hash = "sha256:d2a29b0355fbc03f168aa96d41ff88b1a3b44a3b02acbe491801c98a048017c8", size = 9952, upload-time = "2024-02-12T19:38:44.887Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/43/7e7b2ec865caa92f67b8f0e9231a798d102724ca4c0e1f414316be1c1ef2/pytest_metadata-3.1.1-py3-none-any.whl", hash = "sha256:c8e0844db684ee1c798cfa38908d20d67d0463ecb6137c72e91f418558dd5f4b", size = 11428, upload-time = "2024-02-12T19:38:42.531Z" },
+]
+
+[[package]]
+name = "pytest-timeout"
+version = "2.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/93/0d/04719abc7a4bdb3a7a1f968f24b0f5253d698c9cc94975330e9d3145befb/pytest-timeout-2.3.1.tar.gz", hash = "sha256:12397729125c6ecbdaca01035b9e5239d4db97352320af155b3f5de1ba5165d9", size = 17697, upload-time = "2024-03-07T21:04:01.069Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/27/14af9ef8321f5edc7527e47def2a21d8118c6f329a9342cc61387a0c0599/pytest_timeout-2.3.1-py3-none-any.whl", hash = "sha256:68188cb703edfc6a18fad98dc25a3c61e9f24d644b0b70f33af545219fc7813e", size = 14148, upload-time = "2024-03-07T21:03:58.764Z" },
+]
+
+[[package]]
+name = "python-constraint"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/37/8b/5f1bc2734ca611943e1d6733ee244238679f6410a10cd45ede55a61a8402/python-constraint-1.4.0.tar.bz2", hash = "sha256:501d6f17afe0032dfc6ea6c0f8acc12e44f992733f00e8538961031ef27ccb8e", size = 18416, upload-time = "2018-11-05T09:02:44.334Z" }
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "python-markdown-math"
+version = "0.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ec/17/e7e3f3fce951b8adec10987834f4b2fa721ebd9bd6651ce2a4f39c4c544d/python-markdown-math-0.8.tar.gz", hash = "sha256:8564212af679fc18d53f38681f16080fcd3d186073f23825c7ce86fadd3e3635", size = 8509, upload-time = "2020-11-03T17:33:05.462Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/36/d16118345ff5f503d4d1c708e8427ed2213f2af7aaffac9d59010e665b5c/python_markdown_math-0.8-py3-none-any.whl", hash = "sha256:c685249d84b5b697e9114d7beb352bd8ca2e07fd268fd4057ffca888c14641e5", size = 5858, upload-time = "2020-11-03T17:33:02.998Z" },
+]
+
+[[package]]
+name = "pyuvm"
+version = "2.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cocotb" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3e/af/e39099197953c98431e519683431fad5ffca0ff8e888e24beba92fba984f/pyuvm-2.9.1.tar.gz", hash = "sha256:d9377ead1b20ca0c19ee21d8ecbcdf411949d28c49e3d5119f803e12069e2aea", size = 42730, upload-time = "2023-04-19T17:07:46.352Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/ad/564471cde5124b92ab76d94d1bda5712f51037037781e3705cb634adf722/pyuvm-2.9.1-py3-none-any.whl", hash = "sha256:d988a3e8326a74f610bef381ab3a9bd21e3a30e5e48d1852fa134de3811c9346", size = 40390, upload-time = "2023-04-19T17:07:43.158Z" },
+]
+
+[[package]]
+name = "pywin32"
+version = "311"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/af/449a6a91e5d6db51420875c54f6aff7c97a86a3b13a0b4f1a5c13b988de3/pywin32-311-cp311-cp311-win32.whl", hash = "sha256:184eb5e436dea364dcd3d2316d577d625c0351bf237c4e9a5fabbcfa5a58b151", size = 8697031, upload-time = "2025-07-14T20:13:13.266Z" },
+    { url = "https://files.pythonhosted.org/packages/51/8f/9bb81dd5bb77d22243d33c8397f09377056d5c687aa6d4042bea7fbf8364/pywin32-311-cp311-cp311-win_amd64.whl", hash = "sha256:3ce80b34b22b17ccbd937a6e78e7225d80c52f5ab9940fe0506a1a16f3dab503", size = 9508308, upload-time = "2025-07-14T20:13:15.147Z" },
+    { url = "https://files.pythonhosted.org/packages/44/7b/9c2ab54f74a138c491aba1b1cd0795ba61f144c711daea84a88b63dc0f6c/pywin32-311-cp311-cp311-win_arm64.whl", hash = "sha256:a733f1388e1a842abb67ffa8e7aad0e70ac519e09b0f6a784e65a136ec7cefd2", size = 8703930, upload-time = "2025-07-14T20:13:16.945Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/e5/af35f7ea75cf72f2cd079c95ee16797de7cd71f29ea7c68ae5ce7be1eda0/PyYAML-6.0.1.tar.gz", hash = "sha256:bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43", size = 125201, upload-time = "2023-07-18T00:00:23.308Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/0d/26fb23e8863e0aeaac0c64e03fd27367ad2ae3f3cccf3798ee98ce160368/PyYAML-6.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6965a7bc3cf88e5a1c3bd2e0b5c22f8d677dc88a455344035f03399034eb3007", size = 187867, upload-time = "2023-07-17T23:57:34.35Z" },
+    { url = "https://files.pythonhosted.org/packages/28/09/55f715ddbf95a054b764b547f617e22f1d5e45d83905660e9a088078fe67/PyYAML-6.0.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f003ed9ad21d6a4713f0a9b5a7a0a79e08dd0f221aff4525a2be4c346ee60aab", size = 167530, upload-time = "2023-07-17T23:57:36.975Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/94/7d5ee059dfb92ca9e62f4057dcdec9ac08a9e42679644854dc01177f8145/PyYAML-6.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42f8152b8dbc4fe7d96729ec2b99c7097d656dc1213a3229ca5383f973a5ed6d", size = 732244, upload-time = "2023-07-17T23:57:43.774Z" },
+    { url = "https://files.pythonhosted.org/packages/06/92/e0224aa6ebf9dc54a06a4609da37da40bb08d126f5535d81bff6b417b2ae/PyYAML-6.0.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:062582fca9fabdd2c8b54a3ef1c978d786e0f6b3a1510e0ac93ef59e0ddae2bc", size = 752871, upload-time = "2023-07-17T23:57:51.921Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5e/efd033ab7199a0b2044dab3b9f7a4f6670e6a52c089de572e928d2873b06/PyYAML-6.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d2b04aac4d386b172d5b9692e2d2da8de7bfb6c387fa4f801fbf6fb2e6ba4673", size = 757729, upload-time = "2023-07-17T23:57:59.865Z" },
+    { url = "https://files.pythonhosted.org/packages/03/5c/c4671451b2f1d76ebe352c0945d4cd13500adb5d05f5a51ee296d80152f7/PyYAML-6.0.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:e7d73685e87afe9f3b36c799222440d6cf362062f78be1013661b00c5c6f678b", size = 748528, upload-time = "2023-08-28T18:43:23.207Z" },
+    { url = "https://files.pythonhosted.org/packages/73/9c/766e78d1efc0d1fca637a6b62cea1b4510a7fb93617eb805223294fef681/PyYAML-6.0.1-cp311-cp311-win32.whl", hash = "sha256:1635fd110e8d85d55237ab316b5b011de701ea0f29d07611174a1b42f1444741", size = 130286, upload-time = "2023-07-17T23:58:02.964Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/34/65bb4b2d7908044963ebf614fe0fdb080773fc7030d7e39c8d3eddcd4257/PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34", size = 144699, upload-time = "2023-07-17T23:58:05.586Z" },
+]
+
+[[package]]
+name = "pyzmq"
+version = "26.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "implementation_name == 'pypy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c4/9a/0e2ab500fd5a5a41e7d003e4a49faa7a0333db13e54498a3cf749b9eedd0/pyzmq-26.0.3.tar.gz", hash = "sha256:dba7d9f2e047dfa2bca3b01f4f84aa5246725203d6284e3790f2ca15fba6b40a", size = 267708, upload-time = "2024-05-01T15:34:55.819Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/60/4e5170ffdf1720791752f09261a813efd5e59ec8ccf3e909d50d62a13b7d/pyzmq-26.0.3-cp311-cp311-macosx_10_15_universal2.whl", hash = "sha256:a72a84570f84c374b4c287183debc776dc319d3e8ce6b6a0041ce2e400de3f32", size = 1393498, upload-time = "2024-05-01T15:32:29.285Z" },
+    { url = "https://files.pythonhosted.org/packages/33/fa/e35e8c9e677604bbaa15e0f5887a5c0b031361ae25c6a3577c4720e106c2/pyzmq-26.0.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:7ca684ee649b55fd8f378127ac8462fb6c85f251c2fb027eb3c887e8ee347bcd", size = 1060015, upload-time = "2024-05-01T15:32:30.776Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/b5/625e45790a1b091f54d5d47fd267d051cabdec4f01144f6b2fcb7306515b/pyzmq-26.0.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e222562dc0f38571c8b1ffdae9d7adb866363134299264a1958d077800b193b7", size = 723307, upload-time = "2024-05-01T15:32:32.911Z" },
+    { url = "https://files.pythonhosted.org/packages/84/a5/8c81ad76e34e3b62a8c9e23dd14da01084284dbf0d4db20081859e3f7c77/pyzmq-26.0.3-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f17cde1db0754c35a91ac00b22b25c11da6eec5746431d6e5092f0cd31a3fea9", size = 960756, upload-time = "2024-05-01T15:32:34.367Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/41/02504160c5cc9d8dfe9afa5b7128ebbbc3e47933a4692197d23e601a171c/pyzmq-26.0.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4b7c0c0b3244bb2275abe255d4a30c050d541c6cb18b870975553f1fb6f37527", size = 918684, upload-time = "2024-05-01T15:32:36.188Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/20/92275f936eaa612f0192f8a02b2f66564e41498216f37a760501d2591149/pyzmq-26.0.3-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:ac97a21de3712afe6a6c071abfad40a6224fd14fa6ff0ff8d0c6e6cd4e2f807a", size = 919892, upload-time = "2024-05-01T15:32:38.512Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/86/827e3902f20e10b910587eaa8606e3ec3625fea112f5f2358be6ae624963/pyzmq-26.0.3-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:88b88282e55fa39dd556d7fc04160bcf39dea015f78e0cecec8ff4f06c1fc2b5", size = 1254254, upload-time = "2024-05-01T15:32:40.049Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/c8/b94e4596547a4b136e62f9cc5acc7bed761b1facfa75cf643e5e162dccbc/pyzmq-26.0.3-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:72b67f966b57dbd18dcc7efbc1c7fc9f5f983e572db1877081f075004614fcdd", size = 1565479, upload-time = "2024-05-01T15:32:42.011Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/9d/b1fc9b8f75f8747c41fea246dac11690c470d7204849b6072abbd0339c4f/pyzmq-26.0.3-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:f4b6cecbbf3b7380f3b61de3a7b93cb721125dc125c854c14ddc91225ba52f83", size = 1464884, upload-time = "2024-05-01T15:32:43.68Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/5b/59e06c10e4fd96cd1ff3f27a51638dd67b68ebd8f3e11995046392917272/pyzmq-26.0.3-cp311-cp311-win32.whl", hash = "sha256:eed56b6a39216d31ff8cd2f1d048b5bf1700e4b32a01b14379c3b6dde9ce3aa3", size = 679950, upload-time = "2024-05-01T15:32:45.378Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/11/20e8b114c197ead632bff8730593b5f249dd143ad71dfac9f639b354f309/pyzmq-26.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:3191d312c73e3cfd0f0afdf51df8405aafeb0bad71e7ed8f68b24b63c4f36500", size = 774765, upload-time = "2024-05-01T15:32:47.322Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/91/21de23e07510a0d4d5e4704e6e59edb8a69d1acfa4deac9bda18a53795d6/pyzmq-26.0.3-cp311-cp311-win_arm64.whl", hash = "sha256:b6907da3017ef55139cf0e417c5123a84c7332520e73a6902ff1f79046cd3b94", size = 862842, upload-time = "2024-05-01T15:32:48.87Z" },
+]
+
+[[package]]
+name = "referencing"
+version = "0.35.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/99/5b/73ca1f8e72fff6fa52119dbd185f73a907b1989428917b24cff660129b6d/referencing-0.35.1.tar.gz", hash = "sha256:25b42124a6c8b632a425174f24087783efb348a6f1e0008e63cd4466fedf703c", size = 62991, upload-time = "2024-05-01T20:26:04.574Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/59/2056f61236782a2c86b33906c025d4f4a0b17be0161b63b70fd9e8775d36/referencing-0.35.1-py3-none-any.whl", hash = "sha256:eda6d3234d62814d1c64e305c1331c9a3a6132da475ab6382eaa997b21ee75de", size = 26684, upload-time = "2024-05-01T20:26:02.078Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "0.18.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/aa/e7c404bdee1db7be09860dff423d022ffdce9269ec8e6532cce09ee7beea/rpds_py-0.18.1.tar.gz", hash = "sha256:dc48b479d540770c811fbd1eb9ba2bb66951863e448efec2e2c102625328e92f", size = 25388, upload-time = "2024-05-06T13:28:34.606Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/f3/454ef9c66219ea511991e024f3a379fca618acd4cbe12e369b2d02f9d0b6/rpds_py-0.18.1-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:6b5ff7e1d63a8281654b5e2896d7f08799378e594f09cf3674e832ecaf396ce8", size = 327805, upload-time = "2024-05-06T13:25:02.669Z" },
+    { url = "https://files.pythonhosted.org/packages/58/e3/b5eb611e2d51688726533bb97b420d36a55d4560c53d016e977ff6d48116/rpds_py-0.18.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:8927638a4d4137a289e41d0fd631551e89fa346d6dbcfc31ad627557d03ceb6d", size = 322329, upload-time = "2024-05-06T13:25:05.666Z" },
+    { url = "https://files.pythonhosted.org/packages/92/48/32bed868dd4e7d16e26457cc0b8634d6b16cb0e082a93f044ef5f7c77361/rpds_py-0.18.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:154bf5c93d79558b44e5b50cc354aa0459e518e83677791e6adb0b039b7aa6a7", size = 1114289, upload-time = "2024-05-06T13:25:08.806Z" },
+    { url = "https://files.pythonhosted.org/packages/77/66/905aa687ea072d8980f7b14eb9e3c3023f5f3892eb8b88be024094956014/rpds_py-0.18.1-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:07f2139741e5deb2c5154a7b9629bc5aa48c766b643c1a6750d16f865a82c5fc", size = 1123667, upload-time = "2024-05-06T13:25:11.624Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/6c/c658183fc2d2a6ed97b0816ab4fef59d609e596bf6f5f0898ae955c14885/rpds_py-0.18.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8c7672e9fba7425f79019db9945b16e308ed8bc89348c23d955c8c0540da0a07", size = 1145398, upload-time = "2024-05-06T13:25:14.607Z" },
+    { url = "https://files.pythonhosted.org/packages/91/33/b680feac0159b5b66ebb9e6d635d78e94486b0b7ed58bea273be2cc80817/rpds_py-0.18.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:489bdfe1abd0406eba6b3bb4fdc87c7fa40f1031de073d0cfb744634cc8fa261", size = 1309726, upload-time = "2024-05-06T13:25:16.757Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/a0/a3702128743ae5bf14175a7333a4741db167f62d42f70e0edc15d9cd45c5/rpds_py-0.18.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3c20f05e8e3d4fc76875fc9cb8cf24b90a63f5a1b4c5b9273f0e8225e169b100", size = 1114522, upload-time = "2024-05-06T13:25:19.815Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/3b/a4ed8b067a8f55df92dc1bc4d20858f02ddfdba3057f96759f4dd1bff7af/rpds_py-0.18.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:967342e045564cef76dfcf1edb700b1e20838d83b1aa02ab313e6a497cf923b8", size = 1139472, upload-time = "2024-05-06T13:25:22.14Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/ba/adb81247a2fe211ff74cd4c2790454bbf37eb7430ee898e4aa7ce5cb6507/rpds_py-0.18.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:2cc7c1a47f3a63282ab0f422d90ddac4aa3034e39fc66a559ab93041e6505da7", size = 1277148, upload-time = "2024-05-06T13:25:25.122Z" },
+    { url = "https://files.pythonhosted.org/packages/52/fc/1eb8dcf82ec8d1252c060644fa44478660e94637ddd91dc8d452b467f359/rpds_py-0.18.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:f7afbfee1157e0f9376c00bb232e80a60e59ed716e3211a80cb8506550671e6e", size = 1304556, upload-time = "2024-05-06T13:25:27.737Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/3f/0b8e2ac89076fede032aae3fc9cf9390c6fd99a470b238fb62bbc64f4cbf/rpds_py-0.18.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:9e6934d70dc50f9f8ea47081ceafdec09245fd9f6032669c3b45705dea096b88", size = 1283410, upload-time = "2024-05-06T13:25:29.843Z" },
+    { url = "https://files.pythonhosted.org/packages/74/e0/f9dc97509b3048ddc3ab7b0cd48bd25f78dff45bec463c62b0171c57398c/rpds_py-0.18.1-cp311-none-win32.whl", hash = "sha256:c69882964516dc143083d3795cb508e806b09fc3800fd0d4cddc1df6c36e76bb", size = 196622, upload-time = "2024-05-06T13:25:31.794Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/26/0778cc18815f20e37eb492bfed622d01722db38b2f3f86790753b01b2a73/rpds_py-0.18.1-cp311-none-win_amd64.whl", hash = "sha256:70a838f7754483bcdc830444952fd89645569e7452e3226de4a613a4c1793fb2", size = 209016, upload-time = "2024-05-06T13:25:33.646Z" },
+]
+
+[[package]]
+name = "setuptools"
+version = "65.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/29/f2ad3b78b9ebd24afa282eed9add27b47ef52b37291198021154b4b65166/setuptools-65.7.0.tar.gz", hash = "sha256:4d3c92fac8f1118bb77a22181355e29c239cabfe2b9effdaa665c66b711136d7", size = 2618315, upload-time = "2023-01-11T19:11:22.063Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ff/97/9dc902414912192d68364cc01cf17e826d259ef9753504b7ae1a256f2e35/setuptools-65.7.0-py3-none-any.whl", hash = "sha256:8ab4f1dbf2b4a65f7eec5ad0c620e84c34111a68d3349833494b9088212214dd", size = 1234046, upload-time = "2023-01-11T19:11:19.839Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/71/39/171f1c67cd00715f190ba0b100d606d440a28c93c7714febeca8b79af85e/six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926", size = 34041, upload-time = "2021-05-05T14:18:18.379Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/5a/e7c31adbe875f2abbb91bd84cf2dc52d792b5a01506781dbcf25c91daf11/six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254", size = 11053, upload-time = "2021-05-05T14:18:17.237Z" },
+]
+
+[[package]]
+name = "smmap"
+version = "5.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/04/b5bf6d21dc4041000ccba7eb17dd3055feb237e7ffc2c20d3fae3af62baa/smmap-5.0.1.tar.gz", hash = "sha256:dceeb6c0028fdb6734471eb07c0cd2aae706ccaecab45965ee83f11c8d3b1f62", size = 22291, upload-time = "2023-09-17T11:35:05.241Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/a5/10f97f73544edcdef54409f1d839f6049a0d79df68adbc1ceb24d1aaca42/smmap-5.0.1-py3-none-any.whl", hash = "sha256:e6d8668fa5f93e706934a62d7b4db19c8d9eb8cf2adbb75ef1b675aa332b69da", size = 24282, upload-time = "2023-09-17T11:35:03.253Z" },
+]
+
+[[package]]
+name = "soupsieve"
+version = "2.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/e6/21ccce3262dd4889aa3332e5a119a3491a95e8f60939870a3a035aabac0d/soupsieve-2.8.tar.gz", hash = "sha256:e2dd4a40a628cb5f28f6d4b0db8800b8f581b65bb380b97de22ba5ca8d72572f", size = 103472, upload-time = "2025-08-27T15:39:51.78Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/a0/bb38d3b76b8cae341dad93a2dd83ab7462e6dbcdd84d43f54ee60a8dc167/soupsieve-2.8-py3-none-any.whl", hash = "sha256:0cc76456a30e20f5d7f2e14a98a4ae2ee4e5abdc7c5ea0aafe795f344bc7984c", size = 36679, upload-time = "2025-08-27T15:39:50.179Z" },
+]
+
+[[package]]
+name = "stack-data"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asttokens" },
+    { name = "executing" },
+    { name = "pure-eval" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/28/e3/55dcc2cfbc3ca9c29519eb6884dd1415ecb53b0e934862d3559ddcb7e20b/stack_data-0.6.3.tar.gz", hash = "sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9", size = 44707, upload-time = "2023-09-30T13:58:05.479Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl", hash = "sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695", size = 24521, upload-time = "2023-09-30T13:58:03.53Z" },
+]
+
+[[package]]
+name = "systemrdl-compiler"
+version = "1.27.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "antlr4-python3-runtime" },
+    { name = "colorama" },
+    { name = "markdown" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e7/ed/357d1e4fbc19617b37c1da8ff561fd10c68f3f97561ed789f9599c01da07/systemrdl-compiler-1.27.3.tar.gz", hash = "sha256:db68354bff194cc7236ed68bac64c5bb81a9a17b5ba7b6f37b30078a50a53a3e", size = 449084, upload-time = "2024-01-12T06:12:39.121Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/e2/d80f5f17e6b2f0c0f52e03453a4a6cfec03a103132bc8199ceecc64edb7d/systemrdl_compiler-1.27.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:f76135c001454e55aff75c97f44d5fc53162455218ecd11bf817b106d7f4e649", size = 1168336, upload-time = "2024-01-12T06:10:44.837Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/2c/aa3895b4a300e82252f45b21d378ce203e2708d72783d998428c3492c187/systemrdl_compiler-1.27.3-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:acceab3b67ab59955069203b14881d72128993a5a3eba9c9baac96713f88b9e4", size = 10752687, upload-time = "2024-01-12T06:10:47.303Z" },
+    { url = "https://files.pythonhosted.org/packages/68/c4/737a634d6950d5dfd88b010e6afe32b1f596ee952d9a7e5fe6d30590366a/systemrdl_compiler-1.27.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:218e25567d6282bd6c1caf4ecfbcb5541aa46039bc94f4afd35a1ef83b7e4b2c", size = 10924134, upload-time = "2024-01-12T06:10:52.974Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/62/cff00910b91723f4003389a1b97b15a21f441b68f5ae063d31aa256c4221/systemrdl_compiler-1.27.3-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:da0f705ed485de68f82a4f8db8cabbcf701fef7ee4f188f4e224507854a7e56e", size = 15197968, upload-time = "2024-01-12T06:10:56.259Z" },
+    { url = "https://files.pythonhosted.org/packages/87/ff/08c66dc21bce2963b2735ce772a36f85631bf9a727111971bf5d2f397345/systemrdl_compiler-1.27.3-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:a815fe6f70338b42173586324bb140ecf2e33f2189f336fc49ffda8aa12f02a4", size = 15386246, upload-time = "2024-01-12T06:10:59.716Z" },
+    { url = "https://files.pythonhosted.org/packages/09/ca/5921b898faf65df54dfb86792d28357da3ca50cb521118ed4f3b278c35f0/systemrdl_compiler-1.27.3-cp311-cp311-win32.whl", hash = "sha256:2a145ebc54cdc2efe28e0c2b21135e5bc486d84b2203eb35b9fc73aecd7519ae", size = 885190, upload-time = "2024-01-12T06:11:03.253Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/e9/2f5cc101147654463ac1e5b073149ba0aca7ac08e2beec116e7a5290efa5/systemrdl_compiler-1.27.3-cp311-cp311-win_amd64.whl", hash = "sha256:4f0741fe131942a9b9cc09bca64791504a81c3a0244c094b3935d1b1c4fcff42", size = 917582, upload-time = "2024-01-12T06:11:05.623Z" },
+]
+
+[[package]]
+name = "tabulate"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/fe/802052aecb21e3797b8f7902564ab6ea0d60ff8ca23952079064155d1ae1/tabulate-0.9.0.tar.gz", hash = "sha256:0095b12bf5966de529c0feb1fa08671671b3368eec77d7ef7ab114be2c068b3c", size = 81090, upload-time = "2022-10-06T17:21:48.54Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/40/44/4a5f08c96eb108af5cb50b41f76142f0afa346dfa99d5296fe7202a11854/tabulate-0.9.0-py3-none-any.whl", hash = "sha256:024ca478df22e9340661486f85298cff5f6dcdba14f3813e8830015b9ed1948f", size = 35252, upload-time = "2022-10-06T17:21:44.262Z" },
+]
+
+[[package]]
+name = "testplanner"
+version = "0.0.1"
+source = { git = "https://github.com/antmicro/testplanner?rev=54b6870a1b9c1518269beafe5dfd1465a9eddae6#54b6870a1b9c1518269beafe5dfd1465a9eddae6" }
+dependencies = [
+    { name = "bs4" },
+    { name = "gitpython" },
+    { name = "hjson" },
+    { name = "jinja2" },
+    { name = "mistletoe" },
+    { name = "pyyaml" },
+    { name = "tabulate" },
+]
+
+[[package]]
+name = "tornado"
+version = "6.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/66/398ac7167f1c7835406888a386f6d0d26ee5dbf197d8a571300be57662d3/tornado-6.4.1.tar.gz", hash = "sha256:92d3ab53183d8c50f8204a51e6f91d18a15d5ef261e84d452800d4ff6fc504e9", size = 500623, upload-time = "2024-06-06T18:36:29.93Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/d9/c33be3c1a7564f7d42d87a8d186371a75fd142097076767a5c27da941fef/tornado-6.4.1-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:163b0aafc8e23d8cdc3c9dfb24c5368af84a81e3364745ccb4427669bf84aec8", size = 435924, upload-time = "2024-06-06T18:36:10.575Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/0f/721e113a2fac2f1d7d124b3279a1da4c77622e104084f56119875019ffab/tornado-6.4.1-cp38-abi3-macosx_10_9_x86_64.whl", hash = "sha256:6d5ce3437e18a2b66fbadb183c1d3364fb03f2be71299e7d10dbeeb69f4b2a14", size = 433883, upload-time = "2024-06-06T18:36:13.13Z" },
+    { url = "https://files.pythonhosted.org/packages/13/cf/786b8f1e6fe1c7c675e79657448178ad65e41c1c9765ef82e7f6f765c4c5/tornado-6.4.1-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e2e20b9113cd7293f164dc46fffb13535266e713cdb87bd2d15ddb336e96cfc4", size = 437224, upload-time = "2024-06-06T18:36:14.657Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/8e/a6ce4b8d5935558828b0f30f3afcb2d980566718837b3365d98e34f6067e/tornado-6.4.1-cp38-abi3-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8ae50a504a740365267b2a8d1a90c9fbc86b780a39170feca9bcc1787ff80842", size = 436597, upload-time = "2024-06-06T18:36:17.093Z" },
+    { url = "https://files.pythonhosted.org/packages/22/d4/54f9d12668b58336bd30defe0307e6c61589a3e687b05c366f804b7faaf0/tornado-6.4.1-cp38-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:613bf4ddf5c7a95509218b149b555621497a6cc0d46ac341b30bd9ec19eac7f3", size = 436797, upload-time = "2024-06-06T18:36:19.265Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/3f/2c792e7afa7dd8b24fad7a2ed3c2f24a5ec5110c7b43a64cb6095cc106b8/tornado-6.4.1-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:25486eb223babe3eed4b8aecbac33b37e3dd6d776bc730ca14e1bf93888b979f", size = 437516, upload-time = "2024-06-06T18:36:20.813Z" },
+    { url = "https://files.pythonhosted.org/packages/71/63/c8fc62745e669ac9009044b889fc531b6f88ac0f5f183cac79eaa950bb23/tornado-6.4.1-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:454db8a7ecfcf2ff6042dde58404164d969b6f5d58b926da15e6b23817950fc4", size = 436958, upload-time = "2024-06-06T18:36:22.679Z" },
+    { url = "https://files.pythonhosted.org/packages/94/d4/f8ac1f5bd22c15fad3b527e025ce219bd526acdbd903f52053df2baecc8b/tornado-6.4.1-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a02a08cc7a9314b006f653ce40483b9b3c12cda222d6a46d4ac63bb6c9057698", size = 436882, upload-time = "2024-06-06T18:36:24.124Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/3e/a8124c21cc0bbf144d7903d2a0cadab15cadaf683fa39a0f92bc567f0d4d/tornado-6.4.1-cp38-abi3-win32.whl", hash = "sha256:d9a566c40b89757c9aa8e6f032bcdb8ca8795d7c1a9762910c722b1635c9de4d", size = 438092, upload-time = "2024-06-06T18:36:25.881Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/2f/3f2f05e84a7aff787a96d5fb06821323feb370fe0baed4db6ea7b1088f32/tornado-6.4.1-cp38-abi3-win_amd64.whl", hash = "sha256:b24b8982ed444378d7f21d563f4180a2de31ced9d8d84443907a0a64da2072e7", size = 438532, upload-time = "2024-06-06T18:36:28.494Z" },
+]
+
+[[package]]
+name = "traitlets"
+version = "5.14.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/79/72064e6a701c2183016abbbfedaba506d81e30e232a68c9f0d6f6fcd1574/traitlets-5.14.3.tar.gz", hash = "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7", size = 161621, upload-time = "2024-04-19T11:11:49.746Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl", hash = "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f", size = 85359, upload-time = "2024-04-19T11:11:46.763Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.12.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/db/f35a00659bc03fec321ba8bce9420de607a1d37f8342eee1863174c69557/typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8", size = 85321, upload-time = "2024-06-07T18:52:15.995Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d", size = 37438, upload-time = "2024-06-07T18:52:13.582Z" },
+]
+
+[[package]]
+name = "vcd2pulseview"
+version = "0.1.0"
+source = { editable = "tools/vcd2pulseview" }
+
+[[package]]
+name = "virtualenv"
+version = "20.26.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "distlib" },
+    { name = "filelock" },
+    { name = "platformdirs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/68/60/db9f95e6ad456f1872486769c55628c7901fb4de5a72c2f7bdd912abf0c1/virtualenv-20.26.3.tar.gz", hash = "sha256:4c43a2a236279d9ea36a0d76f98d84bd6ca94ac4e0f4a3b9d46d05e10fea542a", size = 9057588, upload-time = "2024-06-22T01:57:47.963Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/4d/410156100224c5e2f0011d435e477b57aed9576fc7fe137abcf14ec16e11/virtualenv-20.26.3-py3-none-any.whl", hash = "sha256:8cc4a31139e796e9a7de2cd5cf2489de1217193116a8fd42328f1bd65f434589", size = 5684792, upload-time = "2024-06-22T01:57:43.997Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.2.13"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/63/53559446a878410fc5a5974feb13d31d78d752eb18aeba59c7fef1af7598/wcwidth-0.2.13.tar.gz", hash = "sha256:72ea0c06399eb286d978fdedb6923a9eb47e1c486ce63e9b4e64fc18303972b5", size = 101301, upload-time = "2024-01-06T02:10:57.829Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/84/fd2ba7aafacbad3c4201d395674fc6348826569da3c0937e75505ead3528/wcwidth-0.2.13-py2.py3-none-any.whl", hash = "sha256:3da69048e4540d84af32131829ff948f1e022c1c6bdb8d6102117aac784f6859", size = 34166, upload-time = "2024-01-06T02:10:55.763Z" },
+]
+
+[[package]]
+name = "zstandard"
+version = "0.23.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation == 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ed/f6/2ac0287b442160a89d726b17a9184a4c615bb5237db763791a7fd16d9df1/zstandard-0.23.0.tar.gz", hash = "sha256:b2d8c62d08e7255f68f7a740bae85b3c9b8e5466baa9cbf7f57f1cde0ac6bc09", size = 681701, upload-time = "2024-07-15T00:18:06.141Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/40/f67e7d2c25a0e2dc1744dd781110b0b60306657f8696cafb7ad7579469bd/zstandard-0.23.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:34895a41273ad33347b2fc70e1bff4240556de3c46c6ea430a7ed91f9042aa4e", size = 788699, upload-time = "2024-07-15T00:14:04.909Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/46/66d5b55f4d737dd6ab75851b224abf0afe5774976fe511a54d2eb9063a41/zstandard-0.23.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:77ea385f7dd5b5676d7fd943292ffa18fbf5c72ba98f7d09fc1fb9e819b34c23", size = 633681, upload-time = "2024-07-15T00:14:13.99Z" },
+    { url = "https://files.pythonhosted.org/packages/63/b6/677e65c095d8e12b66b8f862b069bcf1f1d781b9c9c6f12eb55000d57583/zstandard-0.23.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:983b6efd649723474f29ed42e1467f90a35a74793437d0bc64a5bf482bedfa0a", size = 4944328, upload-time = "2024-07-15T00:14:16.588Z" },
+    { url = "https://files.pythonhosted.org/packages/59/cc/e76acb4c42afa05a9d20827116d1f9287e9c32b7ad58cc3af0721ce2b481/zstandard-0.23.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:80a539906390591dd39ebb8d773771dc4db82ace6372c4d41e2d293f8e32b8db", size = 5311955, upload-time = "2024-07-15T00:14:19.389Z" },
+    { url = "https://files.pythonhosted.org/packages/78/e4/644b8075f18fc7f632130c32e8f36f6dc1b93065bf2dd87f03223b187f26/zstandard-0.23.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:445e4cb5048b04e90ce96a79b4b63140e3f4ab5f662321975679b5f6360b90e2", size = 5344944, upload-time = "2024-07-15T00:14:22.173Z" },
+    { url = "https://files.pythonhosted.org/packages/76/3f/dbafccf19cfeca25bbabf6f2dd81796b7218f768ec400f043edc767015a6/zstandard-0.23.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd30d9c67d13d891f2360b2a120186729c111238ac63b43dbd37a5a40670b8ca", size = 5442927, upload-time = "2024-07-15T00:14:24.825Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/c3/d24a01a19b6733b9f218e94d1a87c477d523237e07f94899e1c10f6fd06c/zstandard-0.23.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d20fd853fbb5807c8e84c136c278827b6167ded66c72ec6f9a14b863d809211c", size = 4864910, upload-time = "2024-07-15T00:14:26.982Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/a9/cf8f78ead4597264f7618d0875be01f9bc23c9d1d11afb6d225b867cb423/zstandard-0.23.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:ed1708dbf4d2e3a1c5c69110ba2b4eb6678262028afd6c6fbcc5a8dac9cda68e", size = 4935544, upload-time = "2024-07-15T00:14:29.582Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/96/8af1e3731b67965fb995a940c04a2c20997a7b3b14826b9d1301cf160879/zstandard-0.23.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:be9b5b8659dff1f913039c2feee1aca499cfbc19e98fa12bc85e037c17ec6ca5", size = 5467094, upload-time = "2024-07-15T00:14:40.126Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/57/43ea9df642c636cb79f88a13ab07d92d88d3bfe3e550b55a25a07a26d878/zstandard-0.23.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:65308f4b4890aa12d9b6ad9f2844b7ee42c7f7a4fd3390425b242ffc57498f48", size = 4860440, upload-time = "2024-07-15T00:14:42.786Z" },
+    { url = "https://files.pythonhosted.org/packages/46/37/edb78f33c7f44f806525f27baa300341918fd4c4af9472fbc2c3094be2e8/zstandard-0.23.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:98da17ce9cbf3bfe4617e836d561e433f871129e3a7ac16d6ef4c680f13a839c", size = 4700091, upload-time = "2024-07-15T00:14:45.184Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/f1/454ac3962671a754f3cb49242472df5c2cced4eb959ae203a377b45b1a3c/zstandard-0.23.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:8ed7d27cb56b3e058d3cf684d7200703bcae623e1dcc06ed1e18ecda39fee003", size = 5208682, upload-time = "2024-07-15T00:14:47.407Z" },
+    { url = "https://files.pythonhosted.org/packages/85/b2/1734b0fff1634390b1b887202d557d2dd542de84a4c155c258cf75da4773/zstandard-0.23.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:b69bb4f51daf461b15e7b3db033160937d3ff88303a7bc808c67bbc1eaf98c78", size = 5669707, upload-time = "2024-07-15T00:15:03.529Z" },
+    { url = "https://files.pythonhosted.org/packages/52/5a/87d6971f0997c4b9b09c495bf92189fb63de86a83cadc4977dc19735f652/zstandard-0.23.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:034b88913ecc1b097f528e42b539453fa82c3557e414b3de9d5632c80439a473", size = 5201792, upload-time = "2024-07-15T00:15:28.372Z" },
+    { url = "https://files.pythonhosted.org/packages/79/02/6f6a42cc84459d399bd1a4e1adfc78d4dfe45e56d05b072008d10040e13b/zstandard-0.23.0-cp311-cp311-win32.whl", hash = "sha256:f2d4380bf5f62daabd7b751ea2339c1a21d1c9463f1feb7fc2bdcea2c29c3160", size = 430586, upload-time = "2024-07-15T00:15:32.26Z" },
+    { url = "https://files.pythonhosted.org/packages/be/a2/4272175d47c623ff78196f3c10e9dc7045c1b9caf3735bf041e65271eca4/zstandard-0.23.0-cp311-cp311-win_amd64.whl", hash = "sha256:62136da96a973bd2557f06ddd4e8e807f9e13cbb0bfb9cc06cfe6d98ea90dfe0", size = 495420, upload-time = "2024-07-15T00:15:34.004Z" },
+]

--- a/verification/README.md
+++ b/verification/README.md
@@ -2,55 +2,121 @@
 
 The I3C Core is verified with rapid cocotb tests and the UVM test suite, located in `cocotb` and `uvm_i3c` directories, respectively.
 
-## Cocotb
+All verification should be launched from a shell in the project root.
+
+## Cocotb Tests
 
 Tests are split into directories:
 * `top` - top level, full I3C tests
 * `block` - module level, unit tests, subsystems
 
-Once setup is completed, then simulations can be launched with:
+## Setup Dependencies
 
-```{bash}
-make tests
+Clone this repository to a working directory.
+Ensure that all submodules are initialized and populated (e.g. `git submodule update --init --recursive`)
+
+If you wish to use VCS as a simulator, this will also need to be present on the path, and appropriate license server envvars set.
+
+The following FOSS dependencies are required:
+- python311
+- verible
+- lcov
+- verilator 5.024
+- zlib
+
+The python module dependencies are specified in pyproject.toml.
+Lockfiles suitable for pip (requirements.txt) and uv (uv.lock) are provided.
+
+Running `./install.sh` will install `pyenv` and use it to build a virtual environment, which can be activated with `. activate.sh`.
+Alternatively, `uv` can be used with `uv venv && uv sync` building a virtual environment and then activating it with `. .venv/bin/activate`.
+
+### Nix-Alternative
+
+A Nix-based environment is also present, which provides an ephemeral development shell environment containing all of the above FOSS dependencies, plus some conveniences such as GTKwave and Surfer for waveform viewing.
+The python dependencies in this case are managed by uv, which is run at the time of entering the shell via a hook.
+
+This can be convenient and valuable to avoid polluting the base computing environment with project dependencies.
+
+With a Nix installation (e.g. https://nixos.org/download/ ) and the nix-command+flakes experimental features enabled (e.g. `/etc/nix/nix.conf` contains the line `experimental-features = nix-command flakes`), it can be used as follows:
+```
+## Enter the subshell, adding all deps to your path
+$ nix develop
+
+## Run tests
+## e.g
+$ SIMULATOR=verilator make tests-axi
+$ surfer verification/cocotb/top/i3c_axi/test_recovery.fst
+
+## Exit the subshell
+$ exit
 ```
 
-In order to run a specific test, you can also use:
+## Running tests
 
-```{bash}
-TEST=<test_name> make test
+### Cocotb
+
+The top-level Makefile contains a number of targets that can be used to run suites of tests.
+All simulations can be launched with `make tests`.
+In order to run a specific test, you can also use `TEST=<test_name> make test`.
+`make list-tests` will print all of the available tests, which are of the form `<test_name>_verify`.
+
+`make clean` should be run between test invocations where the RTL or testbench environment has been changed.
+
+Passing extra environment variables allows for configuration of what will be run, and how.
+Use `SIMULATOR=<verilator/vcs>` to choose the simulation tool.
+Verilator is the default.
+Setting `CFG_NAME=axi` will pass a set of parameterizations to use the AXI instantiation.
+Wave dumping is enabled by default, but can be disabled by setting `WAVES=0`.
+Setting `TEST` wil choose a specific cocotb test to be run.
+These are selected via “sessions” defined in the noxfiles, which can be printed using `make list-tests`.
+
+Logfiles/waves will be placed adjacent to the specific test run within `verification/cocotb/`.
+e.g.
+```
+SIMULATOR=vcs CFG_NAME=axi TEST=i3c_axi make test
+verdi -base -ssf ./verification/cocotb/top/i3c_axi/test_recovery.fsdb
+```
+or...
+```
+SIMULATOR=verilator CFG_NAME=axi TEST=i3c_axi make test
+gtkwave verification/cocotb/top/i3c_axi/test_i3c_target.fst
 ```
 
-### Debugging simulations
+Note that running many tests via `nox` can be slow, as it does not parallelize jobs.
+To run a single test directly via a `nox` session parameterization, the `test-s` target can be used.
+The parameterization shown can usually be extracted from the stdout of a larger regression, however note the additional quotations/escapes needed.
+e.g.
+```
+SIMULATOR=vcs CFG_NAME=axi TEST="\"i3c_axi_verify(simulator='vcs', coverage=None, test_name='test_recovery', test_group='i3c_axi')\"" make test-s
+```
 
-Launching simulation without `nox` is useful for debugging. In the root of project, export variables:
+### Debugging cocotb simulations
+
+The top-level Makefile invokes `nox` to run tests as parameterized in a series of noxfiles throughout the project.
+These noxfiles invoke the simulators via a seperate invocation of Make, to which the directory of the test is passed (via `-C`) and the test name (via `MODULE=<test_name>`).
+For example, the command to invoke a test might be something like `make -C ./top/i3c_axi/ all TEST=test_ccc`.
+
+Launching a simulation directly (i.e. without `nox` ) can be useful for debugging.
+This can be done, from the project root, as follows:
 
 ```{bash}
-export CALIPTRA_ROOT=$(pwd)/third_party/caliptra-rtl
+# First ensure the environment is setup
 export I3C_ROOT_DIR=$(pwd)
+export CALIPTRA_ROOT=$(pwd)/third_party/caliptra-rtl
+# Then run the following
+pushd verification/cocotb
+make clean
+make -C ./<test_dir> all MODULE=<test_name>
 ```
 
-enter `verification/cocotb/block` directory and run
+### UVM
 
-```{bash}
-make -C ./<block_name> clean all MODULE=<test_name>
-```
+#### Running I3C agent tests
 
-## UVM
+* `make tests-uvm SIMULATOR=simulator_of_your_choice` runs all I3C agent tests.
+* `make i3c-verify-test-uvm SIMULATOR=simulator_of_your_choice TEST=virtual_sequence_to_run` runs a single I3C agent test.
 
-### Running I3C agent tests
+#### Running I3C core tests
 
-* To run all I3C agent tests run `make tests-uvm SIMULATOR=simulator_of_your_choice` in the I3C core root folder.
-* To run single I3C agent test run
-`make i3c-verify-test-uvm SIMULATOR=simulator_of_your_choice TEST=virtual_sequence_to_run`
-in the I3C core root folder.
-
-### Running I3C core tests
-
-* To run all I3C agent tests run `make tests-i3c-core-uvm SIMULATOR=simulator_of_your_choice` in the I3C core root folder.
-* To run single I3C agent test run
-`make i3c-core-verify-test-uvm SIMULATOR=simulator_of_your_choice TEST=virtual_sequence_to_run`
-in the I3C core root folder.
-
-## Tools
-
-In directory `tools`, a noxfile is provided to test [the I3C Core Configuration Tool](../tools/i3c_config/i3c_core_config.py).
+* `make tests-i3c-core-uvm SIMULATOR=simulator_of_your_choice` runs all I3C core tests.
+* `make i3c-core-verify-test-uvm SIMULATOR=simulator_of_your_choice TEST=virtual_sequence_to_run` runs a single I3C core test.

--- a/verification/cocotb/common.mk
+++ b/verification/cocotb/common.mk
@@ -5,7 +5,7 @@ SIM             ?= verilator
 WAVES           ?= 1
 
 # Paths
-CURDIR = $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+CURDIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 I3C_ROOT := $(abspath $(CURDIR)/../..)
 CFGDIR :=
 CONFIG :=
@@ -14,8 +14,7 @@ $(info From common.mk, CURDIR is $(CURDIR))
 # Set pythonpath so that tests can access common modules
 export PYTHONPATH := $(PYTHONPATH):$(CURDIR)/common
 
-# Add empty file to common sources to enforce
-# configuration build before running the tests
+# Add empty file to common sources to enforce configuration build before running the tests
 COMMON_SOURCES += $(TEST_DIR)/sim_build/i3c_config.vh
 
 VERILOG_INCLUDE_DIRS= \
@@ -43,25 +42,33 @@ else
     VERILATOR_COVERAGE = ""
 endif
 
-# Enable processing of #delay statements
+COMPILE_ARGS += +define+DIGITAL_IO_I3C
+
 ifeq ($(SIM), verilator)
+    # Enable processing of #delay statements
     COMPILE_ARGS += --timing
-    COMPILE_ARGS += +define+DIGITAL_IO_I3C
     COMPILE_ARGS += -Wall -Wno-fatal
     COMPILE_ARGS += --x-assign unique --x-initial unique
 
-    EXTRA_ARGS += --trace --trace-structs
+    EXTRA_ARGS += --trace --trace-structs --trace-fst
     EXTRA_ARGS += $(VERILATOR_COVERAGE)
     EXTRA_ARGS += -Wno-DECLFILENAME -Wno-TIMESCALEMOD
 endif
 
 ifeq ($(SIM), vcs)
+    EXTRA_ARGS += +vcs+lic+wait
     COMPILE_ARGS += -deraceclockdata +libext+.sv +libext+.v
-    COMPILE_ARGS += +define+DIGITAL_IO_I3C
     COMPILE_ARGS += $(foreach dir,$(VERILOG_INCLUDE_DIRS),-y $(dir))
-    COMPILE_ARGS += -debug_access+all +memcbk -assert svaext
+    COMPILE_ARGS += -assert svaext
+    COMPILE_ARGS += -Xcflags='-Wno-error=implicit-function-declaration -Wno-error=int-conversion'
     SIM_ARGS += +dumpon
-    EXTRA_ARGS += +vcs+vcdpluson +vpdfile+dump.vpd +vcs+lic+wait
+
+    ifeq ($(WAVES), 1)
+        EXTRA_ARGS += +vcs+vcdpluson +vpdfile+dump.vpd
+        COMPILE_ARGS += -debug_access+all +memcbk -kdb
+        SIM_ARGS += +dumpon
+        SIM_ARGS += -ucli -do $(CURDIR)/vcs.tcl
+    endif
 
     ifneq ($(COVERAGE_TYPE),)
         EXTRA_ARGS += -cm line+cond+fsm+tgl+branch -lca
@@ -69,8 +76,7 @@ ifeq ($(SIM), vcs)
 endif
 
 COCOTB_HDL_TIMEUNIT         = 1ns
-# we need 1fs resolution to handle 333MHz clocks
-COCOTB_HDL_TIMEPRECISION    = 1fs
+COCOTB_HDL_TIMEPRECISION    = 1fs ## we need 1fs resolution to handle 333MHz clocks
 
 # Build directory
 comma := ,

--- a/verification/cocotb/noxfile.py
+++ b/verification/cocotb/noxfile.py
@@ -1,4 +1,40 @@
 # SPDX-License-Identifier: Apache-2.0
+"""i3c_core cocotb test suite.
+
+# tags
+# - "tests"
+# - "ahb"
+# - "axi"
+#
+# sessions
+#
+# > All sessions are named after items in the testplan, with "_verify" suffixed to their names.
+# - ahb_if*
+# - axi_adapter*
+# - axi_adapter_id_filter*
+# - bus_rx_flow*
+# - bus_tx*
+# - bus_tx_flow*
+# - hci_queues_ahb*
+# - hci_queues_axi*
+# - i2c*
+# - i2c_controller_fsm*
+# - i2c_standby_controller*
+# - flow_standby_i2c*
+# - i2c_target_fsm*
+# - i3c_ahb*
+# - i3c_axi*
+# - ccc*
+# - ctrl_bus_timers*
+# - ctrl_bus_monitor*
+# - ctrl_i3c_bus_monitor*
+# - ctrl_edge_detector*
+# - width_converter_Nto8*
+# - width_converter_8toN*
+# - recovery_pec*
+
+"""
+
 import os
 import random
 import time

--- a/verification/cocotb/noxfile.py
+++ b/verification/cocotb/noxfile.py
@@ -60,6 +60,7 @@ def _verify(session, test_group, test_type, test_name, coverage=None, simulator=
                     [
                         "+verilator+rand+reset+2",
                         f"+verilator+seed+{seed}",
+                        "--trace",
                     ]
                 )
             if coverage:

--- a/verification/cocotb/vcs.tcl
+++ b/verification/cocotb/vcs.tcl
@@ -1,0 +1,3 @@
+fsdbDumpfile dump.fsdb
+fsdbDumpvars 0 +all
+run

--- a/verification/uvm_i3c/dv_i3c/i3c_driver.sv
+++ b/verification/uvm_i3c/dv_i3c/i3c_driver.sv
@@ -16,7 +16,7 @@ class i3c_driver extends uvm_driver#(.REQ(i3c_seq_item), .RSP(i3c_seq_item));
   bit host_scl_force_high = 0;
   bit host_scl_force_low = 0;
   i3c_drv_phase_e bus_state;
-  bit stop, rstart;
+  bit stop_b, rstart;
 
   virtual task reset_signals();
     forever begin
@@ -45,7 +45,7 @@ class i3c_driver extends uvm_driver#(.REQ(i3c_seq_item), .RSP(i3c_seq_item));
     forever begin
       if (cfg.if_mode == Device) release_bus();
       // driver drives bus per mode
-      stop = 0;
+      stop_b = 0;
       rstart = 0;
       rsp = null;
       fork
@@ -60,8 +60,8 @@ class i3c_driver extends uvm_driver#(.REQ(i3c_seq_item), .RSP(i3c_seq_item));
               // Device must always react to Stop/RStart conditions
               if (cfg.if_mode == Device) begin
                 wait(req != null);
-                if (req.i3c) cfg.vif.wait_for_i3c_host_stop_or_rstart(cfg.tc.i3c_tc, rstart, stop);
-                else cfg.vif.wait_for_i2c_host_stop_or_rstart(cfg.tc.i2c_tc, rstart, stop);
+                if (req.i3c) cfg.vif.wait_for_i3c_host_stop_or_rstart(cfg.tc.i3c_tc, rstart, stop_b);
+                else cfg.vif.wait_for_i2c_host_stop_or_rstart(cfg.tc.i2c_tc, rstart, stop_b);
               end
               else wait(0);
             end
@@ -81,7 +81,7 @@ class i3c_driver extends uvm_driver#(.REQ(i3c_seq_item), .RSP(i3c_seq_item));
           disable fork;
         end: iso_fork
       join
-      if (cfg.if_mode == Device && stop) begin
+      if (cfg.if_mode == Device && stop_b) begin
         `uvm_info(get_full_name(), "Device got Stop", UVM_HIGH)
         bus_state = DrvIdle;
         rsp.end_with_rstart = 0;
@@ -622,8 +622,7 @@ class i3c_driver extends uvm_driver#(.REQ(i3c_seq_item), .RSP(i3c_seq_item));
             `uvm_info(get_full_name(), $sformatf("Device sampled data[%0d]=%d, T_bit=%b",
                 i, rsp.data[i], rsp.T_bit[i]), UVM_MEDIUM)
             if((^data)^t_bit == 0) begin
-              `uvm_warning(get_full_name(), $sformatf("Device sampled data is incorrect!",
-                  i, rsp.data[i], rsp.T_bit[i]))
+              `uvm_warning(get_full_name(), "Device sampled data is incorrect!")
               break;
             end
           end

--- a/verification/uvm_i3c/noxfile.py
+++ b/verification/uvm_i3c/noxfile.py
@@ -1,4 +1,22 @@
 # SPDX-License-Identifier: Apache-2.0
+"""i3c_core and I3C Agent Unit Test Suites.
+
+# TODO i3c_core - currently unimplemented.
+# TODO Coverage Collection
+
+# tags
+# - i3c_vip_uvm_tests
+# - i3c_vip_uvm_debug_tests
+# - i3c_core_uvm_tests
+# - i3c_core_uvm_debug_tests
+#
+# sessions
+# - i3c_verify_uvm*
+# - i3c_monitor*
+# - i3c_driver*
+# - i3c_core_verify_uvm*
+
+"""
 
 import logging
 import os
@@ -66,7 +84,18 @@ def verify_uvm(
     if isUVMSimFailure(resultsFile=log_file):
         raise Exception("SimFailure: UVM failed. See test logs for more information.")
 
+################################################################################
+#
+# I3C_Agent
+#
 
+"""I3C Agent unit test suite.
+
+This suite of tests are used to check the operation of the I3C Agent in dv_i3c/.
+
+UVM_TESTNAME=i3c_sequence_test
+UVM_VSEQ_TEST=<param>
+"""
 @nox.session(tags=["i3c_vip_uvm_tests"])
 @nox.parametrize("simulator", [SIMULATOR])
 @nox.parametrize(
@@ -97,6 +126,13 @@ def i3c_verify_uvm(session, simulator, uvm_vseq_test, coverage):
     )
 
 
+"""I3C Agent unit test suite which takes bus stimulus from input .csv files.
+
+This suite of tests are used to check the operation of the I3C Agent in dv_i3c/.
+
+UVM_TESTNAME=i3c_sequence_test
+UVM_VSEQ_TEST=direct_vseq
+"""
 @nox.session(tags=["i3c_vip_uvm_debug_tests"])
 @nox.parametrize("simulator", [SIMULATOR])
 @nox.parametrize(
@@ -125,6 +161,13 @@ def i3c_monitor(session, simulator, extra_make_args, coverage):
     )
 
 
+"""I3C Agent unit test suite in tb_driver.sv
+
+This suite of tests are used to check the operation of the I3C Agent in dv_i3c/.
+
+UVM_TESTNAME=i3c_sequence_test
+UVM_VSEQ_TEST=direct_vseq
+"""
 @nox.session(tags=["i3c_vip_uvm_debug_tests"])
 @nox.parametrize("simulator", [SIMULATOR])
 @nox.parametrize("coverage", coverageTypes)
@@ -141,6 +184,18 @@ def i3c_driver(session, simulator, coverage):
         coverage=coverage,
     )
 
+################################################################################
+#
+# I3C_core
+#
+
+"""I3C_core test suite.
+
+# TODO INCOMPLETE.
+
+UVM_TESTNAME=i3c_core_test
+UVM_VSEQ_TEST=<param> (currently fixed to direct_vseq?)
+"""
 @nox.session(tags=["i3c_core_uvm_tests"])
 @nox.parametrize("simulator", [SIMULATOR])
 @nox.parametrize(
@@ -164,6 +219,13 @@ def i3c_core_verify_uvm(session, simulator, uvm_i3c_core_vseq_test, coverage):
     )
 
 
+"""I3C_core test suite.
+
+# TODO INCOMPLETE.
+
+UVM_TESTNAME=i3c_sequence_test
+UVM_VSEQ_TEST=direct_vseq
+"""
 @nox.session(tags=["i3c_core_uvm_debug_tests"])
 @nox.parametrize("simulator", [SIMULATOR])
 @nox.parametrize("coverage", coverageTypes)


### PR DESCRIPTION
Some highlights
- VCS now dumps .fsdb files by default, suitable for Verdi
- Verilator now dumps .fst files by default, a much better format than .vcd
- Documentation in `verification/README.md` now much improved for how to get started running Cocotb tests
- Python dependencies now additionally specified in a pyproject.toml file, suitable for modern tools such as UV.
- A Nix development environment is provided to accelerate repeatable provisioning of all FOSS dependencies