### PR TITLE
Add proper control of SDA drive mode

### DIFF
--- a/src/ctrl/bus_tx_flow.sv
+++ b/src/ctrl/bus_tx_flow.sv
@@ -1,18 +1,21 @@
 /*
-SPDX-License-Identifier: Apache-2.0
+  SPDX-License-Identifier: Apache-2.0
 
-This module controls the low-level aspects of the SDA transmit data flow on the I3C bus. It drives
-the both the data value and the drive mode (OpenDrain or PushPull) of the SDA pad.
-Note: No logic apart from static and guaranteed glitch-free muxing must be inserted between this
-      module and the physical SDA pad!
+  This module controls the low-level aspects of the SDA transmit data flow on the I3C bus. It drives
+  the both the data value and the drive mode (OpenDrain or PushPull) of the SDA pad.
+  Note: No logic apart from static and guaranteed glitch-free muxing must be inserted between this
+        module and the physical SDA pad!
 
-External modules can send following request types to drive the bus:
-- Send data byte,
-- Initiate an IBI with address as byte payload
-- Send Tbit/(N)ACK.
+  External modules can send following request types to drive the bus:
+  - Send raw data bits, including regular ACK/NACK,
+  - Send raw data bytes
+  - Initiate an IBI with address as byte payload
+  - Send an ACK following a write request by the contoller which requires special handoff
+  - Send TbitAbort in a private read, requiring half-bit drive mode change
+  - Send TbitContinue in a private read, requiring special checks for controller-side abort
 
-Requests are made through the tx_req_i struct port which encapsulates all required information.
-Feedback is provided through tx_rsp_o, including any error states.
+  Requests are made through the tx_req_i struct port which encapsulates all required information.
+  Feedback is provided through tx_rsp_o, including any error states.
 */
 
 module bus_tx_flow import i3c_pkg::*; (
@@ -20,10 +23,7 @@ module bus_tx_flow import i3c_pkg::*; (
   input  logic rst_ni,
 
   // Input I3C Bus events
-  input  logic scl_negedge_i,
-  input  logic scl_posedge_i,
-  input  logic scl_stable_low_i,
-  input  logic sda_value_i,
+  input  bus_state_t bus_i,
 
   // Tx request in
   input  bus_tx_req_t tx_req_i,
@@ -57,7 +57,8 @@ module bus_tx_flow import i3c_pkg::*; (
     DriveByte,
     NextTaskDecision,
     WaitNegEdge,
-    WaitPosEdge
+    WaitPosEdge,
+    TReadContSpecial
   } tx_state_e;
 
   tx_state_e state_d, state_q;
@@ -65,46 +66,59 @@ module bus_tx_flow import i3c_pkg::*; (
   // Common logic whenever a transfer gets started, including back-to-back transfers
   function automatic tx_state_e start_transfer(
     input  bus_tx_req_t bus_tx_req,
-    output i3c_byte_t   req_value_d,
-    output i3c_drive_e  drive_mode_d,
-    output logic        bit_counter_en
+    output i3c_byte_t   req_value,
+    output i3c_drive_e  drive_mode,
+    output logic        counter_en
   );
+
+    // Unconditional default values to keep Lint happy
+    req_value  = '1;
+    drive_mode = OpenDrain;
+    counter_en = 1'b0;
+
+    // Decide on value and drive mode following SCL negedge
     case (bus_tx_req.req_type)
       RawByte: begin
-        req_value_d    = bus_tx_req.data;
-        drive_mode_d   = bus_tx_req.drive_type;
-        // Enable bit counter and work on full byte in DriveByte
-        bit_counter_en = 1'b1;
-        return DriveByte;
+        req_value    = bus_tx_req.data;
+        drive_mode   = bus_tx_req.drive_type;
       end
       RawBit: begin
-        req_value_d    = {bus_tx_req.data[7], {7{1'b1}}};
-        drive_mode_d   = bus_tx_req.drive_type;
-        bit_counter_en = 1'b0;
-        // Only one bit to send; wait for posedge
-        return WaitPosEdge;
+        req_value    = {bus_tx_req.data[7], {7{1'b1}}};
+        drive_mode   = bus_tx_req.drive_type;
       end
       AckIbi: begin
-        req_value_d    = '1;
-        drive_mode_d   = OpenDrain;
-        bit_counter_en = 1'b0;
-        return WaitPosEdge;
+        req_value    = '1;
+        drive_mode   = OpenDrain;
+      end
+      AckRegular, AckWrite: begin
+        req_value[7] = 1'b0;
+        drive_mode   = OpenDrain;
+      end
+      TReadCont: begin
+        req_value[7] = 1'b1;
+        drive_mode   = PushPull;
+      end
+      TReadEnd: begin
+        req_value[7] = 1'b0;
+        drive_mode   = PushPull;
       end
       InitIbi: begin
-        req_value_d    = bus_tx_req.data; // Data is IBI address
-        drive_mode_d   = OpenDrain;
-        bit_counter_en = 1'b1;
-        return DriveByte;
+        req_value    = bus_tx_req.data; // Data is IBI address
+        drive_mode   = OpenDrain;
       end
-      default: begin
-        // TODO
-        req_value_d    = '0;
-        drive_mode_d   = OpenDrain;
-        bit_counter_en = 1'b0;
-        return WaitPosEdge;
-      end
-
+      default: ;
     endcase
+
+    // Most request types are only a single bit in length; completion can be signalled at the next
+    // SCL rising edge.
+    if (bus_tx_req.req_type inside {RawByte, InitIbi}) begin
+      // Enable bit counter and work on full byte in DriveByte
+      counter_en = 1'b1;
+      return DriveByte;
+    end else begin
+      counter_en = 1'b0;
+      return WaitPosEdge;
+    end
 
   endfunction : start_transfer
 
@@ -153,7 +167,7 @@ module bus_tx_flow import i3c_pkg::*; (
           // non-IBI frames/transfers.
           // Since no clocking event happens between these two phases, we cannot make any state
           // transition and have to handle both in the same state.
-          if (scl_negedge_i || scl_stable_low_i) begin
+          if (bus_i.scl.neg_edge || bus_i.scl.stable_low) begin
             state_d = start_transfer(tx_req_i, req_value_d, drive_mode_d, bit_counter_en);
           end else begin
             state_d = WaitNegEdge;
@@ -161,7 +175,7 @@ module bus_tx_flow import i3c_pkg::*; (
         end
       end
       WaitNegEdge: begin
-        if (scl_negedge_i) begin
+        if (bus_i.scl.neg_edge) begin
           state_d = start_transfer(tx_req_i, req_value_d, drive_mode_d, bit_counter_en);
         end
       end
@@ -169,7 +183,7 @@ module bus_tx_flow import i3c_pkg::*; (
         if (tx_req_i.req_valid) begin
           bit_counter_en = 1'b1;
           // Simply wait for next edge
-          if (scl_negedge_i) begin
+          if (bus_i.scl.neg_edge) begin
             tx_done = 1'b1;
             // Shift the register which drives sda left to get next bit
             req_value_d = {req_value_q[6:0], 1'b1};
@@ -188,19 +202,61 @@ module bus_tx_flow import i3c_pkg::*; (
       end
       WaitPosEdge: begin
         // Wait for posedge to avoid following rx requests sampling this bit as well
-        if (scl_posedge_i) begin
-          bus_tx_done = 1'b1;
-          // Take over to drive SDA low in PP in case of an IBI Ack by the controller
-          // Specified in Section 5.1.2.3.2
-          if ((tx_req_i.req_type == AckIbi) && (sda_value_i == 1'b0)) begin
-            req_value_d[7] = 1'b0;
-            drive_mode_d = PushPull;
+        if (bus_i.scl.pos_edge) begin
+          // Handle all cases that require half-bit changes to SDA data and drive mode
+          case (tx_req_i.req_type)
+            AckWrite: begin
+              // Release SDA in the middle of ACK to high-Z; Controller takes over driving
+              // Specified in Section 5.1.2.3.1
+              req_value_d[7] = 1'b1;
+            end
+            AckIbi: begin
+              // Take over to drive SDA low in PP in case of an IBI Ack by the controller
+              // Specified in Section 5.1.2.3.2
+              if (bus_i.sda.value == 1'b0) begin
+                req_value_d[7] = 1'b0;
+                drive_mode_d = PushPull;
+              end
+            end
+            TReadEnd, TReadCont: begin
+              // Both cases require to release SDA to high-Z; in case of TReadEnd, the Controller
+              // will take over driving SDA low. In case of TReadCont, the Controller may drive SDA
+              // low after the rising edge to signal a read abort to us.
+              // Specified in Section 5.1.2.3.4
+              req_value_d[7] = 1'b1;
+              drive_mode_d = OpenDrain;
+            end
+            default: ;
+          endcase
+          // In most cases the transaction is completed; flag this to the requester. For TReadCont,
+          // we however must wait until the next SCL negedge, as the Controller may sent an Rs
+          // between then and the SCL posedge that just happened to deny our request to continue.
+          if (tx_req_i.req_type == TReadCont) begin
+            state_d = TReadContSpecial;
+          end else begin
+            bus_tx_done = 1'b1;
+            state_d = NextTaskDecision;
           end
-          state_d = NextTaskDecision;
+        end
+      end
+      TReadContSpecial: begin
+        // If we see an SDA negedge before the next SCL negedge, the Controller aborted the read
+        if (bus_i.sda.neg_edge) begin
+          state_d = Idle;
+        end
+        // Controller has accepted to continue and the requester has provided the respective data
+        // already as part of the TReadCont request such that we are able to clock out the MSB
+        // on this very negedge. Continue with the remaining 7 bits in DriveByte.
+        if (bus_i.scl.neg_edge) begin
+          bus_tx_done    = 1'b1;
+          bit_counter_en = 1'b1;
+          drive_mode_d = PushPull;
+          req_value_d  = tx_req_i.data;
+          state_d      = DriveByte;
         end
       end
       NextTaskDecision: begin
-        if (scl_negedge_i) begin
+        if (bus_i.scl.neg_edge) begin
           if (tx_req_i.req_valid) begin
             // Back-to-back transfer pending, immediately service it
             state_d = start_transfer(tx_req_i, req_value_d, drive_mode_d, bit_counter_en);

--- a/src/ctrl/bus_tx_flow.sv
+++ b/src/ctrl/bus_tx_flow.sv
@@ -23,6 +23,7 @@ module bus_tx_flow import i3c_pkg::*; (
   input  logic scl_negedge_i,
   input  logic scl_posedge_i,
   input  logic scl_stable_low_i,
+  input  logic sda_value_i,
 
   // Tx request in
   input  bus_tx_req_t tx_req_i,
@@ -81,6 +82,12 @@ module bus_tx_flow import i3c_pkg::*; (
         drive_mode_d   = bus_tx_req.drive_type;
         bit_counter_en = 1'b0;
         // Only one bit to send; wait for posedge
+        return WaitPosEdge;
+      end
+      AckIbi: begin
+        req_value_d    = '1;
+        drive_mode_d   = OpenDrain;
+        bit_counter_en = 1'b0;
         return WaitPosEdge;
       end
       InitIbi: begin
@@ -183,6 +190,12 @@ module bus_tx_flow import i3c_pkg::*; (
         // Wait for posedge to avoid following rx requests sampling this bit as well
         if (scl_posedge_i) begin
           bus_tx_done = 1'b1;
+          // Take over to drive SDA low in PP in case of an IBI Ack by the controller
+          // Specified in Section 5.1.2.3.2
+          if ((tx_req_i.req_type == AckIbi) && (sda_value_i == 1'b0)) begin
+            req_value_d[7] = 1'b0;
+            drive_mode_d = PushPull;
+          end
           state_d = NextTaskDecision;
         end
       end

--- a/src/ctrl/bus_tx_flow.sv
+++ b/src/ctrl/bus_tx_flow.sv
@@ -41,13 +41,15 @@ module bus_tx_flow import i3c_pkg::*; (
   logic       bit_counter_en;
   logic [3:0] bit_counter_q, bit_counter_d;
 
-  logic [2:0] reqs;
-  logic       req_any;
   i3c_byte_t  req_value_q, req_value_d;
+  i3c_drive_e drive_mode_q, drive_mode_d;
 
   logic tx_done;     // Indicates finished bit write
   logic bus_tx_done; // Feedback to requester that transfer is done
   logic req_error;
+
+  // TODO
+  assign req_error = 1'b0;
 
   typedef enum logic [2:0] {
     Idle,
@@ -62,29 +64,43 @@ module bus_tx_flow import i3c_pkg::*; (
   // Common logic whenever a transfer gets started, including back-to-back transfers
   function automatic tx_state_e start_transfer(
     input  bus_tx_req_t bus_tx_req,
-    output i3c_byte_t   req_value_out,
-    output logic        bit_counter_en_out
+    output i3c_byte_t   req_value_d,
+    output i3c_drive_e  drive_mode_d,
+    output logic        bit_counter_en
   );
-    req_value_out[7]   = bus_tx_req.data[7];
-    req_value_out[6:0] = bus_tx_req.req_bit ? '1 : bus_tx_req.data[6:0];
-    if (bus_tx_req.req_bit) begin
-      // Only one bit to send; wait for posedge
-      bit_counter_en_out = 1'b0;
-      return WaitPosEdge;
-    end else begin
-      // Enable bit counter and work on full byte in DriveByte
-      bit_counter_en_out = 1'b1;
-      return DriveByte;
-    end
+    case (bus_tx_req.req_type)
+      RawByte: begin
+        req_value_d    = bus_tx_req.data;
+        drive_mode_d   = bus_tx_req.drive_type;
+        // Enable bit counter and work on full byte in DriveByte
+        bit_counter_en = 1'b1;
+        return DriveByte;
+      end
+      RawBit: begin
+        req_value_d    = {bus_tx_req.data[7], {7{1'b1}}};
+        drive_mode_d   = bus_tx_req.drive_type;
+        bit_counter_en = 1'b0;
+        // Only one bit to send; wait for posedge
+        return WaitPosEdge;
+      end
+      InitIbi: begin
+        req_value_d    = bus_tx_req.data; // Data is IBI address
+        drive_mode_d   = OpenDrain;
+        bit_counter_en = 1'b1;
+        return DriveByte;
+      end
+      default: begin
+        // TODO
+        req_value_d    = '0;
+        drive_mode_d   = OpenDrain;
+        bit_counter_en = 1'b0;
+        return WaitPosEdge;
+      end
+
+    endcase
 
   endfunction : start_transfer
 
-  assign reqs    = {tx_req_i.req_byte, tx_req_i.req_bit, tx_req_i.req_ibi};
-  assign req_any = |reqs;
-  // Clever way to ensure that only one bit is HIGH
-  // Source: https://stackoverflow.com/a/11235598
-  // It might be optimized if we're sure there are only 2 requests at most
-  assign req_error = |(reqs & (reqs - 1));
 
   // Bit counter used for byte transfers
   always_comb begin
@@ -101,6 +117,7 @@ module bus_tx_flow import i3c_pkg::*; (
 
   // SDA is simply the MSB of the data shift register. No further logic or muxing.
   assign sda_o = req_value_q[7];
+  assign sel_od_pp_o = drive_mode_q;
 
   always_comb begin : tx_fsm
     bit_counter_en = 1'b0;
@@ -108,17 +125,19 @@ module bus_tx_flow import i3c_pkg::*; (
     tx_done     = 1'b0;
     bus_tx_done = 1'b0;
 
-    req_value_d = req_value_q;
-    state_d     = state_q;
+    req_value_d  = req_value_q;
+    drive_mode_d = drive_mode_q;
+    state_d      = state_q;
     unique case (state_q)
       Idle: begin
-        if (req_any) begin
-          if (tx_req_i.req_ibi) begin
+        if (tx_req_i.req_valid) begin
+          if (tx_req_i.req_type == InitIbi) begin
             // Drive 0 in OD on SDA and wait until the controller gives us a negedge on SCL
             // Note: The controller also could've started to drive SDA below and it will take the
             // delay through the SDA synchronizer for us to detect this, however, this does not
             // present any timing or driving conflict issue.
             req_value_d[7] = 1'b0;
+            drive_mode_d   = OpenDrain;
           end
           // For IBI, this state is 2-in-1: First, SDA is driven low above to initiate the IBI by
           // generating a "target-side start condition". Next, on the SCL negedge that follows,
@@ -128,7 +147,7 @@ module bus_tx_flow import i3c_pkg::*; (
           // Since no clocking event happens between these two phases, we cannot make any state
           // transition and have to handle both in the same state.
           if (scl_negedge_i || scl_stable_low_i) begin
-            state_d = start_transfer(tx_req_i, req_value_d, bit_counter_en);
+            state_d = start_transfer(tx_req_i, req_value_d, drive_mode_d, bit_counter_en);
           end else begin
             state_d = WaitNegEdge;
           end
@@ -136,11 +155,11 @@ module bus_tx_flow import i3c_pkg::*; (
       end
       WaitNegEdge: begin
         if (scl_negedge_i) begin
-          state_d = start_transfer(tx_req_i, req_value_d, bit_counter_en);
+          state_d = start_transfer(tx_req_i, req_value_d, drive_mode_d, bit_counter_en);
         end
       end
       DriveByte: begin
-        if (tx_req_i.req_byte || tx_req_i.req_ibi) begin
+        if (tx_req_i.req_valid) begin
           bit_counter_en = 1'b1;
           // Simply wait for next edge
           if (scl_negedge_i) begin
@@ -155,7 +174,8 @@ module bus_tx_flow import i3c_pkg::*; (
         end else begin
           // Requester cancelled the transaction, e.g., a bus stop condition has occurred or
           // arbitration was lost during the address phase.
-          req_value_d = '1;
+          drive_mode_d = OpenDrain;
+          req_value_d  = '1;
           state_d = Idle;
         end
       end
@@ -168,12 +188,13 @@ module bus_tx_flow import i3c_pkg::*; (
       end
       NextTaskDecision: begin
         if (scl_negedge_i) begin
-          if (req_any) begin
+          if (tx_req_i.req_valid) begin
             // Back-to-back transfer pending, immediately service it
-            state_d = start_transfer(tx_req_i, req_value_d, bit_counter_en);
+            state_d = start_transfer(tx_req_i, req_value_d, drive_mode_d, bit_counter_en);
           end else begin
-            // Reset sda_o to OpenDrain-high & back to Idle
-            req_value_d = '1;
+            // Reset sda_o to High-Z & back to Idle
+            drive_mode_d = OpenDrain;
+            req_value_d  = '1;
             state_d = Idle;
           end
         end
@@ -193,17 +214,17 @@ module bus_tx_flow import i3c_pkg::*; (
     done:  bus_tx_done
   };
 
-  assign sel_od_pp_o = tx_req_i.drive_type; // TODO FIXME - Feedthrough for now
-
   // Sequential process for all flops
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (~rst_ni) begin
       bit_counter_q <= '0;
       req_value_q   <= '1;
+      drive_mode_q  <= OpenDrain;
       state_q       <= Idle;
     end else begin
       bit_counter_q <= bit_counter_d;
       req_value_q   <= req_value_d;
+      drive_mode_q  <= drive_mode_d;
       state_q       <= state_d;
     end
   end

--- a/src/ctrl/bus_tx_flow.sv
+++ b/src/ctrl/bus_tx_flow.sv
@@ -34,6 +34,9 @@ module bus_tx_flow import i3c_pkg::*; (
   // Open Drain / Push Pull
   output logic sel_od_pp_o,
 
+  // Output enable for SDA pad
+  output logic sda_oe_o,
+
   // Output I3C SDA bus line
   output logic sda_o
 );
@@ -42,14 +45,16 @@ module bus_tx_flow import i3c_pkg::*; (
   logic       bit_counter_en;
   logic [3:0] bit_counter_q, bit_counter_d;
 
+  // Registers for all critical signals directly connected to the SDA pad
   i3c_byte_t  req_value_q, req_value_d;
   i3c_drive_e drive_mode_q, drive_mode_d;
+  logic       sda_oe_q, sda_oe_d;
 
   logic tx_done;     // Indicates finished bit write
   logic bus_tx_done; // Feedback to requester that transfer is done
   logic req_error;
 
-  // TODO
+  // TODO Can probably be removed
   assign req_error = 1'b0;
 
   typedef enum logic [2:0] {
@@ -62,6 +67,24 @@ module bus_tx_flow import i3c_pkg::*; (
   } tx_state_e;
 
   tx_state_e state_d, state_q;
+
+  // SDA is simply the MSB of the data shift register. No further logic or muxing.
+  // Similar for pad drive mode and output enable.
+  assign sda_o = req_value_q[7];
+  assign sel_od_pp_o = drive_mode_q;
+  assign sda_oe_o = sda_oe_q;
+
+  /*
+    Truth table for sda_oe.
+
+    sel_od_pp_o | sda_o  || sda_oe_o | IO state
+    ------------+--------++----------+-----------
+         0      |   0    ||    1     |    0
+         0      |   1    ||    0     |   hi-z
+         1      |   0    ||    1     |    0
+         1      |   1    ||    1     |    1
+  */
+  assign sda_oe_d = drive_mode_d || !req_value_d[7];
 
   // Common logic whenever a transfer gets started, including back-to-back transfers
   function automatic tx_state_e start_transfer(
@@ -122,7 +145,6 @@ module bus_tx_flow import i3c_pkg::*; (
 
   endfunction : start_transfer
 
-
   // Bit counter used for byte transfers
   always_comb begin
     bit_counter_d = bit_counter_q;
@@ -136,10 +158,7 @@ module bus_tx_flow import i3c_pkg::*; (
     end
   end
 
-  // SDA is simply the MSB of the data shift register. No further logic or muxing.
-  assign sda_o = req_value_q[7];
-  assign sel_od_pp_o = drive_mode_q;
-
+  // Main FSM which handles all low-level bus details in terms of transmitting
   always_comb begin : tx_fsm
     bit_counter_en = 1'b0;
 
@@ -289,11 +308,13 @@ module bus_tx_flow import i3c_pkg::*; (
       bit_counter_q <= '0;
       req_value_q   <= '1;
       drive_mode_q  <= OpenDrain;
+      sda_oe_q      <= 1'b0;
       state_q       <= Idle;
     end else begin
       bit_counter_q <= bit_counter_d;
       req_value_q   <= req_value_d;
       drive_mode_q  <= drive_mode_d;
+      sda_oe_q      <= sda_oe_d;
       state_q       <= state_d;
     end
   end

--- a/src/ctrl/ccc.sv
+++ b/src/ctrl/ccc.sv
@@ -415,7 +415,6 @@ module ccc
   bus_tx_req_t tx_req_entdaa;
   bus_rx_req_t rx_req_ccc;
   bus_rx_req_t rx_req_entdaa;
-  i3c_byte_t   bus_tx_data;
 
   // ---------------------------------------------------------------------------
   // ENTDAA Handling (Special CCC with its own sub-FSM)
@@ -820,19 +819,9 @@ module ccc
   end
 
   // ===========================================================================
-  // BUS TX/RX REQUEST GENERATION
+  // BUS RX REQUEST GENERATION
   // ===========================================================================
-
-  // TX Request: Bit/byte requests and drive type derived from state
-  assign tx_req_ccc = '{
-    drive_type: (state_q inside {TxData, TxDataTbit}) ? PushPull : OpenDrain,
-    req_byte:   (state_q == TxData),
-    req_bit:    (state_q inside {TxTargetAddrAck, TxDataTbit}),
-    req_ibi:    1'b0,
-    data:       bus_tx_data
-  };
-
-  // RX Request: Request bytes or bits based on current state
+  // Request bytes or bits based on current state
   assign rx_req_ccc = '{
     req_byte: (state_q inside {RxDefByte, RxTargetAddr}) ||
               (state_q inside {RxDefByteOrBusCond, WaitDirectRstart, RxData} && !bus_rstart_det_i),
@@ -846,8 +835,14 @@ module ccc
     done_fsm_o = 1'b0;
     next_ccc_o = 1'b0;
 
-    bus_tx_data = '0;
-    
+    // Default, safe tx request values
+    tx_req_ccc = '{
+      req_valid:  1'b0,
+      req_type:   RawBit,
+      drive_type: OpenDrain,
+      data:       '1
+    };
+
     // Defining byte capture/clear control
     capture_defining_byte = 1'b0;
     clear_defining_byte   = 1'b0;
@@ -1043,7 +1038,9 @@ module ccc
       //   - ACKed: Proceed to appropriate data phase (GET → TxData, SET → RxData)
       //   - NACKed: Wait for bus condition (not addressed, unsupported cmd)
       TxTargetAddrAck: begin
-        bus_tx_data[7] = ~addr_ack;  // Send ACK (0) or NACK (1)
+        tx_req_ccc.req_valid = 1'b1;
+        tx_req_ccc.req_type  = RawBit;
+        tx_req_ccc.data[7]   = ~addr_ack;  // Send ACK (0) or NACK (1)
 
         if (bus_tx_rsp_i.done) begin
           target_addr_ack_done = 1'b1;
@@ -1121,14 +1118,20 @@ module ccc
       end
       
       TxData: begin
-        bus_tx_data = tx_data;
+        tx_req_ccc.drive_type = PushPull;
+        tx_req_ccc.req_valid  = 1'b1;
+        tx_req_ccc.req_type   = RawByte;
+        tx_req_ccc.data       = tx_data;
 
         if (bus_tx_rsp_i.done) state_d = TxDataTbit;
       end
       
       TxDataTbit: begin
-        // T-bit value: 0 = end of data, 1 = more data available
-        bus_tx_data[7] = ~tx_data_last_byte;
+        tx_req_ccc.drive_type = PushPull;
+        tx_req_ccc.req_valid  = 1'b1;
+        tx_req_ccc.req_type   = RawBit;
+        // TBit: 0 = end of data, 1 = more data available
+        tx_req_ccc.data[7]    = ~tx_data_last_byte;
 
         if (bus_rstart_det_i) begin
           // Controller abort: Target sent T=1 but Controller issued Sr

--- a/src/ctrl/ccc.sv
+++ b/src/ctrl/ccc.sv
@@ -1123,23 +1123,24 @@ module ccc
         tx_req_ccc.req_type   = RawByte;
         tx_req_ccc.data       = tx_data;
 
-        if (bus_tx_rsp_i.done) state_d = TxDataTbit;
+        if (bus_tx_rsp_i.done) begin
+          // Increment byte counter as we need the next data byte for the Tbit request
+          inc_tx_byte_num = 1'b1;
+          state_d = TxDataTbit;
+        end
       end
       
       TxDataTbit: begin
-        tx_req_ccc.drive_type = PushPull;
-        tx_req_ccc.req_valid  = 1'b1;
-        tx_req_ccc.req_type   = RawBit;
         // TBit: 0 = end of data, 1 = more data available
-        tx_req_ccc.data[7]    = ~tx_data_last_byte;
+        tx_req_ccc.req_valid  = 1'b1;
+        tx_req_ccc.req_type   = tx_data_last_byte ? TReadEnd : TReadCont;
+        tx_req_ccc.data       = tx_data;
 
         if (bus_rstart_det_i) begin
           // Controller abort: Target sent T=1 but Controller issued Sr
           state_d = RxTargetAddr;
           set_tx_data_complete = 1'b1;
         end else if (bus_tx_rsp_i.done) begin
-          inc_tx_byte_num = 1'b1;
-
           if (tx_data_last_byte) begin
             // Target complete: Target sent T=0, wait for Sr or STOP
             set_tx_data_complete = 1'b1;
@@ -1221,8 +1222,8 @@ module ccc
     end
   end
 
-  // Last byte when we've reached (tx_byte_total - 1)
-  assign tx_data_last_byte = (tx_byte_num == tx_byte_total - 1);
+  // Last byte when we've reached tx_byte_total
+  assign tx_data_last_byte = (tx_byte_num == tx_byte_total);
 
   // TX complete tracking: set by FSM when last T-bit completes normally
   always_ff @(posedge clk_i or negedge rst_ni) begin : proc_tx_data_complete

--- a/src/ctrl/ccc_entdaa.sv
+++ b/src/ctrl/ccc_entdaa.sv
@@ -383,9 +383,8 @@ module ccc_entdaa
   // TX: Open-drain for all ENTDAA transmissions (ACK/NACK/ID bits)
   assign bus_tx_req_o = '{
     drive_type: OpenDrain,
-    req_byte:   1'b0,
-    req_bit:    (state_q inside {AckRsvdByte, SendNack, SendIDBit, AckAddr}),
-    req_ibi:    1'b0,
+    req_valid:  (state_q inside {AckRsvdByte, SendNack, SendIDBit, AckAddr}),
+    req_type:   RawBit,
     data:       bus_tx_data
   };
 

--- a/src/ctrl/controller.sv
+++ b/src/ctrl/controller.sv
@@ -67,6 +67,7 @@ module controller
     input  logic sda_i,
     output logic scl_o,
     output logic sda_o,
+    output logic sda_oe_o,
     output logic sel_od_pp_o,
     input logic arbitration_lost_i,
 
@@ -271,6 +272,8 @@ module controller
     output logic in_hdr_mode_o
 );
 
+  localparam int unsigned RecoveryMode = 'h3;
+
   logic phy_en;
   logic [1:0] phy_mux_select;
   logic i2c_active_en;
@@ -339,25 +342,30 @@ module controller
   bus_state_t ctrl_bus_i[4];
   logic ctrl_scl_o[4];
   logic ctrl_sda_o[4];
+  logic ctrl_sda_oe_o[4];
   logic ctrl_sel_od_pp_i[4];
 
-  localparam int unsigned RecoveryMode = 'h3;
-  always_comb begin : mux_4_to_1
-    scl_o = ctrl_scl_o[phy_mux_select];
-    sda_o = ctrl_sda_o[phy_mux_select];
-    sel_od_pp_o = ctrl_sel_od_pp_i[phy_mux_select];
+  assign ctrl_sda_oe_o[0] = 1'b0;
+  assign ctrl_sda_oe_o[1] = 1'b0;
 
+  // NOTE: For now, the I3C standby (target) device is hard-wired onto the bus for risk mitigation
+  assign scl_o = ctrl_scl_o[3];
+  assign sda_o = ctrl_sda_o[3];
+  assign sda_oe_o    = ctrl_sda_oe_o[3];
+  assign sel_od_pp_o = ctrl_sel_od_pp_i[3];
+
+  assign ctrl_bus_i[3] = bus;
+
+  // Tieoff of all other devices
+  always_comb begin : mux_tieoff
     // Default
-    for (int i=0; i<4; i++) begin
-        ctrl_bus_i[i] = '0;
-        ctrl_bus_i[i].sda.value = '1;
-        ctrl_bus_i[i].scl.value = '1;
-        ctrl_bus_i[i].sda.stable_high = '1;
-        ctrl_bus_i[i].scl.stable_high = '1;
+    for (int i=0; i<3; i++) begin
+      ctrl_bus_i[i] = '0;
+      ctrl_bus_i[i].sda.value = 1'b1;
+      ctrl_bus_i[i].scl.value = 1'b1;
+      ctrl_bus_i[i].sda.stable_high = 1'b1;
+      ctrl_bus_i[i].scl.stable_high = 1'b1;
     end
-
-    // Muxed
-    ctrl_bus_i[phy_mux_select] = bus;
   end
 
   configuration xconfiguration (
@@ -496,6 +504,7 @@ module controller
       .ctrl_bus_i(ctrl_bus_i[2:3]),
       .ctrl_scl_o(ctrl_scl_o[2:3]),
       .ctrl_sda_o(ctrl_sda_o[2:3]),
+      .ctrl_sda_oe_o(ctrl_sda_oe_o[2:3]),
       .phy_sel_od_pp_o(ctrl_sel_od_pp_i[2:3]),
       .arbitration_lost_i(arbitration_lost_i),
       .rx_desc_queue_full_i(tti_rx_desc_queue_full_i),

--- a/src/ctrl/controller_standby.sv
+++ b/src/ctrl/controller_standby.sv
@@ -34,6 +34,7 @@ module controller_standby
     input bus_state_t ctrl_bus_i[2],
     output logic ctrl_scl_o[2],
     output logic ctrl_sda_o[2],
+    output logic ctrl_sda_oe_o[2],
     output logic phy_sel_od_pp_o[2],
     input logic arbitration_lost_i,
 
@@ -327,6 +328,8 @@ module controller_standby
     .source_data_o(tx_queue_rdata_int)
   );
 
+  assign ctrl_sda_oe_o[0] = 1'b0;
+
   controller_standby_i2c #(
       .TtiRxDescDataWidth(TtiRxDescDataWidth),
       .TtiTxDescDataWidth(TtiTxDescDataWidth),
@@ -421,6 +424,7 @@ module controller_standby
       .ctrl_bus_i(ctrl_bus_i[1]),
       .ctrl_scl_o(ctrl_scl_o[1]),
       .ctrl_sda_o(ctrl_sda_o[1]),
+      .ctrl_sda_oe_o(ctrl_sda_oe_o[1]),
       .arbitration_lost_i(arbitration_lost_i),
       .phy_sel_od_pp_o(phy_sel_od_pp_o[1]),
       .rx_desc_queue_wvalid_o(i3c_rx_desc_queue_wvalid_o),

--- a/src/ctrl/controller_standby_i3c.sv
+++ b/src/ctrl/controller_standby_i3c.sv
@@ -23,6 +23,7 @@ module controller_standby_i3c
     input  bus_state_t ctrl_bus_i,
     output logic       ctrl_scl_o,
     output logic       ctrl_sda_o,
+    output logic       ctrl_sda_oe_o,
     output logic       phy_sel_od_pp_o,
     input  logic       arbitration_lost_i,
 
@@ -609,6 +610,7 @@ module controller_standby_i3c
     .tx_rsp_o(bus_tx_rsp),
 
     .sel_od_pp_o(phy_sel_od_pp_o),
+    .sda_oe_o   (ctrl_sda_oe_o),
     .sda_o      (ctrl_sda_o)
   );
 

--- a/src/ctrl/controller_standby_i3c.sv
+++ b/src/ctrl/controller_standby_i3c.sv
@@ -603,13 +603,10 @@ module controller_standby_i3c
     .clk_i,
     .rst_ni,
 
+    .bus_i(ctrl_bus_i),
+
     .tx_req_i(bus_tx_req),
     .tx_rsp_o(bus_tx_rsp),
-
-    .scl_negedge_i   (ctrl_bus_i.scl.neg_edge),
-    .scl_posedge_i   (ctrl_bus_i.scl.pos_edge),
-    .scl_stable_low_i(ctrl_bus_i.scl.stable_low),
-    .sda_value_i     (ctrl_bus_i.sda.value),
 
     .sel_od_pp_o(phy_sel_od_pp_o),
     .sda_o      (ctrl_sda_o)

--- a/src/ctrl/controller_standby_i3c.sv
+++ b/src/ctrl/controller_standby_i3c.sv
@@ -316,7 +316,7 @@ module controller_standby_i3c
   end
 
   always_comb begin
-    bus_tx_req = '{drive_type: OpenDrain, default: '0};
+    bus_tx_req = '{drive_type: OpenDrain, req_type: RawBit, default: '0};
     bus_rx_req = '{default: '0};
 
     bus_tx_rsp_fsm = '{default: '0};

--- a/src/ctrl/controller_standby_i3c.sv
+++ b/src/ctrl/controller_standby_i3c.sv
@@ -609,6 +609,7 @@ module controller_standby_i3c
     .scl_negedge_i   (ctrl_bus_i.scl.neg_edge),
     .scl_posedge_i   (ctrl_bus_i.scl.pos_edge),
     .scl_stable_low_i(ctrl_bus_i.scl.stable_low),
+    .sda_value_i     (ctrl_bus_i.sda.value),
 
     .sel_od_pp_o(phy_sel_od_pp_o),
     .sda_o      (ctrl_sda_o)

--- a/src/ctrl/descriptor_tx.sv
+++ b/src/ctrl/descriptor_tx.sv
@@ -11,117 +11,112 @@
   * Target FSM may respond with a bus error, which means that the current transaction
   should be aborted.
 */
-module descriptor_tx #(
-    parameter int unsigned TtiTxDescDataWidth = 32,
-    parameter int unsigned TtiTxDataWidth = 8,
-    parameter int unsigned TtiTxFifoDepthWidth = 16
+module descriptor_tx import i3c_pkg::*; #(
+  parameter int unsigned TtiTxDescDataWidth = 32,
+  parameter int unsigned TtiTxDataWidth = 8,
+  parameter int unsigned TtiTxFifoDepthWidth = 16
 ) (
-    input logic clk_i,
-    input logic rst_ni,
+  input  logic clk_i,
+  input  logic rst_ni,
 
-    // TTI: TX Descriptor
-    input logic tti_tx_desc_queue_rvalid_i,
-    output logic tti_tx_desc_queue_rready_o,
-    input logic [TtiTxDescDataWidth-1:0] tti_tx_desc_queue_rdata_i,
+  // TTI: TX Descriptor
+  input  logic                          tti_tx_desc_queue_rvalid_i,
+  output logic                          tti_tx_desc_queue_rready_o,
+  input  logic [TtiTxDescDataWidth-1:0] tti_tx_desc_queue_rdata_i,
 
-    // TTI: TX Data
-    input logic tti_tx_queue_rvalid_i,
-    input logic [TtiTxFifoDepthWidth-1:0] tti_tx_queue_depth_i,
-    output logic tti_tx_queue_rready_o,
-    input logic [TtiTxDataWidth-1:0] tti_tx_queue_rdata_i,
-    input  logic tti_tx_queue_empty_i,
-    output logic tx_queue_flush_o,
+  // TTI: TX Data
+  input  logic                           tti_tx_queue_rvalid_i,
+  output logic                           tti_tx_queue_rready_o,
+  input  logic      [TtiTxDataWidth-1:0] tti_tx_queue_rdata_i,
+  input  logic [TtiTxFifoDepthWidth-1:0] tti_tx_queue_depth_i,
+  input  logic                           tti_tx_queue_empty_i,
+  output logic                           tx_queue_flush_o,
 
-    // Interface to the target FSM
-    input logic tx_start_i,
-    input logic tx_abort_i,
-    output logic tx_desc_avail_o,
-    output logic [7:0] tx_byte_o,
-    output logic tx_byte_last_o,
-    output logic tx_byte_valid_o,
-    input logic tx_byte_ready_i,
-    output logic tx_end_o,
+  // Interface to the target FSM
+  output logic      tx_byte_valid_o,
+  input  logic      tx_byte_ready_i,
+  output i3c_byte_t tx_byte_o,
+  output logic      tx_byte_last_o,
+  input  logic      tx_start_i,
+  output logic      tx_end_o,
+  input  logic      tx_abort_i,
+  output logic      tx_desc_avail_o,
 
-    // recovery mode
-    input recovery_mode_enter_i
+  // recovery mode
+  input  logic recovery_mode_enter_i
 );
 
-  logic [31:0] tx_descriptor;
+  logic [TtiTxDescDataWidth-1:0] tx_descriptor;
+  logic [TtiTxDescDataWidth-1:0] data_len_words;
+
   logic [15:0] byte_counter;
   logic [15:0] data_len;
-  logic [TtiTxDescDataWidth-1:0] data_len_words;
+
   logic descriptor_valid;
   logic tx_start;
   logic tx_pending;
   logic tx_end;
   logic flush;
 
-  assign tti_tx_desc_queue_rready_o = ~descriptor_valid && tx_start_i &&
-                                      tti_tx_desc_queue_rvalid_i && !flush &&
-                                      !(tx_abort_i || recovery_mode_enter_i);
+  assign tti_tx_desc_queue_rready_o = tti_tx_desc_queue_rvalid_i && !descriptor_valid && tx_start_i
+                                      && !(flush || tx_abort_i || recovery_mode_enter_i);
 
   assign tx_desc_avail_o = tti_tx_desc_queue_rvalid_i;
 
   always_ff @(posedge clk_i or negedge rst_ni) begin : proc_
     if (!rst_ni) begin
+      tx_descriptor    <= '0;
       descriptor_valid <= '0;
-      tx_descriptor <= '0;
     end else begin
-      if (tx_end) descriptor_valid <= '0;
-      else if (tti_tx_desc_queue_rready_o) begin
-        tx_descriptor <= tti_tx_desc_queue_rdata_i;
-        descriptor_valid <= '1;
-      end
-      else if (tx_abort_i || recovery_mode_enter_i) begin
+      if (tx_end || tx_abort_i || recovery_mode_enter_i) begin
+        tx_descriptor    <= '0;
         descriptor_valid <= '0;
-        tx_descriptor <= '0;
+      end else if (tti_tx_desc_queue_rready_o) begin
+        tx_descriptor    <= tti_tx_desc_queue_rdata_i;
+        descriptor_valid <= 1'b1;
       end
     end
   end
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      flush <= '0;
+      flush <= 1'b0;
     end else begin
       if (!flush) begin
         if ((byte_counter != 16'h0) && (tx_abort_i || recovery_mode_enter_i)) begin
-            flush <= '1;
+          flush <= 1'b1;
         end
       end else begin
-        // Flush complete
-        if ((byte_counter inside {16'd1, 16'd0}) && tti_tx_queue_rvalid_i)
-            flush <= '0;
-        // No more data in the FIFO to complete the flush
-        if (!tti_tx_queue_rvalid_i && tti_tx_queue_empty_i)
-            flush <= '0;
-        // Last word from the FIFO is flushed
-        if (tx_queue_flush_o)
-            flush <= '0;
+        if (((byte_counter inside {16'd1, 16'd0}) && tti_tx_queue_rvalid_i) || // Flush complete
+            (!tti_tx_queue_rvalid_i && tti_tx_queue_empty_i) || // No more data in the FIFO to complete the flush
+            (tx_queue_flush_o)) begin                           // Last word from the FIFO is flushed
+          flush <= 1'b0;
+        end
       end
     end
   end
 
-  assign data_len = tx_descriptor[15:0];
+  assign data_len       = tx_descriptor[15:0];
   assign data_len_words = TtiTxDescDataWidth'(data_len >> 2);
   // Add 1 to depth, because there is one word in the Nto8 converter
-  assign tx_start = ~tx_pending && descriptor_valid &&
-                    (TtiTxDescDataWidth'(tti_tx_queue_depth_i+1'b1) >= data_len_words);
+  assign tx_start = !tx_pending && descriptor_valid &&
+                    (TtiTxDescDataWidth'(tti_tx_queue_depth_i + 1) >= data_len_words);
 
   always_ff @(posedge clk_i or negedge rst_ni) begin : proc_tx_pending
     if (!rst_ni) begin
-      tx_pending <= '0;
+      tx_pending <= 1'b0;
     end else begin
       if (tx_start) begin
-        tx_pending <= '1;
-      end else if (tx_end | tx_abort_i) begin
-        tx_pending <= '0;
+        tx_pending <= 1'b1;
+      end else if (tx_end || tx_abort_i) begin
+        tx_pending <= 1'b0;
       end
     end
   end
 
   always_ff @(posedge clk_i or negedge rst_ni) begin : proc_byte_counter
     if (!rst_ni) begin
-      byte_counter   <= '0;
+      byte_counter <= '0;
     end else begin
       if (tx_start) begin
         byte_counter <= data_len;
@@ -133,13 +128,17 @@ module descriptor_tx #(
     end
   end
 
-  assign tx_end = (byte_counter == 16'h1 && tx_byte_ready_i | flush);
   assign tx_byte_valid_o = tx_pending && tti_tx_queue_rvalid_i;
-  assign tx_byte_last_o = byte_counter == 16'd1;
-  assign tx_byte_o = tti_tx_queue_rdata_i;
-  assign tti_tx_queue_rready_o = (tx_byte_valid_o && tx_byte_ready_i) | (flush && tti_tx_queue_rvalid_i);
+  assign tx_byte_last_o  = (byte_counter == 16'd1);
+  assign tx_byte_o       = tti_tx_queue_rdata_i;
 
-  assign tx_queue_flush_o = (|data_len[1:0] & tx_end) | (|byte_counter[1:0] & tx_end);
+  assign tti_tx_queue_rready_o = (tx_byte_valid_o && tx_byte_ready_i) ||
+                                 (flush && tti_tx_queue_rvalid_i);
+
+  assign tx_end = (byte_counter == 16'h1 && (tx_byte_ready_i || flush));
+  // TODO check these conditions. This probably checks if any of the four bytes per tx_queue word
+  // hasn't been read, in which case a word-flush is required?
+  assign tx_queue_flush_o = (|data_len[1:0] && tx_end) || (|byte_counter[1:0] && tx_end);
 
   assign tx_end_o = tx_end;
 endmodule

--- a/src/ctrl/i3c_target_fsm.sv
+++ b/src/ctrl/i3c_target_fsm.sv
@@ -142,9 +142,7 @@ module i3c_target_fsm import i3c_pkg::*; #(
 
   i3c_byte_t last_byte;
 
-  i3c_byte_t bus_tx_req_data;
-
-  logic bus_tx_req_bit, bus_tx_req_byte;
+  logic bus_tx_req_bit;
   logic bus_rx_req_bit, bus_rx_req_byte;
 
   logic parity_bit;
@@ -225,13 +223,8 @@ module i3c_target_fsm import i3c_pkg::*; #(
   // TODO
   assign tx_host_nack_o = 1'b0;
 
-  assign bus_tx_req_o = '{
-    drive_type: OpenDrain, // TODO Set OD/PP in correct states
-    req_byte:   bus_tx_req_byte,
-    req_bit:    bus_tx_req_bit,
-    req_ibi:    1'b0,
-    data:       bus_tx_req_data
-  };
+  // Shorthand helper signal
+  assign bus_tx_req_bit = bus_tx_req_o.req_valid && (bus_tx_req_o.req_type == RawBit);
 
   assign bus_rx_req_o = '{
     req_byte: bus_rx_req_byte,
@@ -366,7 +359,9 @@ module i3c_target_fsm import i3c_pkg::*; #(
     if (~rst_ni) begin
       tx_end_xfer <= '0;
     end else begin
-      if (bus_tx_rsp_i.done && bus_tx_req_bit) tx_end_xfer <= tx_last_byte_i;
+      if (bus_tx_rsp_i.done && bus_tx_req_bit) begin
+        tx_end_xfer <= tx_last_byte_i;
+      end
     end
   end
 
@@ -405,9 +400,12 @@ module i3c_target_fsm import i3c_pkg::*; #(
 
     bus_rnw_d = 1'b0;
 
-    bus_tx_req_bit  = 1'b0;
-    bus_tx_req_byte = 1'b0;
-    bus_tx_req_data = '0;
+    bus_tx_req_o = '{
+      req_valid:  1'b0,
+      req_type:   RawBit,
+      drive_type: OpenDrain,
+      data:       '1
+    };
 
     bus_rx_req_bit  = 1'b0;
     bus_rx_req_byte = 1'b0;
@@ -454,8 +452,9 @@ module i3c_target_fsm import i3c_pkg::*; #(
         end
       end
       TxAckFByte: begin
-        bus_tx_req_bit     = 1'b1;
-        bus_tx_req_data[7] = 1'b0; // LSB is the only bit used for bit TX transfer
+        bus_tx_req_o.req_valid = 1'b1;
+        bus_tx_req_o.req_type  = RawBit;
+        bus_tx_req_o.data[7]   = 1'b0;
 
         if (bus_tx_rsp_i.done) begin
           if (is_rsvd_byte_match) begin
@@ -511,8 +510,9 @@ module i3c_target_fsm import i3c_pkg::*; #(
         end
       end
       TxAckSByte: begin
-        bus_tx_req_bit     = 1'b1;
-        bus_tx_req_data[7] = 1'b0;
+        bus_tx_req_o.req_valid = 1'b1;
+        bus_tx_req_o.req_type  = RawBit;
+        bus_tx_req_o.data[7]   = 1'b0;
 
         if (bus_tx_rsp_i.done) begin
           if (is_any_addr_match) begin
@@ -549,8 +549,11 @@ module i3c_target_fsm import i3c_pkg::*; #(
 
       // Private Read data loop
       TxPReadData: begin
-        bus_tx_req_byte = 1'b1;
-        bus_tx_req_data = tx_data_byte;
+        bus_tx_req_o.drive_type = PushPull;
+        bus_tx_req_o.req_valid  = 1'b1;
+        bus_tx_req_o.req_type   = RawByte;
+        bus_tx_req_o.data       = tx_data_byte;
+
         tx_pr_abort_o = bus_start_det || bus_stop_det_i;
 
         if (bus_start_det) begin
@@ -560,8 +563,11 @@ module i3c_target_fsm import i3c_pkg::*; #(
         end
       end
       TxPReadTbit: begin
-        bus_tx_req_bit     = 1'b1;
-        bus_tx_req_data[7] = ~tx_end_xfer;
+        bus_tx_req_o.drive_type = PushPull;
+        bus_tx_req_o.req_valid  = 1'b1;
+        bus_tx_req_o.req_type   = RawBit;
+        bus_tx_req_o.data[7]    = ~tx_end_xfer;
+
         tx_pr_abort_o = bus_start_det || bus_stop_det_i;
 
         // FIXME While waiting for a restart condition when the controller wants to abort the read,
@@ -711,7 +717,7 @@ module i3c_target_fsm import i3c_pkg::*; #(
     @(posedge clk_i)
     (
       $rose(bus_addr_valid) |=>
-      ##2 ((is_rsvd_byte_match || is_any_addr_match) && ~bus_tx_req_data[0])
+      ##2 ((is_rsvd_byte_match || is_any_addr_match) && ~bus_tx_req_o.data[7])
       ##1 @(posedge scl_negedge_i) ##1
       ##1 @(posedge clk_i) ##1 $fell(bus_tx_req_bit)
     );
@@ -722,7 +728,7 @@ module i3c_target_fsm import i3c_pkg::*; #(
     @(posedge clk_i)
     (
       $rose(bus_addr_valid) |=>
-      ##2 (~(is_rsvd_byte_match || is_any_addr_match) && bus_tx_req_data[0])
+      ##2 (~(is_rsvd_byte_match || is_any_addr_match) && bus_tx_req_o.data[7])
       ##1 @(posedge scl_negedge_i) ##1
       ##1 @(posedge clk_i) ##1 ($stable(bus_tx_req_bit) && ~bus_tx_req_bit)
     );

--- a/src/ctrl/i3c_target_fsm.sv
+++ b/src/ctrl/i3c_target_fsm.sv
@@ -32,8 +32,8 @@ module i3c_target_fsm import i3c_pkg::*; #(
   parameter int unsigned TxDataWidth  = 8,
   parameter int unsigned IbiDataWidth = 8
 ) (
-  input clk_i,  // clock
-  input rst_ni, // active low reset
+  input  clk_i,  // clock
+  input  rst_ni, // active low reset
 
   input  logic target_enable_i,  // enable target functionality
 
@@ -133,13 +133,6 @@ module i3c_target_fsm import i3c_pkg::*; #(
   logic nack_transaction_q, nack_transaction_d;
   logic rx_overflow_err_q, rx_overflow_err_r; // TODO figure out what 'r' refers to
 
-  logic [RxDataWidth-1:0] rx_data_byte;
-  logic                   rx_data_byte_valid;
-
-  logic [TxDataWidth-1:0] tx_data_byte;
-  logic                   tx_data_byte_valid;
-  logic                   tx_end_xfer;
-
   i3c_byte_t last_byte;
 
   logic bus_tx_req_bit;
@@ -189,8 +182,11 @@ module i3c_target_fsm import i3c_pkg::*; #(
     RxPWriteTbit,
     // Send data in Private Read transfer
     TxPReadData,
-    TxPReadTbit,
-    // Transfer is not targeted to us, wait for SR or P
+    // Signal to Controller in Tbit to transfer more bytes
+    TxPReadTbitCont,
+    // Signal to Controller in Tbit to end the transfer
+    TxPReadTbitEnd,
+    // Transfer is not targeted to us or we are not ready, NAck and wait for SR or P
     WaitStart,
 
     // If bus is available and an IBI is pending
@@ -349,30 +345,6 @@ module i3c_target_fsm import i3c_pkg::*; #(
   // a stop we transition to Idle. 
   assign rx_last_byte_o = (state_q == RxPWriteData) && (state_d inside {RxFByte, Idle});
 
-  // TX FIFO ready when we start writing byte (enter TxPReadData)
-  // Enterng the TXPReadData state, then asserting rready will cause a byte to be
-  // consumed from the FIFO, but we might cancel TxPReadData if Rstart occurs.
-  // On TX cancel, we flush the FIFO, aborting transaction.
-  assign tx_fifo_rready_o = (state_q != TxPReadData) && (state_d == TxPReadData);
-
-  always_ff @(posedge clk_i or negedge rst_ni) begin : set_last_byte_in_xfer
-    if (~rst_ni) begin
-      tx_end_xfer <= '0;
-    end else begin
-      if (bus_tx_rsp_i.done && bus_tx_req_bit) begin
-        tx_end_xfer <= tx_last_byte_i;
-      end
-    end
-  end
-
-  always_ff @(posedge clk_i or negedge rst_ni) begin : capture_tx_data_from_queue
-    if (~rst_ni) begin
-      tx_data_byte <= '0;
-    end else begin
-      if (tx_fifo_rready_o) tx_data_byte <= tx_fifo_rdata_i;
-    end
-  end
-
   // Logic for latching CCC code
   always_ff @(posedge clk_i or negedge rst_ni) begin : latch_ccc_data
     if (~rst_ni) begin
@@ -407,6 +379,8 @@ module i3c_target_fsm import i3c_pkg::*; #(
       data:       '1
     };
 
+    tx_fifo_rready_o = 1'b0;
+
     bus_rx_req_bit  = 1'b0;
     bus_rx_req_byte = 1'b0;
 
@@ -425,6 +399,7 @@ module i3c_target_fsm import i3c_pkg::*; #(
           end
         end
       end
+
       RxFByte: begin
         bus_rx_req_byte = !bus_start_det;
         if (bus_rx_rsp_i.done) begin
@@ -437,7 +412,7 @@ module i3c_target_fsm import i3c_pkg::*; #(
       end
       CheckFByte: begin
         // Signal begin of a private read
-        tx_pr_start_o = !is_rsvd_byte_match && is_any_addr_match && bus_rnw_q;
+        tx_pr_start_o = is_any_addr_match && bus_rnw_q;
 
         if (is_rsvd_byte_match || is_any_addr_match) begin
           // Do not ACK transaction if it is a read and we don't have data to send
@@ -453,8 +428,7 @@ module i3c_target_fsm import i3c_pkg::*; #(
       end
       TxAckFByte: begin
         bus_tx_req_o.req_valid = 1'b1;
-        bus_tx_req_o.req_type  = RawBit;
-        bus_tx_req_o.data[7]   = 1'b0;
+        bus_tx_req_o.req_type  = bus_rnw_q ? AckRegular : AckWrite;
 
         if (bus_tx_rsp_i.done) begin
           if (is_rsvd_byte_match) begin
@@ -466,6 +440,7 @@ module i3c_target_fsm import i3c_pkg::*; #(
           end
         end
       end
+
       RxSByte: begin
         bus_rx_req_byte = !bus_start_det;
 
@@ -492,17 +467,13 @@ module i3c_target_fsm import i3c_pkg::*; #(
       end
       CheckSByte: begin
         if (is_any_addr_match) begin
-          if (bus_rnw_q) begin
-            // Signal begin of a private read
-            // TODO gate this with tx_desc_avail_i ?
-            tx_pr_start_o = 1'b1;
-          end
-          // ACK the transaction if it is a write
-          // If read, ACK only if we have data to send
-          if (tx_desc_avail_i || ~bus_rnw_q) begin
+          // Signal begin of a private read
+          tx_pr_start_o = bus_rnw_q;
+          if (!bus_rnw_q || tx_desc_avail_i) begin
+            // Either private write or private read and data available
             state_d = TxAckSByte;
           end else begin
-            // if there is no data to be sent, NACK the transaction
+            // NAck in case of private read without data available
             state_d = WaitStart;
           end
         end else begin
@@ -511,15 +482,10 @@ module i3c_target_fsm import i3c_pkg::*; #(
       end
       TxAckSByte: begin
         bus_tx_req_o.req_valid = 1'b1;
-        bus_tx_req_o.req_type  = RawBit;
-        bus_tx_req_o.data[7]   = 1'b0;
+        bus_tx_req_o.req_type  = AckRegular;
 
         if (bus_tx_rsp_i.done) begin
-          if (is_any_addr_match) begin
-            state_d = bus_rnw_q ? TxPReadData : RxPWriteData;
-          end else begin
-            state_d = WaitStart;
-          end
+          state_d = bus_rnw_q ? TxPReadData : RxPWriteData;
         end
       end
 
@@ -552,36 +518,47 @@ module i3c_target_fsm import i3c_pkg::*; #(
         bus_tx_req_o.drive_type = PushPull;
         bus_tx_req_o.req_valid  = 1'b1;
         bus_tx_req_o.req_type   = RawByte;
-        bus_tx_req_o.data       = tx_data_byte;
+        bus_tx_req_o.data       = tx_fifo_rdata_i;
 
-        tx_pr_abort_o = bus_start_det || bus_stop_det_i;
+        // Neither stop nor restart may occur as SDA is under control of target. Therefore, we do
+        // not check for Rs or P here.
 
-        if (bus_start_det) begin
-          state_d = RxFByte;
-        end else if (bus_tx_rsp_i.done) begin
-          state_d = TxPReadTbit;
+        if (bus_tx_rsp_i.done) begin
+          // Acknowledge consumption of current byte
+          tx_fifo_rready_o = 1'b1;
+          // Signal continue or end of read
+          state_d = tx_last_byte_i ? TxPReadTbitEnd : TxPReadTbitCont;
         end
       end
-      TxPReadTbit: begin
-        bus_tx_req_o.drive_type = PushPull;
-        bus_tx_req_o.req_valid  = 1'b1;
-        bus_tx_req_o.req_type   = RawBit;
-        bus_tx_req_o.data[7]    = ~tx_end_xfer;
+      TxPReadTbitEnd: begin
+        bus_tx_req_o.req_valid = 1'b1;
+        bus_tx_req_o.req_type  = TReadEnd;
 
-        tx_pr_abort_o = bus_start_det || bus_stop_det_i;
+        if (bus_tx_rsp_i.done) begin
+          state_d = WaitStart;
+        end
+      end
+      TxPReadTbitCont: begin
+        // Special request type: We have to wait until the following SCL negedge to know whether the
+        // Controller has aborted the read prematurely. However, if not, we need to provide the MSB
+        // of the next byte on that very negedge. Therefore, already provide the next byte as part
+        // of this Tbit request; bus_tx_flow will handle all the low-level details.
+        bus_tx_req_o.req_valid = 1'b1;
+        bus_tx_req_o.req_type  = TReadCont;
+        bus_tx_req_o.data      = tx_fifo_rdata_i;
 
-        // FIXME While waiting for a restart condition when the controller wants to abort the read,
-        // the bus_tx_rsp_i.done below can happen first, leading to erroneous draining of the FIFO.
         if (bus_start_det) begin
+          // The host has pulled SDA low before the next SCL negedge to end the transfer (this is
+          // equivalent to a Rs condition)
+          tx_pr_abort_o = 1'b1;
           state_d = RxFByte;
+        end else if (bus_stop_det_i) begin
+          // Should not be possible: SDA is controlled in PP-high by us until the next SCL posedge
+          tx_pr_abort_o = 1'b1;
+          state_d = WaitStart;
         end else if (bus_tx_rsp_i.done) begin
-          if ((tx_fifo_rvalid_i || tx_last_byte_i) && !tx_end_xfer) begin
-            // Continue transfer if FIFO is not empty or if it's the last byte
-            state_d = TxPReadData;
-          end else begin
-            // Wait for START or STOP if it was the last byte already
-            state_d = WaitStart;
-          end
+          // TBit was successfully transmitted as high, we may therefore continue with the next byte
+          state_d = TxPReadData;
         end
       end
 
@@ -696,7 +673,7 @@ module i3c_target_fsm import i3c_pkg::*; #(
   // TODO: Also sub FSM should contribute
   // TODO: Maybe we can do it based on write module rather than states
   assign target_transmitting_o =
-  (state_q inside {TxAckFByte, TxAckSByte, TxPReadData, TxPReadTbit});
+  (state_q inside {TxAckFByte, TxAckSByte, TxPReadData, TxPReadTbitCont, TxPReadTbitEnd});
 
   // TODO: Count which transaction and transfers were addressed to us
   // TODO: Expose xfer,xact counters
@@ -742,11 +719,11 @@ module i3c_target_fsm import i3c_pkg::*; #(
       bins valid_start_trans =
         (Idle => RxFByte);
       bins valid_rstart_trans =
-        (RxPWriteData, TxPReadData, TxPReadTbit, WaitStart => RxFByte),
+        (RxPWriteData, TxPReadData, TxPReadTbitCont, WaitStart => RxFByte),
         (RxSByte => RxSByteRepeated);
       bins valid_stop_trans =
         (RxFByte, CheckFByte, TxAckFByte, RxSByte, RxSByteRepeated, CheckSByte, TxAckSByte,
-         RxPWriteData, RxPWriteTbit, TxPReadData, TxPReadTbit, WaitStart, DoIBI, DoneIBI, DoCCC,
+         RxPWriteData, RxPWriteTbit, TxPReadData, WaitStart, DoIBI, DoneIBI, DoCCC,
          DoneCCC, DoHotJoin, DoRstAction, InHDRMode => Idle);
     }
     BusStartEvent: coverpoint bus_start_det_i {

--- a/src/ctrl/ibi.sv
+++ b/src/ctrl/ibi.sv
@@ -73,10 +73,8 @@ module ibi import i3c_pkg::*; (
     Idle,
     // Request to drive SDA low and transmit target address
     DriveIbiAddr,
-    // Receive ACK/NACK
+    // Receive ACK/NACK, handle SDA handoff
     ReadAck,
-    // Wait for falling SCL (do not change sel_od_pp_o when SCL is high)
-    WaitForSclNegedgeAfterAck,
     // Transmit data byte
     SendData,
     // Transmit T bit
@@ -155,17 +153,22 @@ module ibi import i3c_pkg::*; (
       ReadAck: begin
         if (bus_stop_i) begin
           state_d = Done;
-        end else if (bus_rx_rsp_i.done) begin
-          if (bus_rx_req_nack) begin
-            ibi_status_d = (ibi_status_q == IbiSuccess) ? IbiFailureNack : IbiFailureRetry;
-            state_d = WaitStopOrRstart;
-          end else begin
-            state_d = WaitForSclNegedgeAfterAck;
+        end else begin
+          // TODO only do the special ACK in case we have an MDB
+          bus_tx_req_o.req_valid = 1'b1;
+          bus_tx_req_o.req_type  = AckIbi;
+
+          // Note: Tx and Rx simultaneously! This relies on the 'done' being asserted for both at
+          // the rising edge of SCL!
+          if (bus_rx_rsp_i.done) begin
+            if (bus_rx_req_nack) begin
+              ibi_status_d = (ibi_status_q == IbiSuccess) ? IbiFailureNack : IbiFailureRetry;
+              state_d = WaitStopOrRstart;
+            end else begin
+              state_d = SendData;
+            end
           end
         end
-      end
-      WaitForSclNegedgeAfterAck: begin
-        if (scl_negedge_i) state_d = SendData;
       end
       SendData: begin
         bus_tx_req_o.drive_type = PushPull;

--- a/src/ctrl/ibi.sv
+++ b/src/ctrl/ibi.sv
@@ -65,8 +65,6 @@ module ibi import i3c_pkg::*; (
   logic [2:0] ibi_retry_cnt_q, ibi_retry_cnt_d;
   logic       ibi_can_retry;
 
-  i3c_byte_t bus_tx_req_value;
-
   logic bus_rx_req_nack;
 
   // FSM
@@ -110,13 +108,6 @@ module ibi import i3c_pkg::*; (
   // Retry allowed if count not yet met or indefinite attempts allowed
   assign ibi_can_retry = (ibi_retry_num_i == 3'd7) || (ibi_retry_num_i != ibi_retry_cnt_q);
 
-  assign bus_tx_req_o = '{
-    drive_type: (state_q inside {SendData, SendTbit}) ? PushPull : OpenDrain,
-    req_byte:   (state_q inside {SendData}),
-    req_bit:    (state_q == SendTbit),
-    req_ibi:    (state_q == DriveIbiAddr),
-    data:       bus_tx_req_value
-  };
 
   assign bus_rx_req_o = '{
     req_bit:  (state_q == ReadAck),
@@ -124,10 +115,16 @@ module ibi import i3c_pkg::*; (
   };
 
   always_comb begin : fsm_ibi
-    bus_tx_req_value = '0;
     ibi_byte_ready_o = 1'b0;
     ibi_status_we_o  = 1'b0;
     done_o = 1'b0;
+
+    bus_tx_req_o = '{
+      req_valid:  1'b0,
+      req_type:   RawBit,
+      drive_type: OpenDrain,
+      data:       '1
+    };
 
     state_d      = state_q;
     ibi_status_d = ibi_status_q;
@@ -142,7 +139,9 @@ module ibi import i3c_pkg::*; (
       DriveIbiAddr: begin
         // In this state, we send an IBI request to bus_tx_flow, which then first pulls SDA low and
         // subsequently transmits our IBI address, starting at the following negedge of SCL.
-        bus_tx_req_value = {target_ibi_addr_i, 1'b1};
+        bus_tx_req_o.req_valid = 1'b1;
+        bus_tx_req_o.req_type  = InitIbi;
+        bus_tx_req_o.data      = {target_ibi_addr_i, 1'b1};
 
         if (bus_stop_i) begin
           state_d = Done;
@@ -169,7 +168,10 @@ module ibi import i3c_pkg::*; (
         if (scl_negedge_i) state_d = SendData;
       end
       SendData: begin
-        bus_tx_req_value = ibi_byte_i;
+        bus_tx_req_o.drive_type = PushPull;
+        bus_tx_req_o.req_valid  = 1'b1;
+        bus_tx_req_o.req_type   = RawByte;
+        bus_tx_req_o.data       = ibi_byte_i;
 
         if (bus_stop_i) begin
           ibi_status_d = (ibi_status_q == IbiSuccess) ? IbiFailurePartialData : IbiFailureRetry;
@@ -182,8 +184,12 @@ module ibi import i3c_pkg::*; (
         end
       end
       SendTbit: begin
-        bus_tx_req_value[7] = ~ibi_byte_last_i;
-        ibi_byte_ready_o    = bus_tx_rsp_i.done;
+        bus_tx_req_o.drive_type = PushPull;
+        bus_tx_req_o.req_valid  = 1'b1;
+        bus_tx_req_o.req_type   = RawBit;
+        bus_tx_req_o.data[7]    = ~ibi_byte_last_i;
+
+        ibi_byte_ready_o = bus_tx_rsp_i.done;
 
         if (bus_stop_i) begin
           ibi_status_d = (ibi_status_q == IbiSuccess) ? IbiFailurePartialData : IbiFailureRetry;

--- a/src/i3c.sv
+++ b/src/i3c.sv
@@ -190,6 +190,7 @@ module i3c
     input  logic i3c_sda_i,  // serial data input from i3c bus
     output logic i3c_sda_o,  // serial data output to i3c bus
 
+    output logic i3c_sda_oe_o, // Pad output enable
     output logic sel_od_pp_o,  // 0 - Open Drain, 1 - Push Pull
 
     // DAT memory export interface
@@ -478,6 +479,7 @@ module i3c
   logic ctrl2phy_scl;
   logic ctrl2phy_sda;
   logic ctrl_sel_od_pp;
+  logic ctrl_sda_oe;
 
   // Configuration
   logic phy_en;
@@ -590,6 +592,7 @@ module i3c
       .sda_i(phy2ctrl_sda),
       .scl_o(ctrl2phy_scl),
       .sda_o(ctrl2phy_sda),
+      .sda_oe_o(ctrl_sda_oe),
       .sel_od_pp_o(ctrl_sel_od_pp),
       .arbitration_lost_i(arbitration_lost_q),
 
@@ -1288,6 +1291,8 @@ module i3c
       .ctrl_sda_i(ctrl2phy_sda),
       .ctrl_scl_o(phy2ctrl_scl),
       .ctrl_sda_o(phy2ctrl_sda),
+      .ctrl_sda_oe_i(ctrl_sda_oe),
+      .ctrl_sda_oe_o(i3c_sda_oe_o),
       .sel_od_pp_i(ctrl_sel_od_pp),
       .sel_od_pp_o(sel_od_pp_o)
   );

--- a/src/i3c_pkg.sv
+++ b/src/i3c_pkg.sv
@@ -162,13 +162,24 @@ package i3c_pkg;
     logic stop_det;
   } bus_state_t;
 
+  // Tx transfer types
+  typedef enum logic [2:0] {
+    RawByte,
+    RawBit,
+    InitIbi,
+    AckRegular,
+    AckWrite,
+    AckIbi,
+    TReadCont,
+    TReadEnd
+  } i3c_tx_req_e;
+
   // Tx descriptor
   typedef struct packed {
-    i3c_drive_e drive_type;
-    logic       req_ibi;
-    logic       req_byte;
-    logic       req_bit;
-    i3c_byte_t  data;
+    logic        req_valid;
+    i3c_tx_req_e req_type;
+    i3c_drive_e  drive_type;
+    i3c_byte_t   data;
   } bus_tx_req_t;
 
   typedef struct packed {

--- a/src/i3c_wrapper.sv
+++ b/src/i3c_wrapper.sv
@@ -217,11 +217,12 @@ module i3c_wrapper #(
 `endif
 `endif
 
-      .i3c_scl_i  (scl_i),
-      .i3c_scl_o  (scl_o),
-      .i3c_sda_i  (sda_i),
-      .i3c_sda_o  (sda_o),
-      .sel_od_pp_o(sel_od_pp_o),
+      .i3c_scl_i   (scl_i),
+      .i3c_scl_o   (scl_o),
+      .i3c_sda_i   (sda_i),
+      .i3c_sda_o   (sda_o),
+      .i3c_sda_oe_o(sda_oe),
+      .sel_od_pp_o (sel_od_pp_o),
 
       .dat_mem_src_i (dat_mem_src),
       .dat_mem_sink_o(dat_mem_sink),
@@ -274,18 +275,7 @@ module i3c_wrapper #(
       .cfg_i('0)  // Unused
   );
 
-/*
-  Truth table.
 
-  sel_od_pp_o | sda_o  || sda_oe | IO state
-  ------------+--------++--------+-----------
-       0      |   0    ||   1    |    0
-       0      |   1    ||   0    |   hi-z
-       1      |   0    ||   1    |    0
-       1      |   1    ||   1    |    1
-*/
-
-  assign sda_oe = sel_od_pp_o || !sda_o;
   assign scl_oe = 1'b0;
 
 endmodule

--- a/src/phy/i3c_phy.sv
+++ b/src/phy/i3c_phy.sv
@@ -20,6 +20,10 @@ module i3c_phy (
     output logic ctrl_scl_o,
     output logic ctrl_sda_o,
 
+    // Pad output enable
+    input  logic ctrl_sda_oe_i,
+    output logic ctrl_sda_oe_o,
+
     // Open-Drain / Push-Pull control
     input  logic sel_od_pp_i,
     output logic sel_od_pp_o
@@ -59,5 +63,6 @@ module i3c_phy (
   assign sda_o = ctrl_sda_i;
   assign scl_o = ctrl_scl_i;
   assign sel_od_pp_o = sel_od_pp_i;
+  assign ctrl_sda_oe_o = ctrl_sda_oe_i;
 
 endmodule

--- a/verification/cocotb/block/bus_tx_flow/bus_tx_flow_test_wrapper.sv
+++ b/verification/cocotb/block/bus_tx_flow/bus_tx_flow_test_wrapper.sv
@@ -17,6 +17,8 @@ module bus_tx_flow_test_wrapper
     input logic scl_negedge_i,
     input logic scl_posedge_i,
     input logic scl_stable_low_i,
+    input logic sda_negedge_i,
+    input logic sda_value_i,
 
     // Bus flow control
     input logic req_byte_i,
@@ -34,15 +36,24 @@ module bus_tx_flow_test_wrapper
     output logic sda_o  // Output I3C SDA bus line
 );
 
-  // Map individual signals to struct
+  // Map individual signals to/from structs
   bus_tx_req_t tx_req_i;
   bus_tx_rsp_t tx_rsp_o;
 
-  assign tx_req_i.drive_type = sel_od_pp_i ? PushPull : OpenDrain;
-  assign tx_req_i.req_byte   = req_byte_i;
-  assign tx_req_i.req_bit    = req_bit_i;
-  assign tx_req_i.req_ibi    = req_ibi_i;
-  assign tx_req_i.data       = req_value_i;
+  assign tx_req_i = '{
+    drive_type: (sel_od_pp_i ? PushPull : OpenDrain),
+    req_type:   (req_byte_i ? RawByte : RawBit), 
+    req_valid:  (req_byte_i || req_bit_i),
+    data:       req_value_i
+  };
+
+  bus_state_t bus_i;
+
+  assign bus_i = '{
+    sda: '{neg_edge: sda_negedge_i, value: sda_value_i, default: '0},
+    scl: '{pos_edge: scl_posedge_i, neg_edge: scl_negedge_i, stable_low: scl_stable_low_i, default: '0},
+    default: '0
+  };
 
   assign bus_tx_done_o  = tx_rsp_o.done;
   assign bus_tx_idle_o  = tx_rsp_o.idle;
@@ -51,9 +62,7 @@ module bus_tx_flow_test_wrapper
   bus_tx_flow xbus_tx_flow (
     .clk_i,
     .rst_ni,
-    .scl_negedge_i,
-    .scl_posedge_i,
-    .scl_stable_low_i,
+    .bus_i,
     .tx_req_i,
     .tx_rsp_o,
     .sel_od_pp_o,

--- a/verification/cocotb/block/bus_tx_flow/test_bus_tx_flow.py
+++ b/verification/cocotb/block/bus_tx_flow/test_bus_tx_flow.py
@@ -46,11 +46,12 @@ async def setup_test(dut):
     dut.t_hd_dat_i.value = 5
     dut.req_byte_i.value = 0
     dut.req_bit_i.value = 0
-    dut.req_ibi_i.value = 0
     dut.req_value_i.value = 0
     dut.scl_negedge_i.value = 0
     dut.scl_posedge_i.value = 0
     dut.scl_stable_low_i.value = 0
+    dut.sda_negedge_i.value = 0
+    dut.sda_value_i.value = 1
     dut.sel_od_pp_i.value = 0
 
     await ClockCycles(dut.clk_i, 10)

--- a/verification/cocotb/block/ccc/test_ccc.py
+++ b/verification/cocotb/block/ccc/test_ccc.py
@@ -166,7 +166,7 @@ async def tx_bit(dut):
     bus_tx_rsp_t = {error, idle, done}
     bus_tx_req_t = {drive_type, req_byte, req_bit, data[7:0]}
     """
-    # Wait for req_bit to go high
+    # Wait for a RawBit request to be sent
     while not (get_tx_req_valid(dut) and (get_tx_req_type(dut) == 1)):
         await RisingEdge(dut.clk_i)
     val = get_tx_req_data(dut)  # Get the data from the request
@@ -182,7 +182,7 @@ async def tx_byte(dut):
     bus_tx_rsp_t = {error, idle, done}
     bus_tx_req_t = {drive_type, req_byte, req_bit, data[7:0]}
     """
-    # Wait for req_byte to go high
+    # Wait for RawByte request to be sent
     while not (get_tx_req_valid(dut) and (get_tx_req_type(dut) == 0)):
         await RisingEdge(dut.clk_i)
     val = get_tx_req_data(dut)  # Get the data from the request
@@ -192,6 +192,33 @@ async def tx_byte(dut):
     set_bus_tx_rsp(dut, done=0)
     return val & 0xFF
 
+async def tx_tread_end(dut):
+    """
+    bus_tx_rsp_t = {error, idle, done}
+    bus_tx_req_t = {drive_type, req_byte, req_bit, data[7:0]}
+    """
+    # Wait for a RawBit request to be sent
+    while not (get_tx_req_valid(dut) and (get_tx_req_type(dut) == 7)):
+        await RisingEdge(dut.clk_i)
+    await ClockCycles(dut.clk_i, 3)
+    set_bus_tx_rsp(dut, done=1)
+    await ClockCycles(dut.clk_i, 1)
+    set_bus_tx_rsp(dut, done=0)
+
+async def tx_tread_cont(dut):
+    """
+    bus_tx_rsp_t = {error, idle, done}
+    bus_tx_req_t = {drive_type, req_byte, req_bit, data[7:0]}
+    """
+    # Wait for a RawBit request to be sent
+    while not (get_tx_req_valid(dut) and (get_tx_req_type(dut) == 6)):
+        await RisingEdge(dut.clk_i)
+    val = get_tx_req_data(dut)  # Get the data from the request
+    await ClockCycles(dut.clk_i, 3)
+    set_bus_tx_rsp(dut, done=1)
+    await ClockCycles(dut.clk_i, 1)
+    set_bus_tx_rsp(dut, done=0)
+    return val & 0xFF
 
 async def get_status(dut):
     # CCC - set command code and valid
@@ -216,11 +243,15 @@ async def get_status(dut):
 
     # TX Bytes (GETSTATUS returns 2 bytes)
     status = []
-    for i in range(2):
+    r = range(2)
+    for i in r:
         byte_val = await tx_byte(dut)
         status.append(byte_val)
         # T-bit
-        await tx_bit(dut)
+        if i == r[-1]:
+            await tx_tread_end(dut)
+        else:
+            await tx_tread_cont(dut)
 
     # Stop the frame
     await cycle(dut.clk_i, dut.bus_stop_det_i)

--- a/verification/cocotb/block/ccc/test_ccc.py
+++ b/verification/cocotb/block/ccc/test_ccc.py
@@ -54,19 +54,19 @@ def get_rx_req_byte(dut):
         return int(dut.bus_rx_req_o.req_byte.value)
 
 
-# bus_tx_req_t = {drive_type[11], req_ibi[10], req_byte[9], req_bit[8], data[7:0]}
-def get_tx_req_bit(dut):
+# bus_tx_req_t = {req_valid[12], req_type[11:9], drive_type[8], data[7:0]}
+def get_tx_req_valid(dut):
     if is_verilator():
-        return (int(dut.bus_tx_req_o.value) >> 8) & 0x1
+        return (int(dut.bus_tx_req_o.value) >> 12) & 0x1
     else:
-        return int(dut.bus_tx_req_o.req_bit.value)
+        return int(dut.bus_tx_req_o.req_valid.value)
 
 
-def get_tx_req_byte(dut):
+def get_tx_req_type(dut):
     if is_verilator():
-        return (int(dut.bus_tx_req_o.value) >> 9) & 0x1
+        return (int(dut.bus_tx_req_o.value) >> 9) & 0x7
     else:
-        return int(dut.bus_tx_req_o.req_byte.value)
+        return int(dut.bus_tx_req_o.req_type.value)
 
 
 def get_tx_req_data(dut):
@@ -167,7 +167,7 @@ async def tx_bit(dut):
     bus_tx_req_t = {drive_type, req_byte, req_bit, data[7:0]}
     """
     # Wait for req_bit to go high
-    while not get_tx_req_bit(dut):
+    while not (get_tx_req_valid(dut) and (get_tx_req_type(dut) == 1)):
         await RisingEdge(dut.clk_i)
     val = get_tx_req_data(dut)  # Get the data from the request
     await ClockCycles(dut.clk_i, 3)
@@ -183,7 +183,7 @@ async def tx_byte(dut):
     bus_tx_req_t = {drive_type, req_byte, req_bit, data[7:0]}
     """
     # Wait for req_byte to go high
-    while not get_tx_req_byte(dut):
+    while not (get_tx_req_valid(dut) and (get_tx_req_type(dut) == 0)):
         await RisingEdge(dut.clk_i)
     val = get_tx_req_data(dut)  # Get the data from the request
     await ClockCycles(dut.clk_i, 10)

--- a/verification/cocotb/block/ctrl_descriptor_tx/Makefile
+++ b/verification/cocotb/block/ctrl_descriptor_tx/Makefile
@@ -13,6 +13,7 @@ MODULE      ?= $(subst $(space),$(comma),$(subst .py,,$(TEST_FILES)))
 TOPLEVEL     = descriptor_tx
 
 VERILOG_SOURCES  = \
+    $(SRC_DIR)/i3c_pkg.sv \
     $(SRC_DIR)/ctrl/descriptor_tx.sv
 
 include $(TEST_DIR)/../block_common.mk

--- a/verification/cocotb/top/lib_i3c_top/i3c_controller_fixed.py
+++ b/verification/cocotb/top/lib_i3c_top/i3c_controller_fixed.py
@@ -20,7 +20,7 @@ Usage:
 from typing import Iterable
 
 from cocotbext_i3c.i3c_controller import I3cController, I3cXferMode
-from cocotbext_i3c.common import I3C_RSVD_BYTE, I3cPWResp
+from cocotbext_i3c.common import I3C_RSVD_BYTE, I3cPWResp, I3cState
 
 
 class I3cControllerFixed(I3cController):
@@ -140,3 +140,33 @@ class I3cControllerFixed(I3cController):
         """
         await self.send_stop()
         self.give_bus_control()
+
+    async def recv_addr_ack(self) -> bool:
+        self.scl = 0
+        self.sda = 1
+        # We don't hold the data here, because it's on the target to pull it down
+        # after the required amount of time
+        await self.tdig_l
+        if self.sda_i is None:
+            b = False
+        else:
+            b = bool(self.sda)
+        
+        # Take over driving in case of an ACK by target
+        if b == False:
+            self.sda = 0
+        self.scl = 1
+        await self.tdig_h
+        self.hold_data = False
+
+        return b
+
+    async def send_byte(self, b: int, addr: bool = False) -> bool:
+        self._state = I3cState.ADDR if addr else I3cState.DATA_WR
+        for i in range(8):
+            await self.send_bit(b & (1 << 7 - i))
+        self._state = I3cState.ACK
+        if addr and not(b & 1):
+            return await self.recv_addr_ack()
+        else:
+            return await self.recv_bit_od()

--- a/verification/cocotb/top/lib_i3c_top/test_bypass.py
+++ b/verification/cocotb/top/lib_i3c_top/test_bypass.py
@@ -8,7 +8,7 @@ from boot import boot_init
 from bus2csr import compare_values, dword2int, int2bytes, int2dword
 from ccc import CCC
 from cocotb_helpers import reset_n
-from cocotbext_i3c.i3c_controller import I3cController
+from i3c_controller_fixed import I3cControllerFixed as I3cController
 from cocotbext_i3c.i3c_recovery_interface import I3cRecoveryInterface
 from cocotbext_i3c.i3c_target import I3CTarget
 from interface import I3CTopTestInterface

--- a/verification/cocotb/top/lib_i3c_top/test_ccc.py
+++ b/verification/cocotb/top/lib_i3c_top/test_ccc.py
@@ -7,7 +7,7 @@ from boot import boot_init
 from bus2csr import bytes2int
 from ccc import CCC
 from cocotbext_i3c.common import I3cTargetResetAction
-from cocotbext_i3c.i3c_controller import I3cController
+from i3c_controller_fixed import I3cControllerFixed as I3cController
 from interface import I3CTopTestInterface
 
 import cocotb

--- a/verification/cocotb/top/lib_i3c_top/test_enter_exit_hdr_mode.py
+++ b/verification/cocotb/top/lib_i3c_top/test_enter_exit_hdr_mode.py
@@ -4,7 +4,7 @@ import logging
 import random
 
 from boot import boot_init
-from cocotbext_i3c.i3c_controller import I3cController
+from i3c_controller_fixed import I3cControllerFixed as I3cController
 from cocotbext_i3c.i3c_target import I3CTarget
 from interface import I3CTopTestInterface
 
@@ -74,7 +74,7 @@ async def test_enter_exit_hdr_mode_write(dut):
 
         assert (
         int(dut.xi3c_wrapper.i3c.xcontroller.xcontroller_standby.xcontroller_standby_i3c.xi3c_target_fsm.state_d.value)
-            == 19
+            == 20
         )  # InHDRMode
         test_addr = random.choice(remaining_addrs)
 
@@ -133,7 +133,7 @@ async def test_enter_restart_exit_hdr_mode_write(dut):
 
         assert (
         int(dut.xi3c_wrapper.i3c.xcontroller.xcontroller_standby.xcontroller_standby_i3c.xi3c_target_fsm.state_d.value)
-            == 19
+            == 20
         )  # InHDRMode
         transactions = random.randint(10, 15)
         for i in range(transactions):
@@ -196,7 +196,7 @@ async def test_enter_exit_hdr_mode_read(dut):
 
         assert (
         int(dut.xi3c_wrapper.i3c.xcontroller.xcontroller_standby.xcontroller_standby_i3c.xi3c_target_fsm.state_d.value)
-            == 19
+            == 20
         )  # InHDRMode
         test_addr = random.choice(remaining_addrs)
 
@@ -259,7 +259,7 @@ async def test_enter_restart_exit_hdr_mode_read(dut):
 
         assert (
         int(dut.xi3c_wrapper.i3c.xcontroller.xcontroller_standby.xcontroller_standby_i3c.xi3c_target_fsm.state_d.value)
-            == 19
+            == 20
         )  # InHDRMode
         transactions = random.randint(10, 15)
         for i in range(transactions):

--- a/verification/cocotb/top/lib_i3c_top/test_i3c_target.py
+++ b/verification/cocotb/top/lib_i3c_top/test_i3c_target.py
@@ -6,7 +6,7 @@ from math import ceil
 
 from boot import boot_init
 from bus2csr import dword2int, int2dword
-from cocotbext_i3c.i3c_controller import I3cController
+from i3c_controller_fixed import I3cControllerFixed as I3cController
 from cocotbext_i3c.i3c_target import I3CTarget
 from interface import I3CTopTestInterface
 from utils import format_ibi_data, get_interrupt_status

--- a/verification/cocotb/top/lib_i3c_top/test_interrupts.py
+++ b/verification/cocotb/top/lib_i3c_top/test_interrupts.py
@@ -5,7 +5,7 @@ import random
 
 from boot import boot_init
 from bus2csr import dword2int, int2dword
-from cocotbext_i3c.i3c_controller import I3cController
+from i3c_controller_fixed import I3cControllerFixed as I3cController
 from cocotbext_i3c.i3c_target import I3CTarget
 from interface import I3CTopTestInterface
 from utils import format_ibi_data, get_interrupt_status

--- a/verification/cocotb/top/lib_i3c_top/test_target_reset.py
+++ b/verification/cocotb/top/lib_i3c_top/test_target_reset.py
@@ -4,7 +4,7 @@ import logging
 
 from boot import boot_init
 from ccc import CCC
-from cocotbext_i3c.i3c_controller import I3cController
+from i3c_controller_fixed import I3cControllerFixed as I3cController
 from interface import I3CTopTestInterface
 
 import cocotb


### PR DESCRIPTION
This PR implements dynamic control of the drive mode of the SDA pad for the various parts of the I3C protocol, including the handoff special cases with mid-bit changes.

Furthermore, the drive mode signal is now taken directly from a register without any further logic.

Finally, this PR hard-wires the I3C Target Device to the pads.