### PR TITLE
[src] Fix bus timers

### DIFF
--- a/src/ctrl/bus_timers.sv
+++ b/src/ctrl/bus_timers.sv
@@ -25,8 +25,10 @@ module bus_timers
 (
     input  logic        clk_i,
     input  logic        rst_ni,
-    input  logic        enable_i,
-    input  logic        restart_counter_i,
+    input  logic        enable_i,           // Module enable (i3c_standby_en)
+    input  logic        bus_start_i,        // Bus START/RSTART detected
+    input  logic        bus_stop_i,         // Bus STOP detected
+    input  logic        in_hdr_mode_i,      // Currently in HDR mode
     input  logic [19:0] t_bus_free_i,       // CSR: Time to free
     input  logic [19:0] t_bus_idle_i,       // CSR: Time to idle
     input  logic [19:0] t_bus_available_i,  // CSR: Time to available
@@ -36,13 +38,24 @@ module bus_timers
     output logic        bus_available_o     // Bus is available
 );
   logic [31:0] bus_state_counter;
+  logic count_enable;
+  logic reset_counter;
 
-  logic enable;
-  always_ff @(posedge clk_i or negedge rst_ni) begin : proc_enable
+  // Reset counter when: START detected, disabled, or in HDR mode
+  assign reset_counter = bus_start_i | ~enable_i | in_hdr_mode_i;
+
+  // Track if we've seen STOP (and should be counting)
+  always_ff @(posedge clk_i or negedge rst_ni) begin : proc_count_enable
     if (!rst_ni) begin
-      enable <= '0;
+      count_enable <= '0;
     end else begin
-      enable <= enable_i & ~bus_idle_o;
+      // Stop counting when bus_idle since this is always the largest counter
+      // We need to stop to avoid counter overflow issues.
+      if (reset_counter || bus_idle_o) begin
+        count_enable <= 1'b0;
+      end else if (bus_stop_i) begin
+        count_enable <= 1'b1;
+      end
     end
   end
 
@@ -50,14 +63,10 @@ module bus_timers
     if (!rst_ni) begin
       bus_state_counter <= '0;
     end else begin
-      if (restart_counter_i) begin
+      if (reset_counter) begin
         bus_state_counter <= '0;
-      end else begin
-        if (enable) begin
-          bus_state_counter <= bus_state_counter + 1'b1;
-        end else begin
-          bus_state_counter <= bus_state_counter;
-        end
+      end else if (count_enable) begin
+        bus_state_counter <= bus_state_counter + 1'b1;
       end
     end
   end

--- a/src/ctrl/controller_standby_i3c.sv
+++ b/src/ctrl/controller_standby_i3c.sv
@@ -648,7 +648,9 @@ module controller_standby_i3c
 
     .enable_i         (i3c_standby_en_i),
 
-    .restart_counter_i(ctrl_bus_i.stop_det || in_hdr_mode_o),
+    .bus_start_i      (ctrl_bus_i.start_det | ctrl_bus_i.rstart_det),
+    .bus_stop_i       (ctrl_bus_i.stop_det),
+    .in_hdr_mode_i    (in_hdr_mode_o),
 
     .t_bus_free_i     (t_bus_free_i),
     .t_bus_idle_i     (t_bus_idle_i),

--- a/src/rdl/docs/README.md
+++ b/src/rdl/docs/README.md
@@ -4297,7 +4297,7 @@ Part of data in the IBI queue is considered corrupted and will be discarded.
 
 #### T_FREE field
 
-
+<p>Time in clock cycles from STOP detection until Bus Free Condition (tBUF/tCAS). Configure based on System Clock.</p>
 
 ### T_AVAL_REG register
 
@@ -4311,7 +4311,7 @@ Part of data in the IBI queue is considered corrupted and will be discarded.
 
 #### T_AVAL field
 
-
+<p>Time in clock cycles from STOP detection until Bus Available Condition (tAVAL). Configure based on System Clock. NOTE: I3C spec v1.1.1 Figure 24 shows the time from STOP, and 5.1.3.2.2 describes it as 'a period during which the Bus Free Condition is sustained continuously for a duration of at least tAVAL.' The timer starts at a bus STOP condition and FW can take into account the tBUF if needed.</p>
 
 ### T_IDLE_REG register
 
@@ -4325,7 +4325,7 @@ Part of data in the IBI queue is considered corrupted and will be discarded.
 
 #### T_IDLE field
 
-
+<p>Time in clock cycles from STOP detection until Bus Idle Condition (tIDLE). Configure based on System Clock</p>
 
 ## CtrlCfg register file
 

--- a/src/rdl/soc_management_interface.rdl
+++ b/src/rdl/soc_management_interface.rdl
@@ -361,7 +361,7 @@ regfile SoCManagementInterfaceRegisters{
         name = "";
         field {
             name = "";
-            desc = "";
+            desc = "Time in clock cycles from STOP detection until Bus Free Condition (tBUF/tCAS). Configure based on System Clock.";
             sw = rw;
             hw = r;
             reset = 32'h0000000C;
@@ -371,7 +371,7 @@ regfile SoCManagementInterfaceRegisters{
         name = "";
         field {
             name = "";
-            desc = "";
+            desc = "Time in clock cycles from STOP detection until Bus Available Condition (tAVAL). Configure based on System Clock. NOTE: I3C spec v1.1.1 Figure 24 shows the time from STOP, and 5.1.3.2.2 describes it as 'a period during which the Bus Free Condition is sustained continuously for a duration of at least tAVAL.' The timer starts at a bus STOP condition and FW can take into account the tBUF if needed.";
             sw = rw;
             hw = r;
             reset = 32'h00000012C;
@@ -381,7 +381,7 @@ regfile SoCManagementInterfaceRegisters{
         name = "";
         field {
             name = "";
-            desc = "";
+            desc = "Time in clock cycles from STOP detection until Bus Idle Condition (tIDLE). Configure based on System Clock";
             sw = rw;
             hw = r;
             reset = 32'h0000EA60;

--- a/verification/cocotb/block/ctrl_bus_timers/test_bus_timers.py
+++ b/verification/cocotb/block/ctrl_bus_timers/test_bus_timers.py
@@ -18,7 +18,9 @@ async def setup(dut):
     dut.t_bus_free_i.value = 5
     dut.t_bus_available_i.value = 10
     dut.t_bus_idle_i.value = 50
-    dut.restart_counter_i.value = 0
+    dut.bus_start_i.value = 0
+    dut.bus_stop_i.value = 0
+    dut.in_hdr_mode_i.value = 0
     await ClockCycles(dut.clk_i, 10)
 
 
@@ -41,7 +43,8 @@ async def test_bus_timers(dut: SimHandleBase):
     dut.enable_i.value = 1
 
     for _ in range(3):
-        await cycle(dut.clk_i, dut.restart_counter_i)
+        # Pulse bus_stop_i to start counting (simulates STOP condition)
+        await cycle(dut.clk_i, dut.bus_stop_i)
         await ClockCycles(dut.clk_i, 1)
         assert dut.bus_free_o.value == 0
         assert dut.bus_available_o.value == 0
@@ -50,3 +53,5 @@ async def test_bus_timers(dut: SimHandleBase):
         assert dut.bus_free_o.value == 1
         assert dut.bus_available_o.value == 1
         assert dut.bus_idle_o.value == 1
+        # Pulse bus_start_i to reset (simulates START condition)
+        await cycle(dut.clk_i, dut.bus_start_i)

--- a/verification/cocotb/top/lib_i3c_top/test_i3c_target.py
+++ b/verification/cocotb/top/lib_i3c_top/test_i3c_target.py
@@ -6,6 +6,7 @@ from math import ceil
 
 from boot import boot_init
 from bus2csr import dword2int, int2dword
+from ccc import CCC
 from i3c_controller_fixed import I3cControllerFixed as I3cController
 from cocotbext_i3c.i3c_target import I3CTarget
 from interface import I3CTopTestInterface
@@ -435,6 +436,9 @@ async def test_i3c_target_ibi(dut):
     # Enable IBI ACK-ing
     i3c_controller.enable_ibi(True)
 
+    # Send a broadcast CCC to initialize bus timers (need STOP to start counting)
+    await i3c_controller.i3c_ccc_write(ccc=CCC.BCAST.RSTDAA)
+
     # Write descriptor to the TTI IBI queue. No IBI data
     mdb = 0xAA
     data = []
@@ -530,6 +534,9 @@ async def test_i3c_target_ibi_retry(dut):
 
     result = True
 
+    # Send a broadcast CCC to initialize bus timers (need STOP to start counting)
+    await i3c_controller.i3c_ccc_write(ccc=CCC.BCAST.RSTDAA)
+
     # Disable IBI ACK-ing
     i3c_controller.enable_ibi(False)
 
@@ -603,6 +610,9 @@ async def test_i3c_target_ibi_data(dut):
     target.set_bcr_fields(ibi_req_capable=True, ibi_payload=True)
 
     result = True
+
+    # Send a broadcast CCC to initialize bus timers (need STOP to start counting)
+    await i3c_controller.i3c_ccc_write(ccc=CCC.BCAST.RSTDAA)
 
     # Limit IBI data count that the controller can accept
     i3c_controller.set_max_ibi_data_len(6)

--- a/verification/cocotb/top/lib_i3c_top/test_interrupts.py
+++ b/verification/cocotb/top/lib_i3c_top/test_interrupts.py
@@ -5,6 +5,7 @@ import random
 
 from boot import boot_init
 from bus2csr import dword2int, int2dword
+from ccc import CCC
 from i3c_controller_fixed import I3cControllerFixed as I3cController
 from cocotbext_i3c.i3c_target import I3CTarget
 from interface import I3CTopTestInterface
@@ -28,7 +29,7 @@ async def timeout_task(timeout_us):
     raise TimeoutError("Timeout!")
 
 
-async def test_setup(dut, timeout_us=50):
+async def test_setup(dut, timeout_us=25):
     """
     Sets up controller, target models and top-level core interface
     """
@@ -178,6 +179,9 @@ async def test_ibi_done(dut):
 
     # Enable IBI ACK-ing
     i3c_controller.enable_ibi(True)
+
+    # Send a broadcast CCC to initialize bus timers (need STOP to start counting)
+    await i3c_controller.i3c_ccc_write(ccc=CCC.BCAST.RSTDAA)
 
     # Enable the interrupt
     csr = tb.reg_map.I3C_EC.TTI.INTERRUPT_ENABLE


### PR DESCRIPTION
- Properly start and stop based on the bus_start/stop conditions
- Properly disable timers when we are in hdr mode
- Add better descriptions to the bus_free/idle/available CSRs