### PR TITLE
Coverage improvements

### DIFF
--- a/src/hci/csri.sv
+++ b/src/hci/csri.sv
@@ -103,6 +103,7 @@ module csri
 
   // Update Standby Controller mode based on the controller configuration status
   always_comb begin : wire_hwif_rstact
+    hwif_in.I3C_EC.StdbyCtrlMode.STBY_CR_CCC_CONFIG_RSTACT_PARAMS.RST_ACTION.we = rst_action_valid_i;
     hwif_in.I3C_EC.StdbyCtrlMode.STBY_CR_CCC_CONFIG_RSTACT_PARAMS.RST_ACTION.next = rst_action_valid_i ? rst_action_i : '0;
   end
 
@@ -176,7 +177,6 @@ module csri
   always_comb begin : wire_unconnected_regs
     hwif_in.I3C_EC.StdbyCtrlMode.STBY_CR_VIRT_DEVICE_ADDR.VIRT_STATIC_ADDR_VALID.next = '0;
     hwif_in.I3C_EC.StdbyCtrlMode.__rsvd_3.__rsvd.next = '0;
-    hwif_in.I3C_EC.StdbyCtrlMode.STBY_CR_CCC_CONFIG_RSTACT_PARAMS.RST_ACTION.we = '0;
     hwif_in.I3C_EC.StdbyCtrlMode.STBY_CR_INTR_SIGNAL_ENABLE.STBY_CR_OP_RSTACT_SIGNAL_EN.we = '0;
     hwif_in.I3C_EC.StdbyCtrlMode.STBY_CR_VIRT_DEVICE_ADDR.VIRT_STATIC_ADDR.next = '0;
     hwif_in.I3C_EC.CtrlCfg.CONTROLLER_CONFIG.OPERATION_MODE.next = '0;

--- a/src/i3c.sv
+++ b/src/i3c.sv
@@ -487,24 +487,6 @@ module i3c
   logic ctrl2phy_sda;
   logic ctrl_sel_od_pp;
 
-  // Configuration
-  logic phy_en;
-  logic [1:0] phy_mux_select;
-  logic i2c_active_en;
-  logic i2c_standby_en;
-  logic i3c_active_en;
-  logic i3c_standby_en;
-  logic [19:0] t_hd_dat;
-  logic [19:0] t_su_dat;
-  logic [19:0] t_r;
-  logic [19:0] t_f;
-  logic [19:0] t_bus_free;
-  logic [19:0] t_bus_idle;
-  logic [19:0] t_bus_available;
-  logic [31:0] stby_cr_device_addr_reg;
-  logic [31:0] stby_cr_device_char_reg;
-  logic [31:0] stby_cr_device_pid_lo_reg;
-
   // Interrupts
   logic ctl_irq;
   logic tti_irq;
@@ -912,10 +894,6 @@ module i3c
   logic                          csr_tti_rx_desc_reg_rst_we;
   logic                          csr_tti_rx_desc_reg_rst_data;
 
-  logic                          csr_tti_rx_desc_empty;
-  logic                          csr_tti_rx_desc_full;
-  logic                          csr_tti_rx_desc_write;
-
   // TTI TX Descriptor queue
   logic                          csr_tti_tx_desc_req;
   logic                          csr_tti_tx_desc_ack;
@@ -938,10 +916,6 @@ module i3c
   logic                          csr_tti_rx_data_reg_rst;
   logic                          csr_tti_rx_data_reg_rst_we;
   logic                          csr_tti_rx_data_reg_rst_data;
-
-  logic                          csr_tti_rx_data_empty;
-  logic                          csr_tti_rx_data_full;
-  logic                          csr_tti_rx_data_write;
 
   // TTI TX data queue
   logic                          csr_tti_tx_data_req;

--- a/verification/cocotb/block/bus_tx_flow/test_bus_tx_flow.py
+++ b/verification/cocotb/block/bus_tx_flow/test_bus_tx_flow.py
@@ -193,3 +193,23 @@ async def test_byte_tx_flow(dut):
         await ReadOnly()
         # Ensure that the bus is free
         assert dut.sda_o.value == 1
+
+
+@cocotb.test()
+async def test_both_reqs_at_once_error(dut):
+    await setup_test(dut)
+
+    # Issuing both a bit and a byte request at once
+    # should assert an error signal
+    dut.req_value_i.value = 0xAA
+    dut.req_bit_i.value = 1
+    dut.req_byte_i.value = 1
+
+    await RisingEdge(dut.clk_i)
+    assert dut.req_error_o == 1
+
+    dut.req_bit_i.value = 0
+    dut.req_byte_i.value = 0
+
+    await RisingEdge(dut.clk_i)
+    assert dut.req_error_o == 0

--- a/verification/cocotb/top/lib_i3c_top/test_bus_stall.py
+++ b/verification/cocotb/top/lib_i3c_top/test_bus_stall.py
@@ -8,6 +8,7 @@ from interface import I3CTopTestInterface
 
 import cocotb
 from cocotb.triggers import Timer
+from cocotb_helpers import reset_n
 
 TRANSACTION_COUNT = 1024
 
@@ -63,15 +64,18 @@ async def test_full_tx_desc_write(dut):
     tb = await initialize(dut)
     for _ in range(TRANSACTION_COUNT):
         await tb.write_csr(tb.reg_map.I3C_EC.TTI.TX_DESC_QUEUE_PORT.base_addr, int2dword(random.randint(0, 0xffffffff)), 4)
+    await reset_n(tb.clk, tb.rst_n, cycles=5)
 
 @cocotb.test()
 async def test_full_tx_data_write(dut):
     tb = await initialize(dut)
     for _ in range(TRANSACTION_COUNT):
         await tb.write_csr(tb.reg_map.I3C_EC.TTI.TX_DATA_PORT.base_addr, int2dword(random.randint(0, 0xffffffff)), 4)
+    await reset_n(tb.clk, tb.rst_n, cycles=5)
 
 @cocotb.test()
 async def test_full_ibi_write(dut):
     tb = await initialize(dut)
     for _ in range(TRANSACTION_COUNT):
         await tb.write_csr(tb.reg_map.I3C_EC.TTI.IBI_PORT.base_addr, int2dword(random.randint(0, 0xffffffff)), 4)
+    await reset_n(tb.clk, tb.rst_n, cycles=5)

--- a/verification/cocotb/top/lib_i3c_top/test_ccc.py
+++ b/verification/cocotb/top/lib_i3c_top/test_ccc.py
@@ -9,6 +9,7 @@ from ccc import CCC
 from cocotbext_i3c.common import I3cTargetResetAction
 from cocotbext_i3c.i3c_controller import I3cController
 from interface import I3CTopTestInterface
+from bus2csr import dword2int
 
 import cocotb
 from cocotb.triggers import ClockCycles
@@ -775,6 +776,11 @@ async def test_ccc_rstact(dut, type, rstact):
     await i3c_controller.send_target_reset_pattern()
     assert rst_action == int(sig)
     await i3c_controller.send_stop()
+
+    # Also test the value in RST_ACTION CSR
+    reg = tb.reg_map.I3C_EC.STDBYCTRLMODE.STBY_CR_CCC_CONFIG_RSTACT_PARAMS
+    rstact_csr = dword2int(await tb.read_csr(reg.base_addr, 4)) & reg.RST_ACTION.mask
+    assert (rstact_csr >> reg.RST_ACTION.low) == rst_action
 
     # Start new frame and reset target with reset action set to peripheral reset
     await i3c_controller.target_reset(reset_actions)

--- a/verification/cocotb/top/lib_i3c_top/test_ccc.py
+++ b/verification/cocotb/top/lib_i3c_top/test_ccc.py
@@ -762,20 +762,21 @@ async def test_ccc_rstact(dut, type, rstact):
         assert False, "Unsupported RSTACT type, must be 'broadcast' or 'direct'"
 
     # Send directed RSTACT
-    rst_action = 0xAA
-    await i3c_controller.i3c_ccc_write(
-        ccc=command,
-        defining_byte=rst_action,
-        directed_data=directed_data,
-        stop=False,
-    )
+    for byte in (0xAA, 0x55):
+        rst_action = byte
+        await i3c_controller.i3c_ccc_write(
+            ccc=command,
+            defining_byte=rst_action,
+            directed_data=directed_data,
+            stop=False,
+        )
 
-    # Check if reset action got stored correctly in the logic after Target Reset Pattern
-    sig = dut.xi3c_wrapper.i3c.xcontroller.xcontroller_standby.xcontroller_standby_i3c.rst_action_o
-    assert int(sig) == 0
-    await i3c_controller.send_target_reset_pattern()
-    assert rst_action == int(sig)
-    await i3c_controller.send_stop()
+        # Check if reset action got stored correctly in the logic after Target Reset Pattern
+        sig = dut.xi3c_wrapper.i3c.xcontroller.xcontroller_standby.xcontroller_standby_i3c.rst_action_o
+        assert int(sig) == 0
+        await i3c_controller.send_target_reset_pattern()
+        assert rst_action == int(sig)
+        await i3c_controller.send_stop()
 
     # Also test the value in RST_ACTION CSR
     reg = tb.reg_map.I3C_EC.STDBYCTRLMODE.STBY_CR_CCC_CONFIG_RSTACT_PARAMS

--- a/verification/cocotb/top/lib_i3c_top/test_ccc.py
+++ b/verification/cocotb/top/lib_i3c_top/test_ccc.py
@@ -678,9 +678,9 @@ async def test_ccc_setmwl_direct(dut):
     i3c_controller, _, tb = await test_setup(dut)
 
     # Send direct SETMWL
-    mwl_msb = 0xAB
-    mwl_lsb = 0xCD
-    await i3c_controller.i3c_ccc_write(ccc=command, directed_data=[(TGT_ADR, [mwl_msb, mwl_lsb])])
+    for test_byte in (0x55, 0xAA):
+        mwl_msb = mwl_lsb = test_byte
+        await i3c_controller.i3c_ccc_write(ccc=command, directed_data=[(TGT_ADR, [mwl_msb, mwl_lsb])])
 
     # Check if MWL got written
     sig = dut.xi3c_wrapper.i3c.xcontroller.xconfiguration.get_mwl_o.value
@@ -696,14 +696,16 @@ async def test_ccc_setmrl_direct(dut):
     i3c_controller, _, tb = await test_setup(dut)
 
     # Send direct SETMRL
-    mrl_msb = 0xAB
-    mrl_lsb = 0xCD
-    await i3c_controller.i3c_ccc_write(ccc=command, directed_data=[(TGT_ADR, [mrl_msb, mrl_lsb])])
+    for test_byte in (0x55, 0xAA):
+        mrl_msb = mrl_lsb = ibil = test_byte
+        await i3c_controller.i3c_ccc_write(ccc=command, directed_data=[(TGT_ADR, [mrl_msb, mrl_lsb, ibil])])
 
     # Check if MRL got written
-    sig = dut.xi3c_wrapper.i3c.xcontroller.xconfiguration.get_mrl_o.value
+    sig_mrl = dut.xi3c_wrapper.i3c.xcontroller.xconfiguration.get_mrl_o.value
+    sig_ibil = dut.xi3c_wrapper.i3c.xcontroller.xconfiguration.get_ibil_o.value
     mrl = (mrl_msb << 8) | mrl_lsb
-    assert mrl == int(sig)
+    assert mrl == int(sig_mrl)
+    assert sig_ibil == ibil
 
 
 @cocotb.test()

--- a/verification/cocotb/top/lib_i3c_top/test_i3c_target.py
+++ b/verification/cocotb/top/lib_i3c_top/test_i3c_target.py
@@ -112,10 +112,7 @@ async def test_setup(dut, fclk=333.0, fbus=12.5, verify_boot=True,
     return i3c_controller, i3c_target, tb
 
 
-@cocotb_test()
-async def test_i3c_target_write(dut):
-
-    test_data = [[0xAA, 0x00, 0xBB, 0xCC, 0xDD], [0xDE, 0xAD, 0xBA, 0xBE]]
+async def base_test_i3c_target_write(dut, test_data):
     recv_data = []
 
     # Setup
@@ -199,6 +196,25 @@ async def test_i3c_target_write(dut):
         )
     )
     assert test_data == recv_data
+
+
+@cocotb_test()
+async def test_i3c_target_write(dut):
+    await base_test_i3c_target_write(dut, [
+        [0xAA, 0x00, 0xBB, 0xCC, 0xDD], [0xDE, 0xAD, 0xBA, 0xBE]
+    ])
+
+
+@cocotb_test(timeout=50000)
+async def test_i3c_target_write_255(dut):
+    # to cover RX descriptor (data length) [7:0]
+    await base_test_i3c_target_write(dut, [[0xAA] * 255])
+
+
+@cocotb_test(timeout=50000)
+async def test_i3c_target_write_256(dut):
+    # to cover RX descriptor (data length) [8]
+    await base_test_i3c_target_write(dut, [[0x55] * 256])
 
 
 @cocotb_test()

--- a/verification/waivers/exclusion.yaml
+++ b/verification/waivers/exclusion.yaml
@@ -279,6 +279,13 @@ Constant value in RO register or set by the verilog parameter:
       - TX_DESC_QUEUE_PORT.wr_biten.TX_DESC
       - EXTCAP_HEADER.CAP_LENGTH.value
       - EXTCAP_HEADER.CAP_ID.value
+      - INTERRUPT_STATUS.TRANSFER_ERR_STAT.value
+      - INTERRUPT_STATUS.TRANSFER_ABORT_STAT.value
+      - INTERRUPT_STATUS.IBI_THLD_STAT.value
+      - INTERRUPT_STATUS.TX_DESC_THLD_STAT.value
+      - INTERRUPT_STATUS.TX_DATA_THLD_STAT.value
+      - INTERRUPT_STATUS.TX_DESC_TIMEOUT.value
+      - INTERRUPT_STATUS.RX_DESC_TIMEOUT.value
     - hwif_rec_in:
       - INDIRECT_FIFO_STATUS_3.FIFO_SIZE.we
       - INDIRECT_FIFO_STATUS_3.FIFO_SIZE.next
@@ -287,6 +294,7 @@ Constant value in RO register or set by the verilog parameter:
       - DEVICE_STATUS_0.REC_REASON_CODE.we
       - DEVICE_STATUS_0.REC_REASON_CODE.next
       - DEVICE_STATUS_0.PROT_ERROR.next [7:3]
+      - DEVICE_STATUS_0.PROT_ERROR.next [1:0]   # Only 2 status values are implemented
       - DEVICE_STATUS_0.DEV_STATUS.we
       - DEVICE_STATUS_0.DEV_STATUS.next
     - hwif_rec_out:
@@ -308,6 +316,7 @@ Constant value in RO register or set by the verilog parameter:
       - EXTCAP_HEADER.CAP_LENGTH.value
       - EXTCAP_HEADER.CAP_ID.value
     - hwif_out.I3C_EC:
+      - CtrlCfg.CONTROLLER_CONFIG.OPERATION_MODE.value
       - TTI:
         - IBI_QUEUE_SIZE.IBI_QUEUE_SIZE.value
         - IBI_PORT.wr_biten.IBI_DATA # 32 bit accesses keep this value constant
@@ -703,7 +712,32 @@ Tied off signals:
     - s_cpuif_wr_err      # RDL code doesn't generate access errors
     - i3c_scl_o           # Target mode only
     - s_cpuif_addr [1:0]  # CSR addresses are aligned to 4 bytes
+    - ctrl2phy_scl        # Not used in target only configurations
+    - unused_err                      # Tied to 0
+    - csr_tti_ibi_reg_rst_data        # Tied to 0
+    - csr_tti_tx_data_reg_rst_data    # Tied to 0
+    - csr_tti_rx_data_reg_rst_data    # Tied to 0
+    - csr_tti_tx_desc_reg_rst_data    # Tied to 0
+    - csr_tti_rx_desc_reg_rst_data    # Tied to 0
+    - recovery_irq                    # Tied to 0
+    - ctl_irq                         # Tied to 0
+    - tti_tx_host_nack                # Resolves to 0 in all combinatorial paths
+    - csr_tti_rx_desc_data [31:29]    # Reserved upper 3 bits of the RX descriptor ERROR field
+    - tti_rx_desc_wdata    [31:29]    # Reserved upper 3 bits of the RX descriptor ERROR field
+    - csr_tti_rx_desc_data [27:16]    # Meaningless bits
+    - tti_rx_desc_wdata    [27:16]    # Meaningless bits
+    - csr_tti_rx_desc_data [15:9]     # Unachievable RX descriptor DATA_LENGTH field values
+    - tti_rx_desc_wdata    [15:9]     # Unachievable RX descriptor DATA_LENGTH field values
+    - tti_rx_desc_ready_thld [7:6]       # Unused in 64 FIFO depth configurations
+    - csr_tti_rx_desc_ready_thld_o [7:6] # Unused in 64 FIFO depth configurations
+    - tti_tx_desc_ready_thld [7:6]       # Unused in 64 FIFO depth configurations
+    - csr_tti_tx_desc_ready_thld_o [7:6] # Unused in 64 FIFO depth configurations
     - hwif_tti_in:
+      - RX_DESC_QUEUE_PORT.rd_data.RX_DESC [31:29]
+      - RX_DESC_QUEUE_PORT.rd_data.RX_DESC [27:16]
+      - RX_DESC_QUEUE_PORT.rd_data.RX_DESC [15:9]
+      - QUEUE_THLD_CTRL.RX_DESC_THLD.next [7:6]
+      - QUEUE_THLD_CTRL.TX_DESC_THLD.next [7:6]
       - QUEUE_THLD_CTRL.IBI_THLD.we
       - QUEUE_THLD_CTRL.IBI_THLD.next
       - INTERRUPT_STATUS.TRANSFER_ERR_STAT.we

--- a/verification/waivers/exclusion.yaml
+++ b/verification/waivers/exclusion.yaml
@@ -21,13 +21,22 @@ Constant value in RO register or set by the verilog parameter:
         - DEVICE_STATUS_0.REC_REASON_CODE.we
         - DEVICE_STATUS_0.REC_REASON_CODE.next
         - DEVICE_STATUS_0.PROT_ERROR.next [7:3]
+        - DEVICE_STATUS_0.PROT_ERROR.next [1:0]
         - DEVICE_STATUS_0.DEV_STATUS.we
         - DEVICE_STATUS_0.DEV_STATUS.next
     - hwif_out.I3C_EC:
       - CtrlCfg.CONTROLLER_CONFIG.OPERATION_MODE.value
-      - TTI.IBI_QUEUE_SIZE.IBI_QUEUE_SIZE.value
-      - TTI.EXTCAP_HEADER.CAP_LENGTH.value
-      - TTI.EXTCAP_HEADER.CAP_ID.value
+      - TTI:
+        - IBI_QUEUE_SIZE.IBI_QUEUE_SIZE.value
+        - EXTCAP_HEADER.CAP_LENGTH.value
+        - EXTCAP_HEADER.CAP_ID.value
+        - INTERRUPT_STATUS.TRANSFER_ERR_STAT.value
+        - INTERRUPT_STATUS.TRANSFER_ABORT_STAT.value
+        - INTERRUPT_STATUS.IBI_THLD_STAT.value
+        - INTERRUPT_STATUS.TX_DESC_THLD_STAT.value
+        - INTERRUPT_STATUS.TX_DATA_THLD_STAT.value
+        - INTERRUPT_STATUS.TX_DESC_TIMEOUT.value
+        - INTERRUPT_STATUS.RX_DESC_TIMEOUT.value
       - SecFwRecoveryIf:
         - INDIRECT_FIFO_STATUS_4.MAX_TRANSFER_SIZE.value
         - INDIRECT_FIFO_STATUS_3.FIFO_SIZE.value
@@ -56,6 +65,14 @@ Constant value in RO register or set by the verilog parameter:
         - INDIRECT_FIFO_STATUS_0.REGION_TYPE.next
     - field_storage.I3C_EC:
       - CtrlCfg.CONTROLLER_CONFIG.OPERATION_MODE.value
+      - TTI:
+        - INTERRUPT_STATUS.TRANSFER_ERR_STAT.value
+        - INTERRUPT_STATUS.TRANSFER_ABORT_STAT.value
+        - INTERRUPT_STATUS.IBI_THLD_STAT.value
+        - INTERRUPT_STATUS.TX_DESC_THLD_STAT.value
+        - INTERRUPT_STATUS.TX_DATA_THLD_STAT.value
+        - INTERRUPT_STATUS.TX_DESC_TIMEOUT.value
+        - INTERRUPT_STATUS.RX_DESC_TIMEOUT.value
       - SecFwRecoveryIf:
         - INDIRECT_FIFO_STATUS_3.FIFO_SIZE.value
         - INDIRECT_FIFO_STATUS_2.READ_INDEX.value [31:6]
@@ -506,6 +523,12 @@ Constant value in RO register or set by the verilog parameter:
 Tied off signals:
   signals:
   - MODULE=I3CCSR:
+    - s_cpuif_rd_err      # RDL code doesn't generate access errors
+    - s_cpuif_wr_err      # RDL code doesn't generate access errors
+    - s_cpuif_addr [1:0]  # CSR addresses are aligned to 4 bytes
+    - cpuif_rd_err        # RDL code doesn't generate access errors
+    - cpuif_wr_err        # RDL code doesn't generate access errors
+    - cpuif_addr [1:0]    # CSR addresses are aligned to 4 bytes
     - hwif_in.I3C_EC.SecFwRecoveryIf:
       - INDIRECT_FIFO_STATUS_0.REGION_TYPE.we
       - INDIRECT_FIFO_STATUS_0.REGION_TYPE.next
@@ -716,6 +739,8 @@ Tied off signals:
     - awsize_i [2]        # Data width is only 32-bit
     - rresp_o [0]         # Neither EXOKAY nor DECERR are issued
     - bresp_o [0]         # Neither EXOKAY nor DECERR are issued
+    - scl_oe              # Tied to 0
+    - scl_o               # Target mode only
   - MODULE=i3c:
     - araddr_i [1:0]      # CSR addresses are aligned to 4 bytes
     - awaddr_i [1:0]      # CSR addresses are aligned to 4 bytes
@@ -1005,13 +1030,17 @@ Tied off signals:
     - daa_unique_response [48] # PID[32]
     - bus.sda.stable_low       # Unused
   - MODULE=configuration:
-    - phy_en_o
-    - i2c_active_en_o
-    - i2c_standby_en_o
-    - get_status_fmt1_o [15:8]
-    - get_status_fmt1_o [7:6]
-    - get_status_fmt1_o [4]
-    - pid_o           [32]
-    - virtual_pid_o   [32]
-    - daa_unique_response [48] # PID[32]
-    - bus_enable
+    - phy_en_o                    # Tied to 1 in target-only configs
+    - i2c_active_en_o             # Tied to 0
+    - i2c_standby_en_o            # Tied to 0
+    - get_status_fmt1_o   [15:8]
+    - get_status_fmt1_o   [7:6]
+    - get_status_fmt1_o   [4]
+    - pid_o               [32]
+    - virtual_pid_o       [32]
+    - daa_unique_response [48]    # PID[32]
+    - bus_enable                  # Tied to 1 in target-only configs
+  - MODULE=controller_standby_i3c:
+    - bus_timeout                 # Tied to 0
+    - ibi_bus_tx_req_err          # Tied to 0, commented out in always_comb?
+    - ibi_bus_tx_idle             # Tied to 0, commented out in always_comb?

--- a/verification/waivers/exclusion.yaml
+++ b/verification/waivers/exclusion.yaml
@@ -519,6 +519,12 @@ Constant value in RO register or set by the verilog parameter:
     - target_hot_join_addr_o # I3C spec defines this value to be constant 'h02
     - mwl_dword
     - mrl_dword
+  - MODULE=controller_standby:
+    - target_hot_join_addr_i # I3C spec defines this value to be constant 'h02
+  - MODULE=controller_standby_i3c:
+    - target_hot_join_addr_i # I3C spec defines this value to be constant 'h02
+  - MODULE=controller_standby_i2c:
+    - target_hot_join_addr_i # I3C spec defines this value to be constant 'h02
 
 Tied off signals:
   signals:
@@ -1040,7 +1046,74 @@ Tied off signals:
     - virtual_pid_o       [32]
     - daa_unique_response [48]    # PID[32]
     - bus_enable                  # Tied to 1 in target-only configs
+    - target_hot_join_addr_o
+  - MODULE=controller_standby:
+    - rx_desc_queue_ready_thld_i [7:6] # Unused in 64 FIFO depth configurations
+    - tx_desc_queue_ready_thld_i [7:6] # Unused in 64 FIFO depth configurations
+    - rx_desc_queue_wdata_o [31:29]    # Reserved upper 3 bits of the RX descriptor ERROR field
+    - rx_desc_queue_wdata_o [27:16]    # Meaningless bits
+    - rx_desc_queue_wdata_o [15:9]     # Unachievable RX descriptor DATA_LENGTH field values
+    - phy_en_i                         # Tied to 1 in target-only
+    - i2c_active_en_i                  # Tied to 0
+    - i2c_standby_en_i                 # Tied to 0
+    - get_status_fmt1_i [15:8]         # Tied to 0
+    - get_status_fmt1_i [7:6]          # Tied to 1
+    - get_status_fmt1_i [4]            # Tied to 0; Reserved
+    - pid_i [32]                       # Tied to 0
+    - virtual_pid_i [32]               # Tied to 0
+    - daa_unique_response_i [48]       # PID[32]
   - MODULE=controller_standby_i3c:
+    - ctrl_bus_i.sda.stable_low   # Tied to 0, unused
+    - ctrl_scl_o                  # Tied to 1
+    - rx_desc_queue_wdata_o [31:29] # Reserved upper 3 bits of the RX descriptor ERROR field
+    - rx_desc_queue_wdata_o [27:16] # Meaningless bits
+    - rx_desc_queue_wdata_o [15:9]  # Unachievable RX descriptor DATA_LENGTH field values
+    - get_status_fmt1_o   [15:8]  # Tied to 0
+    - get_status_fmt1_o   [7:6]   # Tied to 1
+    - get_status_fmt1_o   [4]     # Tied to 0; Reserved
+    - pid_i [32]                  # Tied to 0
+    - virtual_pid_i [32]          # Tied to 0
+    - daa_unique_response_i [48]  # PID[32]
+    - tx_host_nack_o              # Tied to 0, only assigned 0 in always_comb
     - bus_timeout                 # Tied to 0
     - ibi_bus_tx_req_err          # Tied to 0, commented out in always_comb?
     - ibi_bus_tx_idle             # Tied to 0, commented out in always_comb?
+    - bus_error                   # Tied to 0
+    - fsm_bus_tx_sel_od_pp        # Tied to 0, is TODO, unimplemented yet (od/pp)
+    - ibi_bus_rx_req_byte         # Tied to 0, only assigned 0 in always_comb
+    - ibi_bus_rx_data [7:1]       # IBI only requests a bit => tied to 0
+    - tx_host_nack                # Tied to 0, only assigned 0 in always_comb
+    - event_cmd_complete          # Tied to 0, is TODO, unimplemented yet (events)
+    - event_unexp_stop            # Tied to 0, is TODO, unimplemented yet (events)
+    - event_tx_arbitration_lost   # Tied to 0, is TODO, unimplemented yet (events)
+    - event_tx_bus_timeout        # Tied to 0, is TODO, unimplemented yet (events)
+    - event_read_cmd_received     # Tied to 0, is TODO, unimplemented yet (events)
+    - is_hotjoin_done             # Tied to 0
+    - entas0                      # Tied to 0, is TODO, unimplemented yet (ENTAS0 CCC)
+    - entas1                      # Tied to 0, is TODO, unimplemented yet (ENTAS1 CCC)
+    - entas2                      # Tied to 0, is TODO, unimplemented yet (ENTAS2 CCC)
+    - entas3                      # Tied to 0, is TODO, unimplemented yet (ENTAS3 CCC)
+    - ent_tm                      # Tied to 0, is TODO, unimplemented yet (ENTTM CCC)
+    - tm                          # Tied to 0, is TODO, unimplemented yet (ENTTM CCC)
+    - set_brgtgt                  # Tied to 0, is TODO, unimplemented yet (SETBRGTGT CCC)
+    - get_acccr                   # Tied to 0
+    - get_mxds                    # Tied to 0
+  - MODULE=controller_standby_i2c:
+    - phy_sel_od_pp_o             # Tied to 0, is TODO
+    - rx_desc_queue_ready_thld_i [7:6] # Unused in 64 FIFO depth configurations
+    - tx_desc_queue_ready_thld_i [7:6] # Unused in 64 FIFO depth configurations
+    - rx_desc_queue_wdata_o [31:29]    # Reserved upper 3 bits of the RX descriptor ERROR field
+    - rx_desc_queue_wdata_o [27:16]    # Meaningless bits
+    - rx_desc_queue_wdata_o [15:9]     # Unachievable RX descriptor DATA_LENGTH field values
+    - bus_start_o                 # Tied to 0, is TODO, make i2c fsm report start/stop condition
+    - bus_rstart_o                # Tied to 0, is TODO, make i2c fsm report start/stop condition
+    - bus_stop_o                  # Tied to 0, is TODO, make i2c fsm report start/stop condition
+    - bus_addr_o                  # Tied to 0, is TODO, make i2c fsm output address
+    - bus_addr_valid_o            # Tied to 0, is TODO, make i2c fsm output address
+    - tx_host_nack_o              # Tied to 0, is TODO, detect host NACKs and expose
+    - i2c_active_en_i             # Tied to 0
+    - i2c_standby_en_i            # Tied to 0
+    - phy_en_i                    # Tied to 1 in target-only configs
+    - pid_i [32]                       # Tied to 0
+    - virtual_pid_i [32]               # Tied to 0
+    - daa_unique_response_i [48]       # PID[32]

--- a/verification/waivers/exclusion.yaml
+++ b/verification/waivers/exclusion.yaml
@@ -705,9 +705,28 @@ Tied off signals:
       - PROT_CAP_2.AGENT_CAPS.next
       - PROT_CAP_2.REC_PROT_VERSION.we
       - PROT_CAP_2.REC_PROT_VERSION.next
+  - MODULE=i3c_wrapper:
+    - araddr_i [1:0]      # CSR addresses are aligned to 4 bytes
+    - awaddr_i [1:0]      # CSR addresses are aligned to 4 bytes
+    - araddr_i [11:10]    # High address bits not used in target only configs
+    - awaddr_i [11:10]    # High address bits not used in target only configs
+    - buser_o             # BUSER is unimplemented (tied to 0)
+    - ruser_o             # RUSER is unimplemented (tied to 0)
+    - arsize_i [2]        # Data width is only 32-bit
+    - awsize_i [2]        # Data width is only 32-bit
+    - rresp_o [0]         # Neither EXOKAY nor DECERR are issued
+    - bresp_o [0]         # Neither EXOKAY nor DECERR are issued
   - MODULE=i3c:
     - araddr_i [1:0]      # CSR addresses are aligned to 4 bytes
     - awaddr_i [1:0]      # CSR addresses are aligned to 4 bytes
+    - araddr_i [11:10]    # High address bits not used in target only configs
+    - awaddr_i [11:10]    # High address bits not used in target only configs
+    - buser_o             # BUSER is unimplemented (tied to 0)
+    - ruser_o             # RUSER is unimplemented (tied to 0)
+    - arsize_i [2]        # Data width is only 32-bit
+    - awsize_i [2]        # Data width is only 32-bit
+    - rresp_o [0]         # Neither EXOKAY nor DECERR are issued
+    - bresp_o [0]         # Neither EXOKAY nor DECERR are issued
     - s_cpuif_rd_err      # RDL code doesn't generate access errors
     - s_cpuif_wr_err      # RDL code doesn't generate access errors
     - i3c_scl_o           # Target mode only


### PR DESCRIPTION
This pull request adds new tests, removes unused signals and waives constant ones.
It also adds more comments to some already existing waivers.

New tests breakdown:
* test_interrupts.py:
    * test_rx_desc_overflow - checks RX descriptor overflow interrupt condition
* test_i3c_target.py:
    * test_i3c_target_write_255 - covers RX descriptor's bits from 0 to 7
    * test_i3c_target_write_256 - covers RX descriptor's 8th bit
* test_enter_exit_hdr_mode.py:
    * test_cycle_all_hdr_modes - sends CCCs ENTHDR0 through ENTHDR7 followed by HDR exit, covers all ent_hdr_x_o signals
* test_csr_access.py
    * test_basic_burst_read - exercises AXI CSR adapter's read path with more complex transactions
    * test_basic_burst_write - exercises AXI CSR adapter's write path with more complex transactions
* test_ccc.py:
    * test_ccc_setmwl_direct - changed mwl and mrl values to better cover all signals
    * test_ccc_rstact - changed test to toggle all bits in the register, also added reset_act CSR readout and compare step
* test_bus_tx_flow.py:
    * test_both_reqs_at_once_error - creates error condition and checks that error signal is raised