### PR TITLE
Fix RX_DESC interrupt, fix T-Bit perrity error with PEC byte, fix AXI hang when recovery_pending

### DIFF
--- a/src/ctrl/descriptor_rx.sv
+++ b/src/ctrl/descriptor_rx.sv
@@ -51,11 +51,9 @@ module descriptor_rx #(
 
   logic [31:0] rx_descriptor;
   logic [15:0] byte_counter;
-  logic [15:0] byte_counter_q;
   logic [3:0] rx_error;
 
   logic transfer_ended;
-  logic transfer_ended_q;
 
   assign transfer_ended = rx_byte_last_i;
 
@@ -75,17 +73,11 @@ module descriptor_rx #(
 
   always_ff @(posedge clk_i or negedge rst_ni) begin : proc_error
     if (!rst_ni) begin
-      byte_counter_q <= '0;
-      transfer_ended_q <= '0;
       rx_error <= '0;
     end else begin
-      transfer_ended_q <= transfer_ended;
-      if (transfer_ended) begin
-        byte_counter_q <= byte_counter;
-      end
       if (rx_byte_err_i)
           rx_error <= 4'b0001;
-      else if (transfer_ended_q)
+      else if (transfer_ended)
           rx_error <= 4'b0000;
     end
   end
@@ -94,9 +86,11 @@ module descriptor_rx #(
   assign rx_byte_ready_o = tti_rx_queue_wready_i;
   assign tti_rx_queue_wdata_o = rx_byte_i;
 
-  assign rx_descriptor = {rx_error, {12{1'b0}}, byte_counter_q};
+  // Build descriptor combinationally: byte_counter is still valid during the
+  // transfer_ended cycle (before the clock edge resets it to 0)
+  assign rx_descriptor = {rx_error, {12{1'b0}}, byte_counter};
   assign tti_rx_desc_queue_wdata_o = rx_descriptor;
-  assign tti_rx_desc_queue_wvalid_o = transfer_ended_q;
-  assign tti_rx_queue_flush_o = transfer_ended_q;
+  assign tti_rx_desc_queue_wvalid_o = transfer_ended;
+  assign tti_rx_queue_flush_o = transfer_ended;
 
 endmodule

--- a/src/recovery/recovery_handler.sv
+++ b/src/recovery/recovery_handler.sv
@@ -470,13 +470,7 @@ module recovery_handler
   // - ctl_bus_addr_valid_q: For posedge detection of address valid
   // - ctl_bus_addr_valid_posedge_q: Delayed posedge aligned with virtual_device_sel_i
   //
-  // FUTUREFIX: The descriptor_rx module sends tti_rx_queue_flush 1 cycle after the
-  // transfer ends (transfer_ended_q). However, virtual_device_sel_i goes low on
-  // the same cycle that transfer_ended fires, causing recovery_pending to
-  // deassert before the flush arrives. This creates a race where the mux
-  // selects descriptor_rx's flush instead of recovery's, corrupting the FIFO.
-  // Extending virtual_device_sel_i by 1 cycle ensures recovery_pending stays
-  // high to block the spurious flush from descriptor_rx.
+  // The flush race is resolved in descriptor_rx (flush fires on transfer_ended cycle).
   //----------------------------------------------------------------------------
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
@@ -724,23 +718,27 @@ module recovery_handler
   always_comb begin : R1MUX
     if (recovery_pending) begin
       tti_rx_desc_queue_wvalid                = '0;
-      ctl_tti_rx_desc_queue_full_o            = '0;
-      ctl_tti_rx_desc_queue_depth_o           = '0;
-      ctl_tti_rx_desc_queue_empty_o           = '0;
-      ctl_tti_rx_desc_queue_wready_o          = 1'b1;
+      ctl_tti_rx_desc_queue_empty_o           = 1'b1; // Need to hide empty to reject AXI reads
       csr_tti_rx_desc_queue_ready_thld_trig_o = '0;
+      
+      ctl_tti_rx_data_queue_empty_o           = 1'b1; // Need to hide empty to reject AXI reads
     end else begin
       tti_rx_desc_queue_wvalid                = ctl_tti_rx_desc_queue_wvalid_i;
-      ctl_tti_rx_desc_queue_full_o            = tti_rx_desc_queue_full;
-      ctl_tti_rx_desc_queue_depth_o           = tti_rx_desc_queue_depth;
       ctl_tti_rx_desc_queue_empty_o           = tti_rx_desc_queue_empty;
-      ctl_tti_rx_desc_queue_wready_o          = tti_rx_desc_queue_wready;
       csr_tti_rx_desc_queue_ready_thld_trig_o = tti_rx_desc_queue_ready_thld_trig;
+      
+      ctl_tti_rx_data_queue_empty_o           = tti_rx_data_queue_empty;
     end
 
-    tti_rx_desc_queue_wdata                   = ctl_tti_rx_desc_queue_wdata_i; // Don't mux data, disabling valid is enough
-  end
+    tti_rx_desc_queue_wdata                 = ctl_tti_rx_desc_queue_wdata_i; // Don't mux data, disabling valid is enough
+    
+    ctl_tti_rx_desc_queue_wready_o          = tti_rx_desc_queue_wready;
 
+    // Don't hide status of queue from status registers
+    ctl_tti_rx_desc_queue_full_o            = tti_rx_desc_queue_full;
+    ctl_tti_rx_desc_queue_depth_o           = tti_rx_desc_queue_depth;
+
+  end
   // Threshold
   assign ctl_tti_rx_desc_queue_ready_thld_o = tti_rx_desc_queue_ready_thld_o;
   assign ctl_tti_rx_desc_queue_ready_thld_trig_o = tti_rx_desc_queue_ready_thld_trig;
@@ -786,9 +784,6 @@ module recovery_handler
       recv_tti_rx_data_valid                  = ctl_tti_rx_data_queue_wvalid_i;
       tti_rx_data_queue_wvalid                = '0;
       tti_rx_data_queue_flush                 = recv_tti_rx_data_queue_flush;
-      ctl_tti_rx_data_queue_full_o            = tti_rx_data_queue_full;
-      ctl_tti_rx_data_queue_depth_o           = tti_rx_data_queue_depth;
-      ctl_tti_rx_data_queue_empty_o           = tti_rx_data_queue_empty;
       ctl_tti_rx_data_queue_wready_o          = recv_tti_rx_data_ready;
       ctl_tti_rx_data_queue_start_thld_trig_o = '0;
       csr_tti_rx_data_queue_ready_thld_trig_o = '0;
@@ -797,9 +792,6 @@ module recovery_handler
       recv_tti_rx_data_valid                  = '0;
       tti_rx_data_queue_wvalid                = ctl_tti_rx_data_queue_wvalid_i;
       tti_rx_data_queue_flush                 = ctl_tti_rx_data_queue_flush_i;
-      ctl_tti_rx_data_queue_full_o            = tti_rx_data_queue_full;
-      ctl_tti_rx_data_queue_depth_o           = tti_rx_data_queue_depth;
-      ctl_tti_rx_data_queue_empty_o           = tti_rx_data_queue_empty;
       ctl_tti_rx_data_queue_wready_o          = tti_rx_data_queue_wready;
       ctl_tti_rx_data_queue_start_thld_trig_o = tti_rx_data_queue_start_thld_trig;
       csr_tti_rx_data_queue_ready_thld_trig_o = tti_rx_data_queue_ready_thld_trig;
@@ -808,6 +800,10 @@ module recovery_handler
     tti_rx_data_queue_wdata                   = ctl_tti_rx_data_queue_wdata_i; // Don't mux data, disabling valid is enough
     recv_tti_rx_data_data = ctl_tti_rx_data_queue_wdata_i;
     recv_tti_rx_data_last = ctl_tti_rx_data_queue_wlast_i;
+
+    // Don't hide status of queue from status registers
+    ctl_tti_rx_data_queue_full_o            = tti_rx_data_queue_full;
+    ctl_tti_rx_data_queue_depth_o           = tti_rx_data_queue_depth;
   end
 
   // Thresholds
@@ -1098,6 +1094,8 @@ module recovery_handler
       .unsupported_err_o,
       .rx_fifo_overflow_err_o,
       .indirect_fifo_overflow_err_o,
+      .rx_desc_wvalid_i(ctl_tti_rx_desc_queue_wvalid_i),
+      .rx_desc_wdata_i (ctl_tti_rx_desc_queue_wdata_i),
       .exec_pending_o(recovery_exec_pending),
       .recovery_mode_enter_o
   );

--- a/src/recovery/recovery_receiver.sv
+++ b/src/recovery/recovery_receiver.sv
@@ -227,6 +227,10 @@ module recovery_receiver
     output logic rx_fifo_overflow_err_o,       // RX FIFO overflow error (always reported)
     output logic indirect_fifo_overflow_err_o, // INDIRECT_FIFO overflow error
 
+    // RX descriptor interface — monitored for bus-level parity errors
+    input  logic                          rx_desc_wvalid_i,
+    input  logic [TtiRxDescDataWidth-1:0] rx_desc_wdata_i,
+
     //--------------------------------------------------------------------------
     // Recovery CSR Interface
     //--------------------------------------------------------------------------
@@ -556,6 +560,7 @@ module recovery_receiver
     inc_csr_sel            = 1'b0;
     load_csr_length        = 1'b0;
     rx_data_queue_select_o = 1'b0;
+    rx_data_queue_flush_o  = 1'b0;
     pec_enable_o           = 1'b0;
     pec_init_o             = 1'b0;
     tx_pec_enable_o        = 1'b0;
@@ -652,11 +657,17 @@ module recovery_receiver
             premature_stop      = 1'b1;
             length_underrun_err = length_err_det_en_i;  // Report as length error (underrun)
             state_d             = Error;
+          end else if (rx_desc_wvalid_i && |rx_desc_wdata_i[31:28] && pec_err_det_en_i) begin
+            // RX descriptor reports bus-level error (T-bit parity) on write-phase PEC
+            // rx_desc_wvalid_i will be asserted same clock cycle as
+            // bus_rstart_i. If not assertion fires
+            pec_err = 1'b1;
+            state_d = Error;
           end else if (bus_rstart_i) begin
             // Repeated Start (Sr) indicates READ command - controller wants to read
             set_cmd_is_rd      = 1'b1;
             latch_pec_from_len = 1'b1;
-            state_d            = CmdDispatch;
+            state_d = CmdDispatch;
           end else if (rx_flow) begin
             capture_len_msb = 1'b1;
             pec_enable_o    = 1'b1;
@@ -699,8 +710,16 @@ module recovery_receiver
             premature_stop      = 1'b1;
             length_underrun_err = ((payload_byte_cnt < cmd_len) || pec_rx_byte_cnt == '0) && length_err_det_en_i;
             state_d             = Error;
+          end else if (rx_data_last_i && |rx_desc_wdata_i[31:28] && pec_err_det_en_i) begin
+            // RX descriptor reports bus-level error (T-bit parity or overflow)
+            // rx_data_last_i should be asserted the same clock cycle
+            // as rx_desc_wvalid_i if not an assertion will fire.
+            pec_err        = 1'b1;
+            state_d        = Error;
           end else if (rx_data_last_i) begin
-            state_d = CmdDispatch;
+              state_d = CmdDispatch;
+              // Flush partial word from width converter before ExecCsrWrite reads
+              rx_data_queue_flush_o = |(payload_byte_cnt[1:0]);
           end
         end
 
@@ -885,18 +904,6 @@ module recovery_receiver
   // Ready to receive during all RX states AND during Error (to drain bus).
   // During Error, bytes are accepted but discarded via converter soft reset.
   assign rx_data_ready_o = state_q inside {RxCmd, RxLenL, RxLenH, RxData, RxPec, Error};
-
-
-  //----------------------------------------------------------------------------
-  // RX Queue Flush/Clear Control
-  //----------------------------------------------------------------------------
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni) begin
-      rx_data_queue_flush_o <= 1'b0;
-    end else begin
-      rx_data_queue_flush_o <= (state_q == CmdDispatch) && |(payload_byte_cnt[1:0]);
-    end
-  end
 
   // Assert soft reset to width converters during Error state (combinational for immediate effect)
   assign conv_soft_reset_o = (state_q == Error);
@@ -1776,6 +1783,12 @@ module recovery_receiver
   assign rx_fifo_overflow_err_o = rx_fifo_overflow_err;
   // INDIRECT_FIFO overflow: reported on each overflow event
   assign indirect_fifo_overflow_err_o = indirect_fifo_overflow_err;
+
+  // rx_desc_wvalid_i must align with rx_data_last_i (both driven by transfer_ended)
+  `I3C_ASSERT(RxDescAlignedWithLast_A, rx_data_last_i |-> rx_desc_wvalid_i)
+
+  // rx_desc_wvalid_i must fire on Sr in RxLenH (read-flow write-phase ends here)
+  `I3C_ASSERT(RxDescAlignedWithRstart_A, (state_q == RxLenH) && bus_rstart_i |-> rx_desc_wvalid_i)
 
 endmodule
 

--- a/verification/cocotb/block/ctrl_descriptor_rx/test_descriptor_rx.py
+++ b/verification/cocotb/block/ctrl_descriptor_rx/test_descriptor_rx.py
@@ -42,13 +42,15 @@ async def test_descriptor_rx(dut: SimHandleBase):
 
     assert dut.rx_byte_ready_o.value == 1
 
-    # Send 5 bytes and wait for the RX descriptor
+    # Send 5 bytes and signal end of transfer
     for i in range(5):
         await send_byte(dut, i)
-    await cycle(dut.clk_i, dut.rx_byte_last_i)
 
+    # Assert rx_byte_last_i for one cycle; descriptor is valid on the same cycle
+    dut.rx_byte_last_i.value = 1
     await ClockCycles(dut.clk_i, 1)
     assert dut.tti_rx_desc_queue_wvalid_o.value == 1
     assert dut.tti_rx_desc_queue_wdata_o.value == 5
+    dut.rx_byte_last_i.value = 0
 
     await ClockCycles(dut.clk_i, 3)

--- a/verification/cocotb/top/i3c_ahb/test_ccc.py
+++ b/verification/cocotb/top/i3c_ahb/test_ccc.py
@@ -1,0 +1,1 @@
+../lib_i3c_top/test_ccc.py

--- a/verification/cocotb/top/i3c_ahb/test_empty_queue_read.py
+++ b/verification/cocotb/top/i3c_ahb/test_empty_queue_read.py
@@ -1,0 +1,1 @@
+../lib_i3c_top/test_empty_queue_read.py

--- a/verification/cocotb/top/i3c_axi/test_empty_queue_read.py
+++ b/verification/cocotb/top/i3c_axi/test_empty_queue_read.py
@@ -1,0 +1,1 @@
+../lib_i3c_top/test_empty_queue_read.py

--- a/verification/cocotb/top/lib_i3c_top/i3c_recovery_interface_fixed.py
+++ b/verification/cocotb/top/lib_i3c_top/i3c_recovery_interface_fixed.py
@@ -343,6 +343,42 @@ class I3cRecoveryInterfaceFixed(I3cRecoveryInterface):
         await self.controller.send_stop()
         self.controller.give_bus_control()
 
+    async def command_read_tbit_error(self, address, command, error_byte_index=0):
+        """
+        Issues a read command with T-bit error on a specific byte in the write phase.
+
+        Write phase xfer: [CMD(0), PEC(1)]. After error injection, attempts
+        the read phase (Sr + Addr+R). Returns None if target NACKs.
+
+        Args:
+            address: I3C target address
+            command: OCP Recovery command code
+            error_byte_index: Byte index in write phase to corrupt (0=CMD, 1=PEC)
+
+        Returns:
+            Tuple of (data, pec_ok) or (None, None) if target NACKed
+        """
+        xfer = [command]
+        pec = int(self.pec_calc.checksum(bytes([address << 1] + xfer)))
+        xfer.append(pec)
+
+        await self.controller.take_bus_control()
+        await self.controller.send_start()
+        await self.controller.write_addr_header(I3C_RSVD_BYTE)
+        await self.controller.send_start()
+        ack = await self.controller.write_addr_header(address)
+
+        if ack:
+            for i, byte in enumerate(xfer):
+                inject_error = (i == error_byte_index)
+                await self.controller.send_byte_tbit(byte, inject_tbit_err=inject_error)
+
+        # Continue with read phase — target may NACK if error was detected
+        try:
+            return await self._i3c_recovery_read(address, send_stop=True)
+        except I3cRecoveryException:
+            return None, None
+
     async def command_write_truncated(self, address, command, data=None, truncate_before_pec=True):
         """
         Issues a write command but truncates it before sending PEC.

--- a/verification/cocotb/top/lib_i3c_top/interface.py
+++ b/verification/cocotb/top/lib_i3c_top/interface.py
@@ -3,6 +3,7 @@
 from bus2csr import get_frontend_bus_if
 from cocotb_helpers import reset_n
 from reg_map import reg_map
+from tti_monitor import TtiQueueMonitor
 
 import cocotb
 from cocotb.handle import SimHandleBase
@@ -23,6 +24,7 @@ class I3CTopTestInterface:
         self.write_csr = self.busIf.write_csr
         self.read_csr_field = self.busIf.read_csr_field
         self.write_csr_field = self.busIf.write_csr_field
+        self.tti_monitor = None
 
     async def setup(self, fclk=500.0):
 
@@ -41,3 +43,11 @@ class I3CTopTestInterface:
         await self.busIf.register_test_interfaces(fclk)
         await ClockCycles(self.clk, 20)
         await reset_n(self.clk, self.rst_n, cycles=5)
+
+        # Start TtiQueueMonitor for every test
+        try:
+            self.tti_monitor = TtiQueueMonitor(self.dut)
+            cocotb.start_soon(self.tti_monitor.run())
+        except AttributeError:
+            self.dut._log.warning("TtiQueueMonitor: required signals not found, skipping")
+            self.tti_monitor = None

--- a/verification/cocotb/top/lib_i3c_top/test_empty_queue_read.py
+++ b/verification/cocotb/top/lib_i3c_top/test_empty_queue_read.py
@@ -1,0 +1,537 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tests that AXI reads to external FIFO queue ports complete without blocking
+when the FIFOs are empty, both in normal mode and recovery mode.
+
+These tests verify the fix for the AXI deadlock bug where reading
+TTI_RX_DESC_QUEUE_PORT during recovery mode caused external_pending
+to latch HIGH (due to R1MUX forcing rx_desc_queue_empty=0 and R4SW
+forcing rd_ack=0), permanently blocking all AXI traffic.
+"""
+
+import logging
+
+from boot import boot_init
+from bus2csr import dword2int, int2dword
+from ccc import CCC
+from i3c_controller_fixed import I3cControllerFixed as I3cController
+from i3c_recovery_interface_fixed import I3cRecoveryInterfaceFixed as I3cRecoveryInterface
+from cocotbext_i3c.i3c_target import I3CTarget
+from interface import I3CTopTestInterface
+
+import cocotb
+from cocotb.result import SimTimeoutError
+from cocotb.triggers import ClockCycles, Combine, RisingEdge, Timer
+
+STATIC_ADDR = 0x5A
+VIRT_STATIC_ADDR = 0x5B
+VIRT_DYNAMIC_ADDR = 0x53
+
+
+async def timeout_task(timeout):
+    await Timer(timeout, "us")
+    raise RuntimeError("Test timeout!")
+
+
+async def init_normal_mode(dut, timeout=50):
+    """
+    Initialize DUT in normal (non-recovery) mode with boot_init.
+    No I3C bus transactions needed -- just AXI/CSR access.
+    """
+    cocotb.log.setLevel(logging.DEBUG)
+    await cocotb.start(timeout_task(timeout))
+
+    tb = I3CTopTestInterface(dut)
+    await tb.setup()
+
+    await boot_init(tb)
+    return tb
+
+
+async def init_recovery_mode(dut, timeout=50):
+    """
+    Initialize DUT and enter recovery mode.
+    """
+    cocotb.log.setLevel(logging.DEBUG)
+    await cocotb.start(timeout_task(timeout))
+
+    tb = I3CTopTestInterface(dut)
+    await tb.setup()
+
+    await boot_init(tb)
+
+    # Enable recovery mode (DEVICE_STATUS_0 = 0x3)
+    await tb.write_csr(
+        tb.reg_map.I3C_EC.SECFWRECOVERYIF.DEVICE_STATUS_0.base_addr,
+        int2dword(0x3), 4
+    )
+
+    return tb
+
+
+async def init_recovery_with_i3c(dut, fclk=333.0, fbus=12.5, timeout=200):
+    """
+    Initialize DUT with I3C bus, virtual device, and recovery mode.
+    Returns (i3c_controller, tb, recovery) for tests that need I3C transactions.
+    """
+    cocotb.log.setLevel(logging.DEBUG)
+    await cocotb.start(timeout_task(timeout))
+
+    i3c_controller = I3cController(
+        sda_i=dut.bus_sda,
+        sda_o=dut.sda_sim_ctrl_i,
+        scl_i=dut.bus_scl,
+        scl_o=dut.scl_sim_ctrl_i,
+        debug_state_o=None,
+        speed=fbus * 1e6,
+    )
+
+    # Target BFM needed so the bus doesn't see an undriven SDA
+    I3CTarget(  # noqa: F841
+        sda_i=dut.bus_sda,
+        sda_o=dut.sda_sim_target_i,
+        scl_i=dut.bus_scl,
+        scl_o=dut.scl_sim_target_i,
+        debug_state_o=None,
+        speed=fbus * 1e6,
+        address=0x23,
+    )
+
+    tb = I3CTopTestInterface(dut)
+    await tb.setup(fclk)
+
+    recovery = I3cRecoveryInterface(i3c_controller)
+
+    await boot_init(tb)
+
+    # Enable recovery mode
+    await tb.write_csr(
+        tb.reg_map.I3C_EC.SECFWRECOVERYIF.DEVICE_STATUS_0.base_addr,
+        int2dword(0x3), 4
+    )
+
+    await ClockCycles(tb.clk, 50)
+
+    # Assign dynamic address to virtual device
+    await i3c_controller.i3c_ccc_write(
+        ccc=CCC.DIRECT.SETDASA,
+        directed_data=[(VIRT_STATIC_ADDR, [VIRT_DYNAMIC_ADDR << 1])]
+    )
+
+    return i3c_controller, tb, recovery
+
+
+# =============================================================================
+# Part A: Normal (non-recovery) mode -- read empty FIFOs
+# =============================================================================
+
+@cocotb.test()
+async def test_normal_read_empty_rx_desc_queue(dut):
+    """
+    Read TTI RX_DESC_QUEUE_PORT when empty in normal mode.
+    Must complete without hanging and return 0.
+    """
+    tb = await init_normal_mode(dut)
+
+    addr = tb.reg_map.I3C_EC.TTI.RX_DESC_QUEUE_PORT.base_addr
+    dut._log.info(f"Reading empty RX_DESC_QUEUE_PORT at 0x{addr:03X}")
+    data = dword2int(await tb.read_csr(addr, 4))
+    dut._log.info(f"RX_DESC_QUEUE_PORT returned: 0x{data:08X}")
+    assert data == 0, f"Expected 0 from empty RX desc queue, got 0x{data:08X}"
+
+
+@cocotb.test()
+async def test_normal_read_empty_rx_data_port(dut):
+    """
+    Read TTI RX_DATA_PORT when empty in normal mode.
+    Must complete without hanging and return 0.
+    """
+    tb = await init_normal_mode(dut)
+
+    addr = tb.reg_map.I3C_EC.TTI.RX_DATA_PORT.base_addr
+    dut._log.info(f"Reading empty RX_DATA_PORT at 0x{addr:03X}")
+    data = dword2int(await tb.read_csr(addr, 4))
+    dut._log.info(f"RX_DATA_PORT returned: 0x{data:08X}")
+    assert data == 0, f"Expected 0 from empty RX data port, got 0x{data:08X}"
+
+
+@cocotb.test()
+async def test_normal_read_empty_indirect_fifo_data(dut):
+    """
+    Read INDIRECT_FIFO_DATA when empty in normal mode.
+    Must complete without hanging and return 0.
+    """
+    tb = await init_normal_mode(dut)
+
+    addr = tb.reg_map.I3C_EC.SECFWRECOVERYIF.INDIRECT_FIFO_DATA.base_addr
+    dut._log.info(f"Reading empty INDIRECT_FIFO_DATA at 0x{addr:03X}")
+    data = dword2int(await tb.read_csr(addr, 4))
+    dut._log.info(f"INDIRECT_FIFO_DATA returned: 0x{data:08X}")
+    assert data == 0, f"Expected 0 from empty indirect FIFO, got 0x{data:08X}"
+
+
+@cocotb.test()
+async def test_normal_read_empty_all_queues(dut):
+    """
+    Read all three empty FIFO ports in normal mode sequentially.
+    Verifies no AXI bus deadlock from back-to-back external reads.
+    """
+    tb = await init_normal_mode(dut)
+
+    # Read RX_DESC_QUEUE_PORT
+    addr = tb.reg_map.I3C_EC.TTI.RX_DESC_QUEUE_PORT.base_addr
+    dut._log.info(f"Reading empty RX_DESC_QUEUE_PORT at 0x{addr:03X}")
+    data = dword2int(await tb.read_csr(addr, 4))
+    assert data == 0, f"RX_DESC_QUEUE_PORT: expected 0, got 0x{data:08X}"
+    dut._log.info("RX_DESC_QUEUE_PORT read OK")
+
+    # Read RX_DATA_PORT
+    addr = tb.reg_map.I3C_EC.TTI.RX_DATA_PORT.base_addr
+    dut._log.info(f"Reading empty RX_DATA_PORT at 0x{addr:03X}")
+    data = dword2int(await tb.read_csr(addr, 4))
+    assert data == 0, f"RX_DATA_PORT: expected 0, got 0x{data:08X}"
+    dut._log.info("RX_DATA_PORT read OK")
+
+    # Read INDIRECT_FIFO_DATA
+    addr = tb.reg_map.I3C_EC.SECFWRECOVERYIF.INDIRECT_FIFO_DATA.base_addr
+    dut._log.info(f"Reading empty INDIRECT_FIFO_DATA at 0x{addr:03X}")
+    data = dword2int(await tb.read_csr(addr, 4))
+    assert data == 0, f"INDIRECT_FIFO_DATA: expected 0, got 0x{data:08X}"
+    dut._log.info("INDIRECT_FIFO_DATA read OK")
+
+    # Verify a normal CSR read still works after all the external reads
+    hci_version = dword2int(await tb.read_csr(
+        tb.reg_map.I3CBASE.HCI_VERSION.base_addr, 4))
+    assert hci_version == 0x120, f"HCI_VERSION: expected 0x120, got 0x{hci_version:X}"
+    dut._log.info("Post-read HCI_VERSION check OK -- AXI bus is not deadlocked")
+
+
+# =============================================================================
+# Part B: Recovery mode -- read empty FIFOs
+# =============================================================================
+
+@cocotb.test()
+async def test_recovery_read_empty_rx_desc_queue(dut):
+    """
+    Read TTI RX_DESC_QUEUE_PORT when empty in recovery mode.
+    This is the exact scenario that caused the AXI deadlock bug:
+    recovery_pending=1 caused R1MUX to force empty=0, preventing rd_ack.
+    """
+    tb = await init_recovery_mode(dut)
+
+    addr = tb.reg_map.I3C_EC.TTI.RX_DESC_QUEUE_PORT.base_addr
+    dut._log.info(f"[RECOVERY] Reading empty RX_DESC_QUEUE_PORT at 0x{addr:03X}")
+    data = dword2int(await tb.read_csr(addr, 4))
+    dut._log.info(f"RX_DESC_QUEUE_PORT returned: 0x{data:08X}")
+    assert data == 0, f"Expected 0 from empty RX desc queue in recovery, got 0x{data:08X}"
+
+
+@cocotb.test()
+async def test_recovery_read_empty_rx_data_port(dut):
+    """
+    Read TTI RX_DATA_PORT when empty in recovery mode.
+    """
+    tb = await init_recovery_mode(dut)
+
+    addr = tb.reg_map.I3C_EC.TTI.RX_DATA_PORT.base_addr
+    dut._log.info(f"[RECOVERY] Reading empty RX_DATA_PORT at 0x{addr:03X}")
+    data = dword2int(await tb.read_csr(addr, 4))
+    dut._log.info(f"RX_DATA_PORT returned: 0x{data:08X}")
+    assert data == 0, f"Expected 0 from empty RX data port in recovery, got 0x{data:08X}"
+
+
+@cocotb.test()
+async def test_recovery_read_empty_indirect_fifo_data(dut):
+    """
+    Read INDIRECT_FIFO_DATA when empty in recovery mode.
+    """
+    tb = await init_recovery_mode(dut)
+
+    addr = tb.reg_map.I3C_EC.SECFWRECOVERYIF.INDIRECT_FIFO_DATA.base_addr
+    dut._log.info(f"[RECOVERY] Reading empty INDIRECT_FIFO_DATA at 0x{addr:03X}")
+    data = dword2int(await tb.read_csr(addr, 4))
+    dut._log.info(f"INDIRECT_FIFO_DATA returned: 0x{data:08X}")
+    assert data == 0, f"Expected 0 from empty indirect FIFO in recovery, got 0x{data:08X}"
+
+
+@cocotb.test()
+async def test_recovery_read_empty_all_queues(dut):
+    """
+    Read all three empty FIFO ports in recovery mode sequentially.
+    Verifies no AXI bus deadlock from back-to-back external reads
+    while recovery_pending is active.
+    """
+    tb = await init_recovery_mode(dut)
+
+    # Read RX_DESC_QUEUE_PORT
+    addr = tb.reg_map.I3C_EC.TTI.RX_DESC_QUEUE_PORT.base_addr
+    dut._log.info(f"[RECOVERY] Reading empty RX_DESC_QUEUE_PORT at 0x{addr:03X}")
+    data = dword2int(await tb.read_csr(addr, 4))
+    assert data == 0, f"RX_DESC_QUEUE_PORT: expected 0, got 0x{data:08X}"
+    dut._log.info("RX_DESC_QUEUE_PORT read OK")
+
+    # Read RX_DATA_PORT
+    addr = tb.reg_map.I3C_EC.TTI.RX_DATA_PORT.base_addr
+    dut._log.info(f"[RECOVERY] Reading empty RX_DATA_PORT at 0x{addr:03X}")
+    data = dword2int(await tb.read_csr(addr, 4))
+    assert data == 0, f"RX_DATA_PORT: expected 0, got 0x{data:08X}"
+    dut._log.info("RX_DATA_PORT read OK")
+
+    # Read INDIRECT_FIFO_DATA
+    addr = tb.reg_map.I3C_EC.SECFWRECOVERYIF.INDIRECT_FIFO_DATA.base_addr
+    dut._log.info(f"[RECOVERY] Reading empty INDIRECT_FIFO_DATA at 0x{addr:03X}")
+    data = dword2int(await tb.read_csr(addr, 4))
+    assert data == 0, f"INDIRECT_FIFO_DATA: expected 0, got 0x{data:08X}"
+    dut._log.info("INDIRECT_FIFO_DATA read OK")
+
+    # Verify a normal CSR read still works -- proves AXI bus is alive
+    hci_version = dword2int(await tb.read_csr(
+        tb.reg_map.I3CBASE.HCI_VERSION.base_addr, 4))
+    assert hci_version == 0x120, f"HCI_VERSION: expected 0x120, got 0x{hci_version:X}"
+    dut._log.info("Post-read HCI_VERSION check OK -- AXI bus is not deadlocked")
+
+
+# =============================================================================
+# Part C: Concurrent I3C recovery transaction + AXI queue access
+#
+# These tests issue an I3C read to the virtual device (PROT_CAP), which
+# asserts recovery_pending in recovery_handler.sv. While that I3C
+# transaction is in-flight we concurrently issue AXI reads/writes to
+# the TTI queue ports. Without the RTL fix, the RX_DESC_QUEUE_PORT read
+# deadlocks the AXI bus and the test times out.
+# =============================================================================
+
+@cocotb.test()
+async def test_concurrent_recovery_xfer_and_rx_desc_read(dut):
+    """
+    While an I3C recovery read (PROT_CAP) is in-flight -- which asserts
+    recovery_pending -- concurrently read TTI RX_DESC_QUEUE_PORT via AXI.
+    This is the exact deadlock scenario from the bug.
+    """
+    i3c_controller, tb, recovery = await init_recovery_with_i3c(dut)
+
+    async def i3c_recovery_read():
+        dut._log.info("[I3C] Starting PROT_CAP read on virtual device")
+        result = await recovery.command_read(
+            VIRT_DYNAMIC_ADDR, I3cRecoveryInterface.Command.PROT_CAP
+        )
+        assert result is not None, "PROT_CAP read returned None"
+        data, pec_ok = result
+        dut._log.info(f"[I3C] PROT_CAP read done, pec_ok={pec_ok}")
+
+    async def axi_read_rx_desc():
+        # Wait for recovery_pending to actually assert (I3C address phase must complete first)
+        recovery_pending = dut.xi3c_wrapper.i3c.xrecovery_handler.recovery_pending
+        dut._log.info("[AXI] Waiting for recovery_pending to assert...")
+        await RisingEdge(recovery_pending)
+        dut._log.info("[AXI] recovery_pending is HIGH -- issuing AXI read")
+        addr = tb.reg_map.I3C_EC.TTI.RX_DESC_QUEUE_PORT.base_addr
+        dut._log.info(f"[AXI] Reading RX_DESC_QUEUE_PORT at 0x{addr:03X} while recovery_pending")
+        data = dword2int(await tb.read_csr(addr, 4))
+        dut._log.info(f"[AXI] RX_DESC_QUEUE_PORT returned: 0x{data:08X}")
+
+    i3c_task = await cocotb.start(i3c_recovery_read())
+    axi_task = await cocotb.start(axi_read_rx_desc())
+    await Combine(i3c_task, axi_task)
+
+    # Verify AXI bus is still alive
+    hci_version = dword2int(await tb.read_csr(
+        tb.reg_map.I3CBASE.HCI_VERSION.base_addr, 4))
+    assert hci_version == 0x120, f"HCI_VERSION: expected 0x120, got 0x{hci_version:X}"
+    dut._log.info("AXI bus alive after concurrent recovery + RX_DESC read")
+
+
+@cocotb.test()
+async def test_concurrent_recovery_xfer_and_tx_desc_write(dut):
+    """
+    While an I3C recovery read (PROT_CAP) is in-flight -- which asserts
+    recovery_pending -- concurrently write TTI TX_DESC_QUEUE_PORT via AXI.
+    """
+    i3c_controller, tb, recovery = await init_recovery_with_i3c(dut)
+
+    async def i3c_recovery_read():
+        dut._log.info("[I3C] Starting PROT_CAP read on virtual device")
+        result = await recovery.command_read(
+            VIRT_DYNAMIC_ADDR, I3cRecoveryInterface.Command.PROT_CAP
+        )
+        assert result is not None, "PROT_CAP read returned None"
+        data, pec_ok = result
+        dut._log.info(f"[I3C] PROT_CAP read done, pec_ok={pec_ok}")
+
+    async def axi_write_tx_desc():
+        recovery_pending = dut.xi3c_wrapper.i3c.xrecovery_handler.recovery_pending
+        dut._log.info("[AXI] Waiting for recovery_pending to assert...")
+        await RisingEdge(recovery_pending)
+        dut._log.info("[AXI] recovery_pending is HIGH -- issuing AXI write")
+        addr = tb.reg_map.I3C_EC.TTI.TX_DESC_QUEUE_PORT.base_addr
+        dut._log.info(f"[AXI] Writing TX_DESC_QUEUE_PORT at 0x{addr:03X} while recovery_pending")
+        await tb.write_csr(addr, int2dword(0x00000010), 4)
+        dut._log.info("[AXI] TX_DESC_QUEUE_PORT write completed")
+
+    i3c_task = await cocotb.start(i3c_recovery_read())
+    axi_task = await cocotb.start(axi_write_tx_desc())
+    await Combine(i3c_task, axi_task)
+
+    # Verify AXI bus is still alive
+    hci_version = dword2int(await tb.read_csr(
+        tb.reg_map.I3CBASE.HCI_VERSION.base_addr, 4))
+    assert hci_version == 0x120, f"HCI_VERSION: expected 0x120, got 0x{hci_version:X}"
+    dut._log.info("AXI bus alive after concurrent recovery + TX_DESC write")
+
+
+@cocotb.test()
+async def test_concurrent_recovery_xfer_and_all_queue_access(dut):
+    """
+    While an I3C recovery read (PROT_CAP) is in-flight -- which asserts
+    recovery_pending -- concurrently access all TTI queue ports via AXI:
+    read RX_DESC, read RX_DATA, write TX_DESC.
+    """
+    i3c_controller, tb, recovery = await init_recovery_with_i3c(dut)
+
+    async def i3c_recovery_read():
+        dut._log.info("[I3C] Starting PROT_CAP read on virtual device")
+        result = await recovery.command_read(
+            VIRT_DYNAMIC_ADDR, I3cRecoveryInterface.Command.PROT_CAP
+        )
+        assert result is not None, "PROT_CAP read returned None"
+        data, pec_ok = result
+        dut._log.info(f"[I3C] PROT_CAP read done, pec_ok={pec_ok}")
+
+    async def axi_queue_access():
+        recovery_pending = dut.xi3c_wrapper.i3c.xrecovery_handler.recovery_pending
+        dut._log.info("[AXI] Waiting for recovery_pending to assert...")
+        await RisingEdge(recovery_pending)
+        dut._log.info("[AXI] recovery_pending is HIGH -- issuing AXI accesses")
+
+        # Read RX_DESC_QUEUE_PORT
+        addr = tb.reg_map.I3C_EC.TTI.RX_DESC_QUEUE_PORT.base_addr
+        dut._log.info(f"[AXI] Reading RX_DESC_QUEUE_PORT at 0x{addr:03X}")
+        data = dword2int(await tb.read_csr(addr, 4))
+        dut._log.info(f"[AXI] RX_DESC_QUEUE_PORT returned 0x{data:08X}")
+
+        # Read RX_DATA_PORT
+        addr = tb.reg_map.I3C_EC.TTI.RX_DATA_PORT.base_addr
+        dut._log.info(f"[AXI] Reading RX_DATA_PORT at 0x{addr:03X}")
+        data = dword2int(await tb.read_csr(addr, 4))
+        dut._log.info(f"[AXI] RX_DATA_PORT returned 0x{data:08X}")
+
+        # Write TX_DESC_QUEUE_PORT
+        addr = tb.reg_map.I3C_EC.TTI.TX_DESC_QUEUE_PORT.base_addr
+        dut._log.info(f"[AXI] Writing TX_DESC_QUEUE_PORT at 0x{addr:03X}")
+        await tb.write_csr(addr, int2dword(0x00000010), 4)
+        dut._log.info("[AXI] TX_DESC_QUEUE_PORT write completed")
+
+    i3c_task = await cocotb.start(i3c_recovery_read())
+    axi_task = await cocotb.start(axi_queue_access())
+    await Combine(i3c_task, axi_task)
+
+    # Verify AXI bus is still alive
+    hci_version = dword2int(await tb.read_csr(
+        tb.reg_map.I3CBASE.HCI_VERSION.base_addr, 4))
+    assert hci_version == 0x120, f"HCI_VERSION: expected 0x120, got 0x{hci_version:X}"
+    dut._log.info("AXI bus alive after concurrent recovery + all queue access")
+
+
+# =============================================================================
+# Part D: Exploratory -- observe RX_DATA_PORT during recovery write
+#
+# Issue a recovery write (INDIRECT_FIFO_DATA) to the virtual target and
+# monitor whether any data transiently appears in the TTI RX data queue.
+# If so, immediately issue an AXI read to RX_DATA_PORT and log the result.
+# This is exploratory: we log findings rather than assert specific values.
+# =============================================================================
+
+@cocotb.test()
+async def test_recovery_write_rx_data_observation(dut):
+    """
+    Exploratory: write 16 bytes to INDIRECT_FIFO_DATA on the virtual target
+    via the recovery interface. In parallel, monitor the RTL signal
+    tti_rx_depth for any transient data appearing in the TTI RX queue.
+    If data appears, immediately read RX_DATA_PORT via AXI and log the result.
+    """
+    i3c_controller, tb, recovery = await init_recovery_with_i3c(dut)
+
+    rx_data_seen = []
+    monitor_done = False
+
+    async def rx_data_monitor():
+        """Watch tti_rx_depth; on >=1 DWORD, read RX_DATA_PORT via AXI."""
+        nonlocal monitor_done
+        rx_depth = dut.xi3c_wrapper.i3c.tti_rx_depth
+        rx_empty = dut.xi3c_wrapper.i3c.tti_rx_empty
+
+        dut._log.info("[MONITOR] Starting RX data queue monitor")
+        dut._log.info(f"[MONITOR] Initial tti_rx_depth={int(rx_depth)}, tti_rx_empty={int(rx_empty)}")
+
+        cycle = 0
+        while not monitor_done:
+            await RisingEdge(tb.clk)
+            cycle += 1
+            depth = int(rx_depth)
+            if depth > 0:
+                sim_time = cocotb.utils.get_sim_time("ns")
+                dut._log.info(
+                    f"[MONITOR] tti_rx_depth={depth} at cycle {cycle} "
+                    f"(sim_time={sim_time}ns) -- issuing AXI read"
+                )
+                addr = tb.reg_map.I3C_EC.TTI.RX_DATA_PORT.base_addr
+                try:
+                    data = dword2int(await tb.read_csr(addr, 4))
+                    rx_data_seen.append((cycle, sim_time, depth, data, "OK"))
+                    dut._log.info(
+                        f"[MONITOR] RX_DATA_PORT returned 0x{data:08X} "
+                        f"(depth was {depth})"
+                    )
+                except SimTimeoutError:
+                    rx_data_seen.append((cycle, sim_time, depth, None, "AXI_TIMEOUT"))
+                    dut._log.warning(
+                        f"[MONITOR] AXI read TIMED OUT at cycle {cycle} "
+                        f"(depth was {depth}) -- AXI bus may be deadlocked"
+                    )
+
+        dut._log.info(f"[MONITOR] Stopped after {cycle} cycles")
+
+    async def recovery_write():
+        """Write 16 bytes of known data to INDIRECT_FIFO_DATA."""
+        nonlocal monitor_done
+        payload = list(range(0xA0, 0xB0))  # 16 bytes: 0xA0..0xAF
+        dut._log.info(f"[WRITE] Starting recovery write, {len(payload)} bytes")
+        await recovery.command_write(
+            VIRT_DYNAMIC_ADDR,
+            I3cRecoveryInterface.Command.INDIRECT_FIFO_DATA,
+            payload,
+        )
+        dut._log.info("[WRITE] Recovery write complete")
+        # Let monitor run a few more cycles to catch any trailing data
+        await ClockCycles(tb.clk, 50)
+        monitor_done = True
+
+    mon_task = await cocotb.start(rx_data_monitor())
+    write_task = await cocotb.start(recovery_write())
+    await Combine(write_task, mon_task)
+
+    # --- Summary ---
+    dut._log.info("=" * 60)
+    if rx_data_seen:
+        dut._log.info(f"[SUMMARY] RX_DATA_PORT had data on {len(rx_data_seen)} occasion(s):")
+        for cycle, sim_ns, depth, data, status in rx_data_seen:
+            if status == "OK":
+                dut._log.info(
+                    f"  cycle={cycle}  sim_time={sim_ns}ns  depth={depth}  "
+                    f"data=0x{data:08X}"
+                )
+            else:
+                dut._log.info(
+                    f"  cycle={cycle}  sim_time={sim_ns}ns  depth={depth}  "
+                    f"status={status} (AXI read hung)"
+                )
+    else:
+        dut._log.info("[SUMMARY] RX_DATA_PORT never had data during recovery write")
+    dut._log.info("=" * 60)
+
+    # Verify AXI bus is still alive
+    hci_version = dword2int(await tb.read_csr(
+        tb.reg_map.I3CBASE.HCI_VERSION.base_addr, 4))
+    assert hci_version == 0x120, f"HCI_VERSION: expected 0x120, got 0x{hci_version:X}"
+    dut._log.info("AXI bus alive after recovery write + RX observation")

--- a/verification/cocotb/top/lib_i3c_top/test_recovery.py
+++ b/verification/cocotb/top/lib_i3c_top/test_recovery.py
@@ -5621,3 +5621,190 @@ async def test_private_read_and_ri_read(dut):
     dut._log.info("Private read data verified OK")
 
     dut._log.info("PASS: Recovery interface read and private read are independent")
+
+
+@cocotb.test()
+async def test_parity_error_isolation(dut):
+    """
+    Verifies that parity/PEC errors on RI writes don't leak into TTI
+    interrupt path, and that T-bit errors on normal target writes do
+    produce the expected TTI interrupt and descriptor error bits.
+
+    Part 1: RI write with corrupted PEC byte
+    Part 2: RI write with T-bit error on last data byte
+    Part 3: Normal target write with T-bit error on last byte
+    """
+
+    i3c_controller, i3c_target, tb, recovery = await initialize(dut, timeout=100)
+
+    # Assign both dynamic addresses
+    await i3c_controller.i3c_ccc_write(
+        ccc=CCC.DIRECT.SETDASA, directed_data=[(STATIC_ADDR, [DYNAMIC_ADDR << 1])]
+    )
+    await i3c_controller.i3c_ccc_write(
+        ccc=CCC.DIRECT.SETDASA, directed_data=[(VIRT_STATIC_ADDR, [VIRT_DYNAMIC_ADDR << 1])]
+    )
+
+    # Enable RI error interrupts so status bits are captured
+    ri_err_enable_mask = (1 << 8) | (1 << 9)  # RI_PEC_ERR_EN | RI_LENGTH_ERR_EN
+    current_enable = dword2int(
+        await tb.read_csr(tb.reg_map.I3C_EC.TTI.TARGET_ERR_INTR_ENABLE.base_addr, 4)
+    )
+    await tb.write_csr(
+        tb.reg_map.I3C_EC.TTI.TARGET_ERR_INTR_ENABLE.base_addr,
+        int2dword(current_enable | ri_err_enable_mask), 4
+    )
+
+    # Clear error counters and status
+    await tb.write_csr(tb.reg_map.I3C_EC.TTI.TARGET_ERR_CNT_RI_PEC.base_addr, int2dword(0), 4)
+    await tb.write_csr(
+        tb.reg_map.I3C_EC.TTI.TARGET_ERR_INTR_STATUS.base_addr, int2dword(0xFFFFFFFF), 4
+    )
+
+    # =========================================================================
+    # Part 1: RI write with T-bit error on PEC byte
+    # Correct PEC value but corrupted T-bit causes the target to detect a
+    # bus-level parity error. CSR should not update.
+    # TTI rx_desc/data_queue_write_r must not assert.
+    # =========================================================================
+    dut._log.info("Part 1: RI write with T-bit error on PEC byte")
+
+    # Seed the CSR with a known good value first
+    await recovery.command_write(
+        VIRT_DYNAMIC_ADDR, I3cRecoveryInterface.Command.DEVICE_RESET, [0x11, 0x22, 0x33]
+    )
+    await ClockCycles(tb.clk, 20)
+
+    # T-bit error on PEC byte (last byte in the xfer)
+    # xfer: [CMD(0), LEN_L(1), LEN_H(2), DATA0(3), DATA1(4), DATA2(5), PEC(6)]
+    write_data_p1 = [0xDE, 0xAD, 0xFF]
+    pec_byte_index = 3 + len(write_data_p1)  # = 6
+    await recovery.command_write_tbit_error(
+        VIRT_DYNAMIC_ADDR, I3cRecoveryInterface.Command.DEVICE_RESET,
+        write_data_p1, error_byte_index=pec_byte_index
+    )
+    await ClockCycles(tb.clk, 20)
+
+    # CSR should retain previous value
+    data = dword2int(
+        await tb.read_csr(tb.reg_map.I3C_EC.SECFWRECOVERYIF.DEVICE_RESET.base_addr, 4)
+    )
+    assert data == 0x332211, (
+        f"Part 1: DEVICE_RESET should retain 0x00332211 after T-bit error, got 0x{data:08X}")
+
+    dut._log.info("Part 1: PASS")
+
+    # =========================================================================
+    # Part 2: RI write with T-bit error on last data byte
+    # The target should detect the bus error and abort. CSR should not update.
+    # TTI rx_desc/data_queue_write_r must not assert.
+    # =========================================================================
+    dut._log.info("Part 2: RI write with T-bit error on last data byte")
+
+    write_data = [0xAA, 0xBB, 0xCC]
+    # xfer layout: [CMD(0), LEN_L(1), LEN_H(2), DATA0(3), DATA1(4), DATA2(5), PEC(6)]
+    last_data_byte_index = 2 + len(write_data)  # 3 header bytes + data_len - 1 = index 5
+
+    await recovery.command_write_tbit_error(
+        VIRT_DYNAMIC_ADDR, I3cRecoveryInterface.Command.DEVICE_RESET,
+        write_data, error_byte_index=last_data_byte_index
+    )
+    await ClockCycles(tb.clk, 20)
+
+    # CSR should still have the Part 1 seeded value
+    data = dword2int(
+        await tb.read_csr(tb.reg_map.I3C_EC.SECFWRECOVERYIF.DEVICE_RESET.base_addr, 4)
+    )
+    assert data == 0x332211, (
+        f"Part 2: DEVICE_RESET should retain 0x00332211 after T-bit error, got 0x{data:08X}")
+
+    dut._log.info("Part 2: PASS")
+
+    # =========================================================================
+    # Part 3: Normal target write with T-bit error on last byte
+    # This targets the main device (not RI). The TTI should see the write
+    # and rx_desc_queue_write_r SHOULD assert. The descriptor error bit
+    # should be set indicating a parity error.
+    # =========================================================================
+    dut._log.info("Part 3: Normal target write with T-bit error on last byte")
+
+    # Clear TTI INTERRUPT_STATUS before the write
+    await tb.write_csr(
+        tb.reg_map.I3C_EC.TTI.INTERRUPT_STATUS.base_addr, int2dword(0xFFFFFFFF), 4
+    )
+
+    writes_before = tb.tti_monitor.normal_write_count
+
+    test_data = [0x01, 0x02, 0x03, 0x04]
+    await i3c_controller.i3c_write(DYNAMIC_ADDR, test_data, inject_tbit_err=True)
+    await ClockCycles(tb.clk, 50)
+
+    # TTI should have received the write — monitor counts normal writes
+    assert tb.tti_monitor.normal_write_count > writes_before, (
+        "Part 3: rx_desc/data_queue_write_r should have asserted for normal target write")
+
+    # Read RX descriptor — error bit should be set
+    rx_desc = dword2int(
+        await tb.read_csr(tb.reg_map.I3C_EC.TTI.RX_DESC_QUEUE_PORT.base_addr, 4)
+    )
+    err_stat = rx_desc >> 28
+    assert err_stat != 0, f"Part 3: RX descriptor error bits should be set, got err={err_stat}"
+
+    # TTI PROTOCOL_ERROR status should be set
+    protocol_err = await tb.read_csr_field(
+        tb.reg_map.I3C_EC.TTI.STATUS.base_addr, tb.reg_map.I3C_EC.TTI.STATUS.PROTOCOL_ERROR
+    )
+    assert protocol_err == 1, f"Part 3: TTI PROTOCOL_ERROR should be set, got {protocol_err}"
+
+    # Clear the RX data FIFO so it doesn't affect subsequent tests
+    await tb.write_csr_field(
+        tb.reg_map.I3C_EC.TTI.RESET_CONTROL.base_addr,
+        tb.reg_map.I3C_EC.TTI.RESET_CONTROL.RX_DATA_RST, 1
+    )
+    await tb.write_csr_field(
+        tb.reg_map.I3C_EC.TTI.RESET_CONTROL.base_addr,
+        tb.reg_map.I3C_EC.TTI.RESET_CONTROL.RX_DATA_RST, 0
+    )
+
+    dut._log.info("Part 3: PASS")
+
+    # =========================================================================
+    # Part 4: RI read with T-bit error on write-phase PEC byte
+    # Read flow: S + 0x7E + Sr + Addr+W + CMD(0) + PEC(1) + Sr + Addr+R + ...
+    # Corrupt T-bit on PEC (index 1). The target should detect the error
+    # and either NACK the read phase or return no data.
+    # =========================================================================
+    dut._log.info("Part 4: RI read with T-bit error on write-phase PEC byte")
+
+    # First do a valid write so the CSR has known data to read back
+    await recovery.command_write(
+        VIRT_DYNAMIC_ADDR, I3cRecoveryInterface.Command.DEVICE_RESET, [0x11, 0x22, 0x33]
+    )
+    await ClockCycles(tb.clk, 20)
+
+    # Now attempt a read with T-bit error on the PEC byte (index 1)
+    result = await recovery.command_read_tbit_error(
+        VIRT_DYNAMIC_ADDR, I3cRecoveryInterface.Command.DEVICE_RESET,
+        error_byte_index=1,
+    )
+    await ClockCycles(tb.clk, 20)
+
+    # The read should fail — either NACK (None) or protocol exception
+    assert result[0] is None, (
+        f"Part 4: Read should fail after T-bit error on write-phase PEC, got data={result[0]}")
+
+    dut._log.info("Part 4: PASS")
+
+    # =========================================================================
+    # Final: TTI monitor checks automatically at test end
+    # =========================================================================
+
+    dut._log.info("=" * 70)
+    dut._log.info("TEST SUMMARY: test_parity_error_isolation")
+    dut._log.info("=" * 70)
+    dut._log.info("  Part 1: RI write with T-bit error on PEC byte - PASS")
+    dut._log.info("  Part 2: RI write with T-bit error on last data byte - PASS")
+    dut._log.info("  Part 3: Normal target T-bit error (TTI interrupt fired) - PASS")
+    dut._log.info("  Part 4: RI read with T-bit error on write-phase PEC - PASS")
+    dut._log.info("  Monitor: No RI writes leaked to TTI - PASS")
+    dut._log.info("=" * 70)

--- a/verification/cocotb/top/lib_i3c_top/tti_monitor.py
+++ b/verification/cocotb/top/lib_i3c_top/tti_monitor.py
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Continuous TTI queue write monitor.
+
+Verifies that recovery (RI) I3C transactions never leak descriptor/data
+write pulses into the TTI interrupt path, and that normal target writes
+do produce them.
+
+Started automatically by I3CTopTestInterface.setup(); raises immediately
+on violation to fail the test.
+"""
+
+import cocotb
+from cocotb.triggers import RisingEdge, First
+
+
+class TtiQueueMonitor:
+    """Watches rx_desc_queue_write_r and rx_data_queue_write_r in tti.sv.
+
+    Invariant: these signals must NEVER assert while recovery_pending is high.
+    During recovery, RI data is consumed by the recovery receiver — any write
+    pulse reaching the TTI interrupt logic indicates a gating bug.
+    """
+
+    # Hierarchical paths relative to dut
+    _TTI = "xi3c_wrapper.i3c.xtti"
+    _REC = "xi3c_wrapper.i3c.xrecovery_handler"
+
+    def __init__(self, dut):
+        self.dut = dut
+        self._normal_write_count = 0
+        self._running = False
+
+        # Resolve signal handles once
+        tti = getattr(dut, "xi3c_wrapper").i3c.xtti
+        rec = getattr(dut, "xi3c_wrapper").i3c.xrecovery_handler
+        self._rx_desc_write_r = tti.rx_desc_queue_write_r
+        self._rx_data_write_r = tti.rx_data_queue_write_r
+        self._recovery_pending = rec.recovery_pending
+
+    async def run(self):
+        """Main monitor loop — start with cocotb.start_soon().
+
+        Raises AssertionError immediately when a violation is detected,
+        which propagates to the test and causes it to fail.
+        """
+        self._running = True
+        while True:
+            # Wait for either write_r signal to assert
+            await First(
+                RisingEdge(self._rx_desc_write_r),
+                RisingEdge(self._rx_data_write_r),
+            )
+
+            desc_w = int(self._rx_desc_write_r.value)
+            data_w = int(self._rx_data_write_r.value)
+            rec_pending = int(self._recovery_pending.value)
+
+            if rec_pending:
+                # RI write leaked through to TTI interrupt path
+                sig = []
+                if desc_w:
+                    sig.append("rx_desc_queue_write_r")
+                if data_w:
+                    sig.append("rx_data_queue_write_r")
+                msg = (
+                    f"TTI queue write during recovery_pending=1: "
+                    f"{', '.join(sig)} @ {cocotb.utils.get_sim_time('ns')}ns"
+                )
+                self.dut._log.error(msg)
+                raise AssertionError(f"TtiQueueMonitor: {msg}")
+            else:
+                self._normal_write_count += 1
+
+    @property
+    def normal_write_count(self):
+        """Number of legitimate (non-recovery) queue write events observed."""
+        return self._normal_write_count


### PR DESCRIPTION
**RTL:**
- descriptor_rx: Remove 1-cycle delay registers; emit flush and descriptor on the transfer_ended cycle instead of transfer_ended_q, eliminating the recovery/TTI flush race condition and aligning the output signals with the virtual_device_sel from i3c_target_fsm.
- recovery_receiver: Detect bus-level T-bit errors via rx_desc_wdata error bits during RI write/read flows; flush partial words combinationally; add alignment assertions
- recovery_handler: Wire rx_desc interface to recovery_receiver; default empty queue status to 1 (fixing AXI hang; remove stale FUTUREFIX comment

**Verification:**
- Add TtiQueueMonitor: continuous checker that asserts immediately if TTI queue interrupt fire during recovery_pending, centralized in I3CTopTestInterface.setup() so all tests get it automatically
- Add test_parity_error_isolation: validates T-bit errors during PEC
- Add T-bit error injection helpers to i3c_recovery_interface_fixed
- Add AXI empty queue read tests for descriptor/data queue edge cases and while we are recovery_pending == 1 (hang scenario)