### PR TITLE
[src] fix CCC RSTACT

### DIFF
--- a/src/csr/I3CCSR.sv
+++ b/src/csr/I3CCSR.sv
@@ -8374,16 +8374,16 @@ module I3CCSR (
         automatic logic load_next_c;
         next_c = field_storage.I3C_EC.StdbyCtrlMode.STBY_CR_CCC_CONFIG_RSTACT_PARAMS.RST_ACTION.value;
         load_next_c = '0;
-        if(hwif_in.I3C_EC.StdbyCtrlMode.STBY_CR_CCC_CONFIG_RSTACT_PARAMS.RST_ACTION.we) begin // HW Write - we
-            next_c = hwif_in.I3C_EC.StdbyCtrlMode.STBY_CR_CCC_CONFIG_RSTACT_PARAMS.RST_ACTION.next;
-            load_next_c = '1;
-        end
+        
+        // HW Write
+        next_c = hwif_in.I3C_EC.StdbyCtrlMode.STBY_CR_CCC_CONFIG_RSTACT_PARAMS.RST_ACTION.next;
+        load_next_c = '1;
         field_combo.I3C_EC.StdbyCtrlMode.STBY_CR_CCC_CONFIG_RSTACT_PARAMS.RST_ACTION.next = next_c;
         field_combo.I3C_EC.StdbyCtrlMode.STBY_CR_CCC_CONFIG_RSTACT_PARAMS.RST_ACTION.load_next = load_next_c;
     end
     always_ff @(posedge clk or negedge hwif_in.rst_ni) begin
         if(~hwif_in.rst_ni) begin
-            field_storage.I3C_EC.StdbyCtrlMode.STBY_CR_CCC_CONFIG_RSTACT_PARAMS.RST_ACTION.value <= 8'h0;
+            field_storage.I3C_EC.StdbyCtrlMode.STBY_CR_CCC_CONFIG_RSTACT_PARAMS.RST_ACTION.value <= 8'h1;
         end else begin
             if(field_combo.I3C_EC.StdbyCtrlMode.STBY_CR_CCC_CONFIG_RSTACT_PARAMS.RST_ACTION.load_next) begin
                 field_storage.I3C_EC.StdbyCtrlMode.STBY_CR_CCC_CONFIG_RSTACT_PARAMS.RST_ACTION.value <= field_combo.I3C_EC.StdbyCtrlMode.STBY_CR_CCC_CONFIG_RSTACT_PARAMS.RST_ACTION.next;

--- a/src/csr/I3CCSR_pkg.sv
+++ b/src/csr/I3CCSR_pkg.sv
@@ -903,7 +903,6 @@ package I3CCSR_pkg;
 
     typedef struct packed{
         logic [7:0] next;
-        logic we;
     } I3CCSR__I3C_EC__StdbyCtrlMode__STBY_CR_CCC_CONFIG_RSTACT_PARAMS__RST_ACTION__in_t;
 
     typedef struct packed{

--- a/src/csr/I3CCSR_uvm.sv
+++ b/src/csr/I3CCSR_uvm.sv
@@ -3579,7 +3579,7 @@ package I3CCSR_uvm;
 
         virtual function void build();
             this.RST_ACTION = new("RST_ACTION");
-            this.RST_ACTION.configure(this, 8, 0, "RO", 1, 'h0, 1, 1, 0);
+            this.RST_ACTION.configure(this, 8, 0, "RO", 1, 'h1, 1, 1, 0);
             this.RESET_TIME_PERIPHERAL = new("RESET_TIME_PERIPHERAL");
             this.RESET_TIME_PERIPHERAL.configure(this, 8, 8, "RW", 1, 'h0, 1, 1, 0);
             this.RESET_TIME_TARGET = new("RESET_TIME_TARGET");

--- a/src/ctrl/ccc.sv
+++ b/src/ctrl/ccc.sv
@@ -286,8 +286,8 @@ module ccc
     // -------------------------------------------------------------------------
     input  logic target_reset_detect_i,
     input  logic peripheral_reset_done_i,
-    output logic rstact_armed_o,
-    output logic escalate_reset_o
+    output logic peripheral_reset_o,
+    output logic escalated_reset_o
 );
 
 
@@ -441,9 +441,14 @@ module ccc
   // ---------------------------------------------------------------------------
   // RSTACT Handling
   // ---------------------------------------------------------------------------
-  logic [7:0] rst_action;
-  logic       rst_action_valid;
-  logic       rstact_armed;
+  logic [7:0] rst_action_q;
+  logic [7:0] rst_action_d;
+  logic       rstact_armed_q;
+  logic       rstact_armed_d;
+  logic       escalate_rst_arm_q;
+  logic       escalate_rst_arm_d;
+  logic       set_peripheral_reset;
+  logic       set_escalate_reset;
 
   // ---------------------------------------------------------------------------
   // HDR Mode Handling
@@ -509,7 +514,6 @@ module ccc
   logic        disec_ibi_next;
   logic        disec_crr_next;
   logic        disec_hj_next;
-  logic        rst_action_valid_next;
 
   // ---------------------------------------------------------------------------
   // Broadcast CCC Handler Next-State Signals
@@ -1066,6 +1070,9 @@ module ccc
           end else if (target_addr_matches_any_get_cmd) begin
             // ACKed GET command: Target transmits data
             state_d = TxData;
+          end else if (is_rstact) begin
+            // RSTACT write: no data phase (defining byte already captured)
+            state_d = WaitForBusCond;
           end else begin
             // ACKed SET command (including SETDASA): Target receives data
             state_d = RxData;
@@ -1293,7 +1300,7 @@ module ccc
           tx_data = 8'hFF;
         end else if (defining_byte inside {8'h00, 8'h01, 8'h02}) begin
           // 0x00-0x02: Return armed action, or 0x80 if not armed
-          tx_data = rstact_armed ? rst_action : 8'h80;
+          tx_data = rstact_armed_q ? rst_action_q : 8'h80;
         end
       end
       
@@ -1445,7 +1452,6 @@ module ccc
     disec_ibi_next        = 1'b0;
     disec_crr_next        = 1'b0;
     disec_hj_next         = 1'b0;
-    rst_action_valid_next = 1'b0;
 
     // Process received data bytes
     // Note: For Direct CCCs, rx_data_valid only fires when target address matched
@@ -1553,24 +1559,6 @@ module ccc
       endcase
     end
 
-    // -----------------------------------------------------------------
-    // RSTACT: Arm reset action (triggers on ACK/T-bit, not data bytes)
-    // -----------------------------------------------------------------
-    case (command_code)
-      CCC_DIRECT_RSTACT: begin
-        // Direct RSTACT: Arm after target address ACK for action values (0x00-0x7F)
-        if (target_addr_ack_done && addr_ack_target && ~defining_byte[7]) begin
-          rst_action_valid_next = 1'b1;
-        end
-      end
-      CCC_BCAST_RSTACT: begin
-        // Broadcast RSTACT: Arm after defining byte T-bit for action values (0x00-0x7F)
-        if (def_byte_tbit_valid && ~defining_byte[7]) begin
-          rst_action_valid_next = 1'b1;
-        end
-      end
-      default: begin end
-    endcase
   end
 
   // ---------------------------------------------------------------------------
@@ -1594,7 +1582,6 @@ module ccc
       disec_ibi        <= '0;
       disec_crr        <= '0;
       disec_hj         <= '0;
-      rst_action_valid <= 1'b0;
     end else begin
       set_dasa_valid   <= set_dasa_valid_next;
       set_dasa_addr    <= set_dasa_addr_next;
@@ -1612,7 +1599,6 @@ module ccc
       disec_ibi        <= disec_ibi_next;
       disec_crr        <= disec_crr_next;
       disec_hj         <= disec_hj_next;
-      rst_action_valid <= rst_action_valid_next;
     end
   end
 
@@ -1671,58 +1657,107 @@ module ccc
   end
 
   // ===========================================================================
-  // RSTACT STATE MACHINE
+  // RSTACT
   // ===========================================================================
-  // Track RSTACT armed state and handle reset actions
-  always_ff @(posedge clk_i or negedge rst_ni) begin : rst_action_state
-    if (~rst_ni) begin
-      rstact_armed <= '0;
-      rst_action   <= '0;
+
+  always_comb begin : proc_rstact_comb
+    rstact_armed_d    = rstact_armed_q;
+    rst_action_d      = rst_action_q;
+
+    // --- Arming: Clear on START (not Repeated START) ---
+    // Spec: "Any reset action configured via the RSTACT CCC shall be cleared
+    // by the next SCL falling edge following a START (but not by the next
+    // Repeated START)."
+    if (bus_start_det_i) begin
+      rstact_armed_d = 1'b0;
+      rst_action_d   = 8'h00;
     end else begin
-      if (rst_action_valid) begin
-        rstact_armed <= 1'b1;
-        rst_action   <= defining_byte;
+
+      case(command_code) 
+        CCC_BCAST_RSTACT: begin
+          if (def_byte_tbit_valid && (defining_byte inside {8'h00, 8'h01, 8'h02})) begin
+            rstact_armed_d = 1'b1;
+            rst_action_d   = defining_byte;
+          end
+        end
+
+        CCC_DIRECT_RSTACT: begin
+          if (target_addr_ack_done && addr_ack && ~target_rnw &&
+             (defining_byte inside {8'h00, 8'h01, 8'h02})) begin
+            rstact_armed_d = 1'b1;
+            rst_action_d   = defining_byte;
+          end
+        end
+      endcase
+
+    end
+  end
+
+
+  always_comb begin : proc_escalate_rst_arm_comb
+    escalate_rst_arm_d = escalate_rst_arm_q;
+
+    // --- Escalation: Clear on any RSTACT CCC (any format) or GETSTATUS ---
+    // FAQ: "receiving the RSTACT CCC in any format will cause the Target to
+    // clear any escalation operation that might be in progress even if the
+    // Target does not support that Defining Byte value or if the Target NACKs"
+    // FAQ: "This state is cleared if the Target sees either any RSTACT CCC, or a
+    //       GETSTATUS CCC addressed to it."
+    if ((command_code_valid && (command_code == CCC_BCAST_RSTACT)) ||
+        (target_addr_ack_done && target_addr_matches_any &&
+            ((command_code == CCC_DIRECT_RSTACT) || 
+             (command_code == CCC_DIRECT_GETSTATUS)))) begin 
+      escalate_rst_arm_d = 1'b0;
+    // --- Escalation: Arm after default peripheral reset ---
+    // First reset pattern with no armed RSTACT action sets the escalation flag.
+    // A second reset pattern (still without RSTACT/GETSTATUS) will then escalate.
+    end else if (target_reset_detect_i && ~rstact_armed_q && ~escalate_rst_arm_q) begin
+      escalate_rst_arm_d = 1'b1;
+    end
+  end
+
+  // Armed path, 0x01: peripheral reset on Target Reset Pattern
+  // Default path, first reset pattern without RSTACT: peripheral reset
+  assign set_peripheral_reset = target_reset_detect_i && (
+                                  (rstact_armed_q && (rst_action_q == 8'h01)) ||
+                                  (~rstact_armed_q && ~escalate_rst_arm_q));
+
+  // Armed path, 0x02: whole-target reset on Target Reset Pattern
+  // Default path, second reset pattern without intervening RSTACT/GETSTATUS: escalate
+  assign set_escalate_reset = target_reset_detect_i && (
+                                (rstact_armed_q && (rst_action_q == 8'h02)) ||
+                                (~rstact_armed_q && escalate_rst_arm_q));
+                                
+
+  // ---------------------------------------------------------------------------
+  // Sequential logic: RSTACT registers
+  // ---------------------------------------------------------------------------
+  always_ff @(posedge clk_i or negedge rst_ni) begin : proc_rstact_seq
+    if (~rst_ni) begin
+      rstact_armed_q     <= 1'b0;
+      rst_action_q       <= 8'h00;
+      escalate_rst_arm_q <= 1'b0;
+      peripheral_reset_o <= 1'b0;
+      escalated_reset_o   <= 1'b0;
+    end else begin
+      rstact_armed_q     <= rstact_armed_d;
+      rst_action_q       <= rst_action_d;
+      escalate_rst_arm_q <= escalate_rst_arm_d;
+
+      if (set_peripheral_reset) begin
+        peripheral_reset_o <= 1'b1;
+      end else if (peripheral_reset_done_i) begin
+        peripheral_reset_o <= 1'b0;
       end
 
-      // Clear on start condition
-      if (bus_start_det_i) begin
-        rstact_armed <= '0;
-        rst_action   <= '0;
+      if (set_escalate_reset) begin
+        escalated_reset_o <= 1'b1;
       end
     end
   end
 
-  assign rstact_armed_o = rstact_armed;
-  
-  // Generate reset action outputs when armed and reset detected
-  always_ff @(posedge clk_i or negedge rst_ni) begin : rst_action_output_gen
-    if (~rst_ni) begin
-      rst_action_valid_o <= '0;
-      rst_action_o <= '0;
-    end else begin
-      if (rstact_armed & target_reset_detect_i) begin
-        rst_action_valid_o <= 1'b1;
-        rst_action_o <= rst_action;
-      end
-
-      if (bus_start_det_i) begin
-        rst_action_valid_o <= '0;
-        rst_action_o <= '0;
-      end
-    end
-  end
-
-  // Reset escalation logic
-  always_ff @(posedge clk_i or negedge rst_ni) begin : reset_escalation
-    if (~rst_ni) begin
-      escalate_reset_o <= '0;
-    end else begin
-      if (peripheral_reset_done_i) escalate_reset_o <= '1;
-      if (command_code inside {CCC_DIRECT_RSTACT, CCC_BCAST_RSTACT, CCC_DIRECT_GETSTATUS} &
-          command_code_valid)
-        escalate_reset_o <= '0;
-    end
-  end
+  assign rst_action_o       = rst_action_q;
+  assign rst_action_valid_o = rstact_armed_q;
 
   // ===========================================================================
   // ENEC/DISEC OUTPUT ASSIGNMENTS

--- a/src/ctrl/controller_standby_i3c.sv
+++ b/src/ctrl/controller_standby_i3c.sv
@@ -280,8 +280,6 @@ module controller_standby_i3c
   // Private write parity error (from target FSM)
   logic te2_err_priv_wr;
 
-  logic escalate_reset;
-  logic rstact_armed;
 
   // Drive all unused inputs here
   assign ctrl_scl_o   = 1'b1;
@@ -548,8 +546,8 @@ module controller_standby_i3c
 
     .target_reset_detect_i   (target_reset_detect),
     .peripheral_reset_done_i,
-    .rstact_armed_o          (rstact_armed),
-    .escalate_reset_o        (escalate_reset)
+    .peripheral_reset_o,
+    .escalated_reset_o
   );
 
   bus_tx_flow u_bus_tx_flow (
@@ -713,31 +711,5 @@ module controller_standby_i3c
     .ibi_pending_o
   );
 
-  logic peripheral_reset;
-  logic escalated_reset;
-
-  always_ff @(posedge clk_i or negedge rst_ni) begin : register_peripheral_reset
-    if (~rst_ni) begin
-      peripheral_reset_o <= '0;
-    end else begin
-      if (peripheral_reset) peripheral_reset_o <= 1'b1;
-      if (peripheral_reset_done_i) peripheral_reset_o <= '0;
-    end
-  end
-
-  always_ff @(posedge clk_i or negedge rst_ni) begin : register_escalated_reset
-    if (~rst_ni) begin
-      escalated_reset_o <= '0;
-    end else begin
-      if (escalated_reset) escalated_reset_o <= 1'b1;
-    end
-  end
-
-  // Reset peripheral for reset action 0x1 or when we receive 1st Target Reset Pattern
-  assign peripheral_reset = ((rst_action_o == 8'h1) & rst_action_valid_o) |
-                              (target_reset_detect & ~escalate_reset & ~rstact_armed);
-  // Escalate reset for reset action 0x2 or when we receive 2nd Target Reset Pattern
-  assign escalated_reset = ((rst_action_o == 8'h2) & rst_action_valid_o) |
-                             (target_reset_detect & escalate_reset & ~rstact_armed);
 
 endmodule

--- a/src/hci/hci.sv
+++ b/src/hci/hci.sv
@@ -312,7 +312,7 @@ module hci
   end : wire_hwif
 
   always_comb begin : wire_hwif_rstact
-    hwif_in.I3C_EC.StdbyCtrlMode.STBY_CR_CCC_CONFIG_RSTACT_PARAMS.RST_ACTION.next = rst_action_valid_i ? rst_action_i : '0;
+    hwif_in.I3C_EC.StdbyCtrlMode.STBY_CR_CCC_CONFIG_RSTACT_PARAMS.RST_ACTION.next = rst_action_valid_i ? rst_action_i : 9'h1;
   end
 
   always_comb begin : wire_address_setting
@@ -572,7 +572,6 @@ module hci
 
   always_comb begin : wire_unconnected_regs
     hwif_in.I3C_EC.StdbyCtrlMode.STBY_CR_VIRT_DEVICE_ADDR.VIRT_STATIC_ADDR_VALID.next = '0;
-    hwif_in.I3C_EC.StdbyCtrlMode.STBY_CR_CCC_CONFIG_RSTACT_PARAMS.RST_ACTION.we = '0;
     hwif_in.I3C_EC.StdbyCtrlMode.STBY_CR_INTR_SIGNAL_ENABLE.STBY_CR_OP_RSTACT_SIGNAL_EN.we = '0;
     hwif_in.I3C_EC.StdbyCtrlMode.STBY_CR_VIRT_DEVICE_ADDR.VIRT_STATIC_ADDR.next = '0;
     hwif_in.I3C_EC.CtrlCfg.CONTROLLER_CONFIG.OPERATION_MODE.next = '0;

--- a/src/rdl/docs/README.md
+++ b/src/rdl/docs/README.md
@@ -2564,14 +2564,14 @@ STBY_CR_INTR_SIGNAL_ENABLE</p>
 
 | Bits|      Identifier     |Access|Reset|                  Name                  |
 |-----|---------------------|------|-----|----------------------------------------|
-| 7:0 |      RST_ACTION     |   r  | 0x0 |     Defining Byte of the RSTACT CCC    |
+| 7:0 |      RST_ACTION     |   r  | 0x1 |     Defining Byte of the RSTACT CCC    |
 | 15:8|RESET_TIME_PERIPHERAL|  rw  | 0x0 |        Time to Reset Peripheral        |
 |23:16|  RESET_TIME_TARGET  |  rw  | 0x0 |          Time to Reset Target          |
 |  31 |  RESET_DYNAMIC_ADDR |  rw  | 0x1 |Reset Dynamic Address after Target Reset|
 
 #### RST_ACTION field
 
-<p>Contains the Defining Byte received with the last Direct SET CCC sent by the Active Controller.</p>
+<p>Contains the Defining Byte received with the last Direct SET CCC sent by the Active Controller. If not armed (START or RSTACT with unsupported defining byte) set to spec default 0x1.</p>
 
 #### RESET_TIME_PERIPHERAL field
 

--- a/src/rdl/standby_controller_mode.rdl
+++ b/src/rdl/standby_controller_mode.rdl
@@ -751,11 +751,10 @@ regfile StandbyControllerModeRegisters#(
         } RESET_TIME_PERIPHERAL[15:8];
         field {
             name = "Defining Byte of the RSTACT CCC";
-            desc = "Contains the Defining Byte received with the last Direct SET CCC sent by the Active Controller.";
+            desc = "Contains the Defining Byte received with the last Direct SET CCC sent by the Active Controller. If not armed (START or RSTACT with unsupported defining byte) set to spec default 0x1.";
             hw   = rw;
-            we   = true;
             sw   = r;
-            reset = 1'b0;
+            reset = 1'b1;
         } RST_ACTION[7:0];
     } STBY_CR_CCC_CONFIG_RSTACT_PARAMS;
     reg {

--- a/verification/cocotb/common/reg_map.py
+++ b/verification/cocotb/common/reg_map.py
@@ -2846,7 +2846,7 @@ reg_map = Munch.fromDict({
                 "RST_ACTION": {
                     "low": 0,
                     "mask": 255,
-                    "reset": 0,
+                    "reset": 1,
                     "sw": "r",
                     "hw": "rw",
                     "woclr": 0,

--- a/verification/cocotb/top/lib_i3c_top/test_ccc.py
+++ b/verification/cocotb/top/lib_i3c_top/test_ccc.py
@@ -809,11 +809,10 @@ async def test_ccc_rstact(dut, type, rstact):
         stop=False,
     )
 
-    # Check if reset action got stored correctly in the logic after Target Reset Pattern
+    # Check if reset action got stored correctly in the logic after RSTACT CCC
     sig = dut.xi3c_wrapper.i3c.xcontroller.xcontroller_standby.xcontroller_standby_i3c.rst_action_o
-    assert int(sig) == 0
-    await i3c_controller.send_target_reset_pattern()
     assert rst_action == int(sig), f"Expected rst_action_o={rst_action}, got {int(sig)}"
+    await i3c_controller.send_target_reset_pattern()
     await i3c_controller.send_stop()
 
     # Start new frame and reset target with reset action set to peripheral reset

--- a/verification/cocotb/top/lib_i3c_top/test_recovery.py
+++ b/verification/cocotb/top/lib_i3c_top/test_recovery.py
@@ -790,7 +790,7 @@ async def test_chained_ri_and_ccc_commands(dut):
     # 16. CCC command (GETMRL) - STOP
     # =========================================================================
     responses = await i3c_controller.i3c_ccc_read(
-        ccc=CCC.DIRECT.GETMRL, addr=DYNAMIC_ADDR, count=2,
+        ccc=CCC.DIRECT.GETMRL, addr=DYNAMIC_ADDR, count=3,
         stop=True
     )
 
@@ -3375,7 +3375,7 @@ async def test_ri_comprehensive_stress(dut):
 
         # Directed CCC: GETMRL
         responses = await i3c_controller.i3c_ccc_read(
-            ccc=CCC.DIRECT.GETMRL, addr=DYNAMIC_ADDR, count=2, stop=True
+            ccc=CCC.DIRECT.GETMRL, addr=DYNAMIC_ADDR, count=3, stop=True
         )
         dut._log.info(f"  GETMRL: {responses[0][1].hex()}")
 


### PR DESCRIPTION
1. RSTACT CSR was never updated due to we tied to 0.
2. RSTACT logic was completely broken. 
    a. broadcast CCC wasn't trans from ADDR ACK -> wait for bus condition 
    b. The escalate and arm in general were broken
3. Add support for RSTACT defining bytes 0x4/0x84 per I3C spec we have virtual targets so we must support this. 