### PR TITLE
[src] Fix ENTDAA TE3 parity bypass and stale data in RX/TX width converters

### DIFF
--- a/src/ctrl/ccc.sv
+++ b/src/ctrl/ccc.sv
@@ -1139,9 +1139,11 @@ module ccc
         tx_req_ccc.data       = tx_data;
 
         if (bus_rstart_det_i) begin
-          // Controller abort: Target sent T=1 but Controller issued Sr
+          // Controller abort: Sr during T-bit means the transfer is
+          // incomplete — do NOT mark tx_data_complete. This prevents
+          // get_status_done_o from falsely firing on an aborted GETSTATUS,
+          // which would prematurely clear the Protocol Error in err_o.
           state_d = RxTargetAddr;
-          set_tx_data_complete = 1'b1;
         end else if (bus_tx_rsp_i.done) begin
           if (tx_data_last_byte) begin
             // Target complete: Target sent T=0, wait for Sr or STOP

--- a/src/ctrl/ccc_entdaa.sv
+++ b/src/ctrl/ccc_entdaa.sv
@@ -163,7 +163,7 @@ module ccc_entdaa
 
   // Odd parity check on received address byte
   // Address is in bits [7:1], parity bit is in bit [0]
-  assign parity_ok = (~^bus_rx_rsp_i.data[7:1] == bus_rx_rsp_i.data[0]) || te3_err_det_en_i;
+  assign parity_ok = (~^bus_rx_rsp_i.data[7:1] == bus_rx_rsp_i.data[0]) || !te3_err_det_en_i;
 
   // Extract 7-bit address from received byte (discard parity bit)
   assign address_o = bus_rx_rsp_i.data[7:1];

--- a/src/ctrl/i3c_target_fsm.sv
+++ b/src/ctrl/i3c_target_fsm.sv
@@ -130,7 +130,9 @@ module i3c_target_fsm import i3c_pkg::*; #(
 
   // Target specific variables
   logic nack_transaction_q, nack_transaction_d;
-  logic rx_overflow_err_q, rx_overflow_err_r;
+  logic rx_overflow_err_q, rx_overflow_err_d;
+  logic rx_fifo_wvalid_raw;
+
 
   i3c_byte_t last_byte;
 
@@ -308,24 +310,36 @@ module i3c_target_fsm import i3c_pkg::*; #(
     end
   end
 
+
+  // RX FIFO valid before overflow gating: byte complete with no protocol error.
+  assign rx_fifo_wvalid_raw = (state_q == RxPWriteTbit) && (state_d != RxPWriteTbit) &&
+                              !(te2_err_priv_wr || parity_err);
+
+  // Overflow detection using rx_fifo_wvalid_raw to detect overflow on the same
+  // cycle the byte completes, avoiding a combo loop (raw does not depend on
+  // rx_overflow_err_d).
+  always_comb begin
+    rx_overflow_err_d = rx_overflow_err_q;
+
+    if (rx_fifo_wvalid_raw & ~rx_fifo_wready_i) begin
+      rx_overflow_err_d = 1'b1;
+    end else if (target_idle_o | state_d inside {RxFByte, Idle}) begin
+      rx_overflow_err_d = 1'b0;
+    end 
+  end 
   always_ff @(posedge clk_i or negedge rst_ni) begin : latch_rx_overflow_error
     if (~rst_ni) begin
-      rx_overflow_err_r <= 1'b0;
       rx_overflow_err_q <= 1'b0;
     end else begin
-      rx_overflow_err_q <= rx_overflow_err_r;
-      if (state_d == RxPWriteData & ~rx_fifo_wready_i & rx_fifo_wvalid_o) rx_overflow_err_r <= 1'b1;
-      else if (target_idle_o | state_d inside {RxFByte, Idle}) rx_overflow_err_r <= 1'b0;
-    end
-  end
+      rx_overflow_err_q <= rx_overflow_err_d;
+    end 
+  end 
 
-  assign rx_overflow_err_o = ~rx_overflow_err_q & rx_overflow_err_r;
+  assign rx_overflow_err_o = ~rx_overflow_err_q & rx_overflow_err_d;
 
-  // RX FIFO valid when we finish reading byte (leave RxPWriteTbit) and there was no protocol error.
-  // Use te2_err_priv_wr (combinational) so that errored byte is blocked in the same cycle the 
-  // mismatch is detected.
-  assign rx_fifo_wvalid = (state_q == RxPWriteTbit) && (state_d != RxPWriteTbit) &&
-                          !(te2_err_priv_wr || parity_err || rx_overflow_err_o);
+  // Final gated valid: block the push if overflow is detected this cycle.
+  assign rx_fifo_wvalid = rx_fifo_wvalid_raw & ~rx_overflow_err_d;
+
 
   always_ff @(posedge clk_i or negedge rst_ni) begin : latch_rx_fifo_wvalid
     if (~rst_ni) begin

--- a/src/ctrl/i3c_target_fsm.sv
+++ b/src/ctrl/i3c_target_fsm.sv
@@ -249,8 +249,9 @@ module i3c_target_fsm import i3c_pkg::*; #(
 
   // TE0 error: Invalid reserved address + RnW combinations
   // Uses shared function from i3c_pkg to ensure consistency with ccc.sv
-  // Qualified with last_addr_valid_o to only report when address is valid
-  assign te0_err_o = te0_enable_i && last_addr_valid_o && is_te0_rsvd_addr_err(bus_addr_q, bus_rnw_q);
+  // Qualified with bus_addr_valid (single-cycle pulse) so te0_err_o is a
+  // single-cycle pulse, consistent with all other TE error signals.
+  assign te0_err_o = te0_enable_i && bus_addr_valid && is_te0_rsvd_addr_err(bus_addr_d, bus_rnw_d);
 
   // Latch whether this transaction is to be NACK'd.
   always_ff @(posedge clk_i or negedge rst_ni) begin : clk_nack_transaction

--- a/src/ctrl/i3c_target_fsm.sv
+++ b/src/ctrl/i3c_target_fsm.sv
@@ -313,7 +313,9 @@ module i3c_target_fsm import i3c_pkg::*; #(
 
 
   // RX FIFO valid before overflow gating: byte complete with no protocol error.
-  assign rx_fifo_wvalid_raw = (state_q == RxPWriteTbit) && (state_d != RxPWriteTbit) &&
+  // Gate with bus_rx_rsp_i.done so that STOP/Sr during the T-bit phase does NOT
+  // push an unchecked byte (the T-bit was never received, parity was never verified).
+  assign rx_fifo_wvalid_raw = (state_q == RxPWriteTbit) && bus_rx_rsp_i.done &&
                               !(te2_err_priv_wr || parity_err);
 
   // Overflow detection using rx_fifo_wvalid_raw to detect overflow on the same
@@ -354,12 +356,18 @@ module i3c_target_fsm import i3c_pkg::*; #(
       end
     end
   end
-  // FSM on the last T bit will transition to
-  // RxPWriteData because the Sr/Stop doesn't happen until after we complete
-  // the T bit and are waiting for the next set of data in RxPWriteData. In
-  // this state if we get a repeat start we transition into RxFByte if we get
-  // a stop we transition to Idle. 
-  assign rx_last_byte_o = (state_q == RxPWriteData) && (state_d inside {RxFByte, Idle});
+  // Normal path: FSM completes the T-bit in RxPWriteTbit, transitions to
+  // RxPWriteData, and waits for the next byte. Sr/Stop arrives in RxPWriteData,
+  // setting state_d to RxFByte or Idle respectively.
+  //
+  // Abort path: If Sr/Stop arrives while still in RxPWriteTbit (before the T-bit
+  // completes), the incomplete byte is NOT pushed (gated by bus_rx_rsp_i.done
+  // above), but we still need a descriptor for the previously completed bytes.
+  // Including RxPWriteTbit in the state_q check covers this abort case. The
+  // normal T-bit completion (state_d = RxPWriteData) is excluded by the
+  // state_d inside {RxFByte, Idle} check, so no spurious descriptor is generated.
+  assign rx_last_byte_o = (state_q inside {RxPWriteData, RxPWriteTbit}) &&
+                          (state_d inside {RxFByte, Idle});
 
   // Logic for latching CCC code
   always_ff @(posedge clk_i or negedge rst_ni) begin : latch_ccc_data

--- a/src/rdl/docs/README.md
+++ b/src/rdl/docs/README.md
@@ -2818,7 +2818,7 @@ Part of data in the IBI queue is considered corrupted and will be discarded.
 
 #### TX_DATA_RST field
 
-<p>TTI TX Data Queue Buffer Software Reset. Also resets the tti_conv_Nto8 since first dword is immediatly loaded into the converter and can't be cleared otherwise.</p>
+<p>TTI TX Data Queue Buffer Software Reset. Also resets the tti_conv_Nto8 since first dword is immediately loaded into the converter and can't be cleared otherwise.</p>
 
 #### RX_DATA_RST field
 

--- a/src/rdl/docs/README.md
+++ b/src/rdl/docs/README.md
@@ -2818,7 +2818,7 @@ Part of data in the IBI queue is considered corrupted and will be discarded.
 
 #### TX_DATA_RST field
 
-<p>TTI TX Data Queue Buffer Software Reset</p>
+<p>TTI TX Data Queue Buffer Software Reset. Also resets the tti_conv_Nto8 since first dword is immediatly loaded into the converter and can't be cleared otherwise.</p>
 
 #### RX_DATA_RST field
 

--- a/src/rdl/target_transaction_interface.rdl
+++ b/src/rdl/target_transaction_interface.rdl
@@ -153,7 +153,7 @@ regfile TargetTransactionInterfaceRegisters #(
         } RX_DATA_RST[4:4];
         field {
             name = "TX_DATA_RST";
-            desc = "TTI TX Data Queue Buffer Software Reset";
+            desc = "TTI TX Data Queue Buffer Software Reset. Also resets the tti_conv_Nto8 since first dword is immediatly loaded into the converter and can't be cleared otherwise.";
             sw = rw;
             hw = rw;
             we = true;

--- a/src/rdl/target_transaction_interface.rdl
+++ b/src/rdl/target_transaction_interface.rdl
@@ -153,7 +153,7 @@ regfile TargetTransactionInterfaceRegisters #(
         } RX_DATA_RST[4:4];
         field {
             name = "TX_DATA_RST";
-            desc = "TTI TX Data Queue Buffer Software Reset. Also resets the tti_conv_Nto8 since first dword is immediatly loaded into the converter and can't be cleared otherwise.";
+            desc = "TTI TX Data Queue Buffer Software Reset. Also resets the tti_conv_Nto8 since first dword is immediately loaded into the converter and can't be cleared otherwise.";
             sw = rw;
             hw = rw;
             we = true;

--- a/src/recovery/recovery_handler.sv
+++ b/src/recovery/recovery_handler.sv
@@ -530,7 +530,7 @@ module recovery_handler
   ) tti_conv_8toN (
       .clk_i,
       .rst_ni(rst_ni),
-      .soft_reset_ni(~bypass_i3c_core_i & ~recv_conv_soft_reset),
+      .soft_reset_ni(~bypass_i3c_core_i & ~recv_conv_soft_reset & ~tti_rx_data_queue_reg_rst),
 
       .sink_valid_i(tti_rx_data_queue_wvalid),
       .sink_ready_o(tti_rx_data_queue_wready),

--- a/src/recovery/recovery_handler.sv
+++ b/src/recovery/recovery_handler.sv
@@ -842,7 +842,7 @@ module recovery_handler
 
     end else begin
       tti_tx_data_queue_rready_conv_source    = ctl_tti_tx_data_queue_rready_i;
-      tti_tx_data_queue_flush_conv_source     = ctl_tti_tx_data_queue_flush_i;
+      tti_tx_data_queue_flush_conv_source     = ctl_tti_tx_data_queue_flush_i | tti_tx_data_queue_reg_rst;
       send_tti_tx_data_ready                  = '0;
       ctl_tti_tx_data_queue_full_o            = tti_tx_data_queue_full;
       ctl_tti_tx_data_queue_depth_o           = tti_tx_data_queue_depth;

--- a/verification/cocotb/top/lib_i3c_top/test_i3c_target.py
+++ b/verification/cocotb/top/lib_i3c_top/test_i3c_target.py
@@ -1008,3 +1008,89 @@ async def test_i3c_target_private_read_sizes_and_abort(dut):
     await ClockCycles(tb.clk, 10)
 
     await ClockCycles(tb.clk, 100)
+
+
+@cocotb.test()
+async def test_i3c_target_tx_flush_clears_converter(dut):
+    """
+    Verify that TTI RESET_CONTROL.TX_DATA_RST flushes both the TX FIFO
+    and the width_converter_Nto8 shift register.
+
+    Steps:
+    1. Write 8 bytes (2 dwords) to the TX FIFO (no descriptor yet, so no read).
+       The first dword is eagerly pulled into the Nto8 converter's sreg.
+    2. Flush TX data queue via RESET_CONTROL.TX_DATA_RST.
+    3. Write new data and a descriptor, then perform a private read.
+    4. Verify the read returns only the new data (no stale sreg bytes).
+    """
+
+    i3c_controller, i3c_target, tb = await test_setup(dut)
+
+    def compare(expected, received):
+        dut._log.info("Expected: [" + " ".join([f"{d:02X}" for d in expected]) + "]")
+        dut._log.info("Received: [" + " ".join([f"{d:02X}" for d in received]) + "]")
+        assert expected == received
+
+    async def enqueue_tx_data(data):
+        """Write data to TTI TX FIFO and TX descriptor."""
+        length = len(data)
+        for i in range((length + 3) // 4):
+            word = data[4 * i]
+            if 4 * i + 1 < length:
+                word |= data[4 * i + 1] << 8
+            if 4 * i + 2 < length:
+                word |= data[4 * i + 2] << 16
+            if 4 * i + 3 < length:
+                word |= data[4 * i + 3] << 24
+            await tb.write_csr(tb.reg_map.I3C_EC.TTI.TX_DATA_PORT.base_addr, int2dword(word), 4)
+        await tb.write_csr(tb.reg_map.I3C_EC.TTI.TX_DESC_QUEUE_PORT.base_addr, int2dword(length), 4)
+
+    # Step 1: Write stale data to TX FIFO (data only, no descriptor)
+    stale_data = [0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE, 0xBA, 0xBE]
+    for i in range(2):
+        word = (stale_data[4 * i]
+                | stale_data[4 * i + 1] << 8
+                | stale_data[4 * i + 2] << 16
+                | stale_data[4 * i + 3] << 24)
+        await tb.write_csr(tb.reg_map.I3C_EC.TTI.TX_DATA_PORT.base_addr, int2dword(word), 4)
+
+    # Wait for the converter to pull the first dword into its sreg
+    await ClockCycles(tb.clk, 10)
+
+    # Step 2: Flush TX data queue via RESET_CONTROL
+    await tb.write_csr_field(
+        tb.reg_map.I3C_EC.TTI.RESET_CONTROL.base_addr,
+        tb.reg_map.I3C_EC.TTI.RESET_CONTROL.TX_DATA_RST,
+        1,
+    )
+    await ClockCycles(tb.clk, 10)
+    await tb.write_csr_field(
+        tb.reg_map.I3C_EC.TTI.RESET_CONTROL.base_addr,
+        tb.reg_map.I3C_EC.TTI.RESET_CONTROL.TX_DATA_RST,
+        0,
+    )
+
+    # Also flush the TX descriptor queue
+    await tb.write_csr_field(
+        tb.reg_map.I3C_EC.TTI.RESET_CONTROL.base_addr,
+        tb.reg_map.I3C_EC.TTI.RESET_CONTROL.TX_DESC_RST,
+        1,
+    )
+    await ClockCycles(tb.clk, 10)
+    await tb.write_csr_field(
+        tb.reg_map.I3C_EC.TTI.RESET_CONTROL.base_addr,
+        tb.reg_map.I3C_EC.TTI.RESET_CONTROL.TX_DESC_RST,
+        0,
+    )
+    await ClockCycles(tb.clk, 10)
+
+    # Step 3: Write new data and enqueue descriptor, then do private read
+    new_data = [random.randint(0, 255) for _ in range(8)]
+    await enqueue_tx_data(new_data)
+    rx_resp = await i3c_controller.i3c_read(TARGET_ADDRESS, 8)
+    assert not rx_resp.nack, "Unexpected NACK on post-flush read"
+
+    # Step 4: Verify we got the new data, not stale sreg contents
+    compare(new_data, list(rx_resp.data))
+
+    await ClockCycles(tb.clk, 100)


### PR DESCRIPTION
- ENTDAA TE3 parity check bypassed when enabled — parity_ok in ccc_entdaa.sv used || te3_err_det_en_i instead of || 
  !te3_err_det_en_i, making TE3 error detection non-functional. The target ACKed addresses with bad parity instead of 
  NACKing per I3C spec §5.1.10.1.4.
- Stale RX byte after overflow — After an RX FIFO overflow during a private write, rx_fifo_wvalid_o stayed asserted in 
  i3c_target_fsm.sv. When the FIFO later drained, the stale byte entered the 8-to-N width converter and corrupted the next 
  transfer. Fixed by gating wvalid on overflow and clearing the converter on RX FIFO reset.
- Stale TX data after FIFO reset — The N-to-8 converter immediately loads from the TX FIFO, so a TX FIFO reset alone 
  left up to 32 bits of stale data in the converter. Added converter clear on TX FIFO reset to fully flush the TX path.
- Fix TE0 pulsing for 2 clock cycles causing the counter to be inaccurate. 
- [handle STOP/Sr during T-bit in private write](https://github.com/chipsalliance/i3c-core/pull/139/changes/a001dff568aef77b7ddf3d4e45a016490a37acb1)
- [do not mark tx_data_complete on Sr abort in TxDataTbit](https://github.com/chipsalliance/i3c-core/pull/139/changes/b554fe9234cecb8954e22d2e425f8d8e947f0eaf)
