### PR TITLE
Correctly handle Write-Ack bus handoff

### DIFF
--- a/src/ctrl/bus_tx_flow.sv
+++ b/src/ctrl/bus_tx_flow.sv
@@ -110,7 +110,7 @@ module bus_tx_flow import i3c_pkg::*; (
         req_value    = '1;
         drive_mode   = OpenDrain;
       end
-      AckRegular, AckWrite: begin
+      AckRegular, AckHandoff: begin
         req_value[7] = 1'b0;
         drive_mode   = OpenDrain;
       end
@@ -222,7 +222,7 @@ module bus_tx_flow import i3c_pkg::*; (
         if (bus_i.scl.pos_edge) begin
           // Handle all cases that require half-bit changes to SDA data and drive mode
           case (tx_req_i.req_type)
-            AckWrite: begin
+            AckHandoff: begin
               // Release SDA in the middle of ACK to high-Z; Controller takes over driving
               // Specified in Section 5.1.2.3.1
               req_value_d[7] = 1'b1;

--- a/src/ctrl/ccc.sv
+++ b/src/ctrl/ccc.sv
@@ -1014,8 +1014,11 @@ module ccc
       // ---------------------------------------------------------------------
       WaitDirectRstart: begin
         // Wait for repeated start before target address
-        if (bus_rstart_det_i) state_d = RxTargetAddr;
-        else if (bus_rx_rsp_i.done) state_d = RxDirectDefByteTbit;
+        if (bus_rstart_det_i) begin
+          state_d = RxTargetAddr;
+        end else if (bus_rx_rsp_i.done) begin
+          state_d = RxDirectDefByteTbit;
+        end
       end
       
       RxDirectDefByteTbit: begin
@@ -1078,6 +1081,8 @@ module ccc
             state_d = WaitForBusCond;
           end else begin
             // ACKed SET command (including SETDASA): Target receives data
+            // We must overwrite the tx_request used above to handle the write handoff properly
+            tx_req_ccc.req_type = AckHandoff;
             state_d = RxData;
           end
         end

--- a/src/ctrl/i3c_target_fsm.sv
+++ b/src/ctrl/i3c_target_fsm.sv
@@ -646,7 +646,8 @@ module i3c_target_fsm import i3c_pkg::*; (
       end
       TxAckFByte: begin
         bus_tx_req_o.req_valid = 1'b1;
-        bus_tx_req_o.req_type  = bus_rnw_q ? AckRegular : AckWrite;
+        // Spec Annex A: Every "FByte" Ack is a Handoff except Private Reads after non-rsvd-Byte
+        bus_tx_req_o.req_type  = (bus_rnw_q && !is_rsvd_byte_match) ? AckRegular : AckHandoff;
 
         if (bus_tx_rsp_i.done) begin
           if (is_rsvd_byte_match) begin
@@ -700,7 +701,8 @@ module i3c_target_fsm import i3c_pkg::*; (
       end
       TxAckSByte: begin
         bus_tx_req_o.req_valid = 1'b1;
-        bus_tx_req_o.req_type  = AckRegular;
+        // For Private Writes, perform AckHandoff
+        bus_tx_req_o.req_type  = bus_rnw_q ? AckRegular : AckHandoff;
 
         if (bus_tx_rsp_i.done) begin
           state_d = bus_rnw_q ? TxPReadData : RxPWriteData;

--- a/src/i3c_pkg.sv
+++ b/src/i3c_pkg.sv
@@ -168,7 +168,7 @@ package i3c_pkg;
     RawBit,
     InitIbi,
     AckRegular,
-    AckWrite,
+    AckHandoff,
     AckIbi,
     TReadCont,
     TReadEnd

--- a/verification/cocotb/top/lib_i3c_top/boot.py
+++ b/verification/cocotb/top/lib_i3c_top/boot.py
@@ -258,28 +258,30 @@ async def umbrella_stby_init(
     )
 
     # Set static address and valid
-    await tb.write_csr_field(
-        tb.reg_map.I3C_EC.STDBYCTRLMODE.STBY_CR_DEVICE_ADDR.base_addr,
-        tb.reg_map.I3C_EC.STDBYCTRLMODE.STBY_CR_DEVICE_ADDR.STATIC_ADDR,
-        static_addr,
-    )
-    await tb.write_csr_field(
-        tb.reg_map.I3C_EC.STDBYCTRLMODE.STBY_CR_DEVICE_ADDR.base_addr,
-        tb.reg_map.I3C_EC.STDBYCTRLMODE.STBY_CR_DEVICE_ADDR.STATIC_ADDR_VALID,
-        0x1,
-    )
+    if static_addr is not None:
+        await tb.write_csr_field(
+            tb.reg_map.I3C_EC.STDBYCTRLMODE.STBY_CR_DEVICE_ADDR.base_addr,
+            tb.reg_map.I3C_EC.STDBYCTRLMODE.STBY_CR_DEVICE_ADDR.STATIC_ADDR,
+            static_addr,
+        )
+        await tb.write_csr_field(
+            tb.reg_map.I3C_EC.STDBYCTRLMODE.STBY_CR_DEVICE_ADDR.base_addr,
+            tb.reg_map.I3C_EC.STDBYCTRLMODE.STBY_CR_DEVICE_ADDR.STATIC_ADDR_VALID,
+            0x1,
+        )
 
     # Set static address and valid for virtual device
-    await tb.write_csr_field(
-        tb.reg_map.I3C_EC.STDBYCTRLMODE.STBY_CR_VIRT_DEVICE_ADDR.base_addr,
-        tb.reg_map.I3C_EC.STDBYCTRLMODE.STBY_CR_VIRT_DEVICE_ADDR.VIRT_STATIC_ADDR,
-        virtual_static_addr,
-    )
-    await tb.write_csr_field(
-        tb.reg_map.I3C_EC.STDBYCTRLMODE.STBY_CR_VIRT_DEVICE_ADDR.base_addr,
-        tb.reg_map.I3C_EC.STDBYCTRLMODE.STBY_CR_VIRT_DEVICE_ADDR.VIRT_STATIC_ADDR_VALID,
-        0x1,
-    )
+    if virtual_static_addr is not None:
+        await tb.write_csr_field(
+            tb.reg_map.I3C_EC.STDBYCTRLMODE.STBY_CR_VIRT_DEVICE_ADDR.base_addr,
+            tb.reg_map.I3C_EC.STDBYCTRLMODE.STBY_CR_VIRT_DEVICE_ADDR.VIRT_STATIC_ADDR,
+            virtual_static_addr,
+        )
+        await tb.write_csr_field(
+            tb.reg_map.I3C_EC.STDBYCTRLMODE.STBY_CR_VIRT_DEVICE_ADDR.base_addr,
+            tb.reg_map.I3C_EC.STDBYCTRLMODE.STBY_CR_VIRT_DEVICE_ADDR.VIRT_STATIC_ADDR_VALID,
+            0x1,
+        )
     # Set dynamic address and valid
     if dynamic_addr is not None:
         await tb.write_csr_field(

--- a/verification/cocotb/top/lib_i3c_top/test_i3c_target.py
+++ b/verification/cocotb/top/lib_i3c_top/test_i3c_target.py
@@ -21,7 +21,7 @@ TARGET_ADDRESS = 0x5A
 
 
 async def test_setup(dut, fclk=333.0, fbus=12.5,
-                     static_addr=0x5A, virtual_static_addr=0x5B,
+                     static_addr=TARGET_ADDRESS, virtual_static_addr=0x5B,
                      dynamic_addr=None, virtual_dynamic_addr=None):
     """
     Sets up controller, target models and top-level core interface
@@ -343,7 +343,7 @@ async def test_i3c_target_read_empty(dut):
 async def test_i3c_target_read_to_multiple_targets(dut):
 
     # Setup
-    i3c_controller, i3c_target, tb = await test_setup(dut, fclk=100)
+    i3c_controller, i3c_target, tb = await test_setup(dut, fclk=100, virtual_static_addr=None)
 
     # Generates a randomized transfer and puts it into the TTI TX queue
     async def make_transfer(min_len=1, max_len=16):


### PR DESCRIPTION
This PR renames the `AckRegular` tx transfer type to `AckHandoff` and changes the Target and CCC FSMs to use it in all situations where bus handover from target to controller is required, as per Annex A of the I3C Spec.

It furthermore contains @mkj121 's changes from https://github.com/chipsalliance/i3c-core/tree/v1p5-randomisation-fix to fix a seed-dependent regression failure.