### PR TITLE
[src] align bus_rx_flow done timing with bus_tx_flow

### DIFF
--- a/src/ctrl/bus_rx_flow.sv
+++ b/src/ctrl/bus_rx_flow.sv
@@ -19,7 +19,6 @@ module bus_rx_flow (
   logic       bit_counter_en;
 
   logic [6:0] rx_data;
-  logic       rx_bit;
 
   logic rx_bit_en;
   logic rx_done, rx_rsp_done;
@@ -40,7 +39,7 @@ module bus_rx_flow (
   assign rx_rsp_o = '{
     idle: (state_q == Idle),
     done: rx_rsp_done,
-    data: rx_req_bit ? {{7{1'b0}}, rx_bit} : {rx_data[6:0], sda_i}
+    data: rx_req_bit ? {{7{1'b0}}, sda_i} : {rx_data[6:0], sda_i}
   };
 
   always_ff @(posedge clk_i or negedge rst_ni) begin : ff_bit_request
@@ -51,20 +50,9 @@ module bus_rx_flow (
     end
   end
 
-  always_ff @(posedge clk_i or negedge rst_ni) begin : read_bit_from_bus
-    if (~rst_ni) begin
-      rx_done <= '0;
-      rx_bit  <= '0;
-    end else begin
-      if (rx_bit_en & scl_posedge_i) begin
-        rx_done <= 1'b1;
-        rx_bit  <= sda_i;
-      end else begin
-        rx_done <= '0;
-        rx_bit  <= '0;
-      end
-    end
-  end
+  // rx_done is combinational: fires on the same clk_i edge as scl_posedge_i,
+  // aligning it with bus_tx_flow's combinational tx_rsp_o.done.
+  assign rx_done = rx_bit_en & scl_posedge_i;
 
   always_ff @(posedge clk_i or negedge rst_ni) begin : read_byte_from_bus
     if (~rst_ni) begin
@@ -108,13 +96,13 @@ module bus_rx_flow (
       Idle: begin end
       ReadByte: begin
         bit_counter_en = 1'b1;
-        rx_bit_en = ~rx_done;
+        rx_bit_en = 1'b1;
         if (~|bit_counter & rx_done) begin
           rx_rsp_done = 1'b1;
         end
       end
       ReadBit: begin
-        rx_bit_en = ~rx_done;
+        rx_bit_en = 1'b1;
         if (rx_done) rx_rsp_done = 1'b1;
       end
       NextTaskDecision: begin

--- a/src/ctrl/i3c_target_fsm.sv
+++ b/src/ctrl/i3c_target_fsm.sv
@@ -612,11 +612,21 @@ module i3c_target_fsm import i3c_pkg::*; (
           bus_tx_req_o.data       = {target_ibi_addr_i, 1'b1};
 
           // On arb lost, inform IBI requester and hand over to regular RxFByte
-          // to receive rest of address
+          // to receive rest of address.  When arb loss coincides with the
+          // final bit (RnW), bus_rx_rsp_i.done fires on the same clock;
+          // skip RxFByte and go directly to CheckFByte so the completed
+          // byte is not lost.
           if (arbitration_lost_i) begin
             ibi_status_we_o = 1'b1;
             ibi_status_o    = IbiFailureAddressArb;
-            state_d = RxFByte;
+            if (bus_rx_rsp_i.done) begin
+              bus_addr_valid = 1'b1;
+              bus_addr_d     = bus_rx_rsp_i.data[7:1];
+              bus_rnw_d      = bus_rx_rsp_i.data[0];
+              state_d = CheckFByte;
+            end else begin
+              state_d = RxFByte;
+            end
           end else if (bus_tx_rsp_i.done) begin
             // IBI address has been submitted successfully, we won arbitration. Continue with IBI.
             state_d = IbiReadAck;

--- a/verification/cocotb/block/bus_rx_flow/test_bus_rx_flow.py
+++ b/verification/cocotb/block/bus_rx_flow/test_bus_rx_flow.py
@@ -6,7 +6,7 @@ from bus_monitor import BusMonitor
 
 import cocotb
 from cocotb.clock import Clock
-from cocotb.triggers import ClockCycles, FallingEdge, First, ReadOnly, RisingEdge
+from cocotb.triggers import ClockCycles, FallingEdge, First, RisingEdge
 
 CLOCK_PERIOD_NS = 2
 SCL_CLK_RATIO = 40
@@ -63,11 +63,12 @@ async def test_multiple_bit_reads(dut):
     await setup_test(dut)
 
     for d in data:
+        # Drive SDA during SCL low, before the posedge samples it
         await FallingEdge(dut.scl_i)
+        dut.sda_i.value = d
         await RisingEdge(dut.clk_i)
         dut.rx_req_bit_i.value = 1
 
-        dut.sda_i.value = d
         scl_negedge = FallingEdge(dut.scl_i)
         done_posedge = RisingEdge(dut.rx_done_o)
         result = await First(scl_negedge, done_posedge)
@@ -93,24 +94,27 @@ async def test_multiple_byte_reads(dut):
     await setup_test(dut)
 
     for d in data:
+        # Align to SCL falling edge and set request
         await FallingEdge(dut.scl_i)
         await RisingEdge(dut.clk_i)
         dut.rx_req_byte_i.value = 1
 
+        # Drive all 8 SDA bits, each set during SCL low so it is stable
+        # before the rising edge samples it.
         for b in range(8):
             dut.sda_i.value = (d >> (7 - b)) & 1
-            scl_negedge = FallingEdge(dut.scl_i)
-            done_posedge = RisingEdge(dut.rx_done_o)
+            await RisingEdge(dut.scl_i)
+            if b < 7:
+                await FallingEdge(dut.scl_i)
 
-            result = await First(scl_negedge, done_posedge)
-
-            if result == done_posedge:
-                await ReadOnly()
-                assert dut.rx_data_o.value == d
-                break
-
-            if b == 7:
-                assert False, "Did not detect RX Done when expected"
+        # After the 8th SCL rising edge, wait for done.
+        # done fires combinationally on the 8th scl_posedge_i pulse
+        # (scl_posedge_i is delayed t_r clk cycles after SCL rises).
+        await RisingEdge(dut.rx_done_o)
+        assert dut.rx_data_o.value == d, (
+            f"Byte mismatch: rx_data_o={int(dut.rx_data_o.value):#04x}, "
+            f"expected={d:#04x}"
+        )
 
         await RisingEdge(dut.clk_i)
         dut.rx_req_byte_i.value = 0

--- a/verification/cocotb/top/lib_i3c_top/test_ccc.py
+++ b/verification/cocotb/top/lib_i3c_top/test_ccc.py
@@ -3950,9 +3950,6 @@ async def test_ccc_entdaa_stop_in_ackrsvdbyte(dut):
 
     # Raw ENTDAA: S + 7E/W + 0x07 + Sr + 7E/R + ACK bit → STOP during ACK
     log.info("ENTDAA with STOP during AckRsvdByte")
-    if tb.bus_monitor:
-        tb.bus_monitor.suppress_check("BUS_CONTENTION")
-        tb.bus_monitor.suppress_check("ENTDAA_DA_HANDOFF")
     await i3c_controller.take_bus_control()
     await i3c_controller.send_start()
     await i3c_controller.write_addr_header(0x7E)
@@ -3963,9 +3960,6 @@ async def test_ccc_entdaa_stop_in_ackrsvdbyte(dut):
     # STOP right after ACK (target is in AckRsvdByte or just transitioned)
     await i3c_controller.send_stop()
     i3c_controller.give_bus_control()
-    if tb.bus_monitor:
-        tb.bus_monitor.unsuppress_check("BUS_CONTENTION")
-        tb.bus_monitor.unsuppress_check("ENTDAA_DA_HANDOFF")
     await ClockCycles(tb.clk, 50)
 
     # Recovery

--- a/verification/cocotb/top/lib_i3c_top/test_ibi.py
+++ b/verification/cocotb/top/lib_i3c_top/test_ibi.py
@@ -1354,8 +1354,11 @@ async def test_ibi_multiple_arb_losses(dut):
     """
     CP25/CP4/CP10: Force multiple consecutive IBI failures to exhaust the
     retry counter. retry_num=2 allows 3 attempts total (cnt 0,1,2);
-    3 NACKs should exhaust retries → IbiFailureRetry(3).
-    HW does NOT auto-flush the IBI FIFO on retry exhaustion.
+    3 NACKs should exhaust retries -> IbiFailureRetry(3).
+
+    HW does NOT auto-flush the IBI FIFO on retry exhaustion.  FW must
+    explicitly clear the IBI queue (IBI_QUEUE_RST) and reset the retry
+    counter (IBI_RETRY_CTR_RST) before queuing a fresh IBI.
 
     Uses NACK-based approach since bus-level arbitration timing makes
     it impractical to guarantee VIP wins on every attempt.
@@ -1377,24 +1380,31 @@ async def test_ibi_multiple_arb_losses(dut):
         )
 
     # After 3 NACKs with retry_num=2, counter (3) > retry_num (2)
-    # → IbiFailureRetry(3) + flush
+    # -> IbiFailureRetry(3).  descriptor_ibi stays in WriteMdb with
+    # stale data; InhibitRetry prevents further IBI attempts.
     await ClockCycles(tb.clk, 50)
     await check_ibi_status(tb, 3, "retry exhausted via consecutive NACKs")
 
-    # Verify IBI data was flushed — a fresh IBI should work cleanly.
-    # The retry counter is NOT reset by IbiFailureRetry, so we must
-    # reset it via FW before queuing the fresh IBI. Otherwise the DUT
-    # will immediately flush the new IBI too (counter > retry_num).
+    # FW recovery sequence: flush stale IBI data, then reset retry counter.
+    # IBI_QUEUE_RST clears descriptor_ibi back to Idle + empties FIFO.
+    await tb.write_csr_field(
+        tb.reg_map.I3C_EC.TTI.RESET_CONTROL.base_addr,
+        tb.reg_map.I3C_EC.TTI.RESET_CONTROL.IBI_QUEUE_RST,
+        1,
+    )
+    await ClockCycles(tb.clk, 5)
     await tb.write_csr_field(
         tb.reg_map.I3C_EC.TTI.RESET_CONTROL.base_addr,
         tb.reg_map.I3C_EC.TTI.RESET_CONTROL.IBI_RETRY_CTR_RST,
         1,
     )
+    await ClockCycles(tb.clk, 5)
+
     mdb_fresh = 0xFF
     fresh_data = [0x11, 0x22]
     await send_ibi(tb, mdb_fresh, fresh_data)
 
-    # DUT initiates IBI when bus_available fires (~1µs after last STOP).
+    # DUT initiates IBI when bus_available fires (~1us after last STOP).
     i3c_controller.enable_ibi(True)
     response = await with_timeout(
         i3c_controller.wait_for_ibi(), 20, "us",
@@ -1403,6 +1413,7 @@ async def test_ibi_multiple_arb_losses(dut):
     await check_ibi_status(tb, 0, "fresh IBI after retry exhaustion")
 
     await ClockCycles(tb.clk, 10)
+    await tb.teardown()
 
 
 # =============================================================================
@@ -1518,23 +1529,22 @@ async def test_rxfbytearb_collision_blind_drive(dut):
 @cocotb.test()
 async def test_ibi_flush_from_idle_interrupt_flood(dut):
     """
-    Provoke IbiFailureRetry while the target FSM is in Idle.
+    Verify correct behavior after IbiFailureRetry while FSM is in Idle.
 
-    i3c_target_fsm.sv:463-469: In Idle, when ibi_pending && !ibi_can_retry,
-    the FSM asserts ibi_byte_flush_o and ibi_status_we_o combinationally
-    every cycle without transitioning out of Idle.  descriptor_ibi.sv only
-    checks ibi_byte_flush_i in WriteMdb and WriteData states (lines 102, 125).
-    If the flush is ignored (descriptor_ibi still in DescLatch/DescPop) or if
-    the descriptor_ibi gets stuck in WriteMdb, ibi_pending stays high and
-    ibi_status_we_o fires every cycle, flooding IBI_DONE interrupts.
+    After retry exhaustion:
+    - descriptor_ibi stays in WriteMdb (HW does NOT auto-flush)
+    - InhibitRetry prevents repeated ibi_status_we_o pulses (no flood)
+    - FW must use IBI_QUEUE_RST to clear stale data before re-queuing
 
-    Per spec Sec.5.1.6.2: An IBI disposal shall produce a single status update.
-    ibi_status_we_o must not assert for more than one cycle per IBI disposal.
+    Verifies that:
+    1. IbiFailureRetry status is reported exactly once (InhibitRetry works)
+    2. FW recovery sequence (IBI_QUEUE_RST + IBI_RETRY_CTR_RST) restores
+       clean state for a fresh IBI
     """
     log = logging.getLogger("test_ibi_flush_idle_flood")
     i3c_controller, _, tb = await test_setup(dut)
 
-    # retry_num=0 → allows exactly 1 attempt (cnt 0 ≤ retry_num 0)
+    # retry_num=0 -> allows exactly 1 attempt (cnt 0 <= retry_num 0)
     await init_ibi(i3c_controller, tb, retry_num=0)
 
     # Internal signal handles
@@ -1559,35 +1569,27 @@ async def test_ibi_flush_from_idle_interrupt_flood(dut):
     result = await i3c_controller.wait_for_ibi_event()
     assert result["ack"] is False, "Expected NACK for first IBI"
 
-    # After NACK: counter increments 0→1.  retry_num=0, so 1 > 0 → can't retry.
-    # DUT: IbiReadAck → WaitRestart → (STOP) → Idle.
+    # After NACK: counter increments 0->1.  retry_num=0, so 1 > 0 -> can't retry.
+    # DUT: IbiReadAck -> WaitRestart -> (STOP) -> Idle.
     # In Idle: descriptor_ibi is still in WriteMdb (MDB was never consumed).
-    # ibi_pending=1 && !ibi_can_retry → IbiFailureRetry flush.
+    # ibi_pending=1 && !ibi_can_retry -> IbiFailureRetry (single pulse).
+    # InhibitRetry prevents further status writes.
     await ClockCycles(tb.clk, 200)
     await check_ibi_status(tb, 3, "IbiFailureRetry after 1 NACK")
 
-    # Confirm descriptor_ibi returned to Idle after the first flush
+    # descriptor_ibi should be in WriteMdb (state 3) -- HW does NOT
+    # auto-flush on retry exhaustion.  FW must clear explicitly.
     desc_state = int(desc_ibi.state_q.value)
-    assert desc_state == 0, (
-        f"descriptor_ibi stuck in state {desc_state} after first IbiFailureRetry"
+    assert desc_state == 3, (
+        f"descriptor_ibi expected in WriteMdb(3) after IbiFailureRetry, "
+        f"got state {desc_state}"
     )
 
     # -----------------------------------------------------------------
-    # Phase 2: Queue a FRESH IBI with the retry counter still exhausted.
-    #
-    # descriptor_ibi: Idle → DescLatch → DescPop → WriteMdb (~3 sys clks).
-    # When WriteMdb is reached:  ibi_byte_valid_o=1 → ibi_pending=1.
-    # Target FSM (Idle): ibi_pending && !ibi_can_retry → flush + status_we.
-    #
-    # Bug scenario: descriptor_ibi ignores flush or gets stuck in WriteMdb,
-    # causing ibi_status_we_o to fire every cycle (flood).
+    # Phase 2: Verify InhibitRetry prevents status flood.
+    # descriptor_ibi is still in WriteMdb (ibi_pending=1) but
+    # InhibitRetry gates the Idle IBI path.
     # -----------------------------------------------------------------
-    mdb_fresh = 0xBB
-    data_fresh = [0x22, 0x33]
-    await send_ibi(tb, mdb_fresh, data_fresh)
-
-    # Monitor ibi_status_we_o for 500 system clock cycles.
-    # Correct behavior: at most 1 pulse (single IbiFailureRetry disposal).
     status_we_count = 0
     for _ in range(500):
         await ClockCycles(tb.clk, 1)
@@ -1596,32 +1598,35 @@ async def test_ibi_flush_from_idle_interrupt_flood(dut):
             status_we_count += 1
     log.info(f"ibi_status_we_o pulse count over 500 cycles: {status_we_count}")
 
-    desc_state = int(desc_ibi.state_q.value)
-    log.info(f"descriptor_ibi state after fresh-IBI flush: {desc_state}")
-
-    # -----------------------------------------------------------------
-    # Phase 3: Assertions — correct spec behavior
-    # -----------------------------------------------------------------
-    assert status_we_count <= 1, (
+    assert status_we_count == 0, (
         f"ibi_status_we_o asserted {status_we_count} times in 500 "
-        f"cycles (expected ≤ 1).  descriptor_ibi.state_q = {desc_state}. "
-        f"Flush from Idle/IbiFailureRetry was ignored or not handled atomically, "
-        f"causing ibi_status_we_o flood."
+        f"cycles (expected 0 -- InhibitRetry should suppress). "
+        f"descriptor_ibi.state_q = {int(desc_ibi.state_q.value)}."
     )
 
+    # -----------------------------------------------------------------
+    # Phase 3: FW recovery -- flush queue, reset retry counter, fresh IBI
+    # -----------------------------------------------------------------
+    await tb.write_csr_field(
+        tb.reg_map.I3C_EC.TTI.RESET_CONTROL.base_addr,
+        tb.reg_map.I3C_EC.TTI.RESET_CONTROL.IBI_QUEUE_RST,
+        1,
+    )
+    await ClockCycles(tb.clk, 5)
+
+    # Confirm descriptor_ibi returned to Idle after FW queue reset
+    desc_state = int(desc_ibi.state_q.value)
     assert desc_state == 0, (
-        f"descriptor_ibi stuck in state {desc_state} (expected "
-        f"Idle=0) after second IbiFailureRetry."
+        f"descriptor_ibi stuck in state {desc_state} after IBI_QUEUE_RST "
+        f"(expected Idle=0)"
     )
 
-    # -----------------------------------------------------------------
-    # Phase 4: Clean IBI after counter reset
-    # -----------------------------------------------------------------
     await tb.write_csr_field(
         tb.reg_map.I3C_EC.TTI.RESET_CONTROL.base_addr,
         tb.reg_map.I3C_EC.TTI.RESET_CONTROL.IBI_RETRY_CTR_RST,
         1,
     )
+    await ClockCycles(tb.clk, 5)
 
     mdb_clean = 0xCC
     data_clean = [0x44]

--- a/verification/cocotb/top/lib_i3c_top/test_ibi.py
+++ b/verification/cocotb/top/lib_i3c_top/test_ibi.py
@@ -1660,10 +1660,6 @@ async def test_ibi_rxfbytearb_wins_arbitration(dut):
     i3c_controller, _, tb = await test_setup(dut, static_addr=DUT_ADDR)
     await init_ibi(i3c_controller, tb, addr=DUT_ADDR)
 
-    # Suppress known DUT tSCO violation on IBI ACK handoff path
-    # (pre-existing issue, not related to this test's coverage goal)
-    if tb.bus_monitor:
-        tb.bus_monitor.suppress_check("IBI_ACK_HANDOFF")
 
     mdb = 0xAA
     data = [0x11, 0x22]


### PR DESCRIPTION
bus_rx_flow.rx_done was registered (1 clock late) while bus_tx_flow.bus_tx_done was combinational. This caused i3c_target_fsm to consume a stale RX byte-done as the IBI ACK/NACK response when transitioning RxFByteArb -> IbiReadAck, resulting in a false NACK.  
 
Make rx_done combinational to fire on the same clock as tx_done. Remove the rx_bit holding register (sda_i is already synchronous and stable during SCL HIGH). Handle the new simultaneity of arbitration_lost_i and bus_rx_rsp.done in RxFByteArb by capturing the completed byte and skipping directly to CheckFByte.
