### PR TITLE
[tb] Broadcast ccc with no target addresses

### DIFF
--- a/verification/cocotb/top/lib_i3c_top/boot.py
+++ b/verification/cocotb/top/lib_i3c_top/boot.py
@@ -114,9 +114,11 @@ async def boot_init(
     )
 
     # Inform the I3C bus monitor of the DUT's dynamic address
-    dut_addr = dynamic_addr if dynamic_addr is not None else static_addr
+   
     if hasattr(tb, 'bus_monitor') and tb.bus_monitor is not None:
-        tb.bus_monitor.set_dut_dynamic_addr(dut_addr)
+        dut_addr = dynamic_addr if dynamic_addr is not None else static_addr
+        if dur_addr is not None:
+            tb.bus_monitor.set_dut_dynamic_addr(dut_addr)
         virt_addr = virtual_dynamic_addr if virtual_dynamic_addr is not None else virtual_static_addr
         if virt_addr is not None:
             tb.bus_monitor.set_virt_dynamic_addr(virt_addr)

--- a/verification/cocotb/top/lib_i3c_top/boot.py
+++ b/verification/cocotb/top/lib_i3c_top/boot.py
@@ -117,7 +117,7 @@ async def boot_init(
    
     if hasattr(tb, 'bus_monitor') and tb.bus_monitor is not None:
         dut_addr = dynamic_addr if dynamic_addr is not None else static_addr
-        if dur_addr is not None:
+        if dut_addr is not None:
             tb.bus_monitor.set_dut_dynamic_addr(dut_addr)
         virt_addr = virtual_dynamic_addr if virtual_dynamic_addr is not None else virtual_static_addr
         if virt_addr is not None:

--- a/verification/cocotb/top/lib_i3c_top/test_ccc.py
+++ b/verification/cocotb/top/lib_i3c_top/test_ccc.py
@@ -769,7 +769,7 @@ async def test_ccc_enec_disec_bcast(dut):
 
     _EVENT_TOGGLE_BYTE = 0b00001011
 
-    i3c_controller, _, tb = await test_setup(dut)
+    i3c_controller, _, tb = await test_setup(dut, static_addr=None, virtual_static_addr=None)
     await ClockCycles(tb.clk, 50)
 
     # Read default values


### PR DESCRIPTION
Tests i3c-core can accept BCAST CCC when no static or dynamic address 