### PR TITLE
[env] Clean up Makefiles and add cocotb support for Xcelium

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,11 @@ __pycache__
 *.vpd
 *.fst
 *.fsdb
+*.rc
+.verisium_debug*
+verisium_debug*
+*.shm
+*xrun.history
 novas.*
 verdiLog
 *.xml

--- a/Makefile
+++ b/Makefile
@@ -224,7 +224,7 @@ install-uvm:
 clean: ## Clean all generated sources
 	rm -rf $(I3C_ROOT_DIR)/{dsim.env,dsim_work,sw,*.log,*.rpt,*.vcd}
 	rm -rf $(GENERIC_UVM_DIR) $(VERILATOR_UVM_DIR)
-	rm -rf {$(VERIFICATION_DIR),$(COCOTB_VERIF_DIR),$(BLOCK_VERIF_DIR),$(TOP_VERIF_DIR),$(UVM_VERIF_DIR)}/**/{.nox,obj_dir,__pycache__,report,sim_build,*.dat,*.info,*.json,*.log,*.vpd,*.vcd,*.fsdb,*.fst,*.xml,ucli.key}
+	rm -rf {$(VERIFICATION_DIR),$(COCOTB_VERIF_DIR),$(BLOCK_VERIF_DIR),$(TOP_VERIF_DIR),$(UVM_VERIF_DIR)}/**/{.nox,obj_dir,__pycache__,report,sim_build,*.dat,*.info,*.json,*.log,*.vpd,*.vcd,*.fsdb,*.fst,*.shm,*.xml,ucli.key,xrun.history}
 	rm -rf $(TOOL_DIR)/**/{.nox,obj_dir,__pycache__,report,sim_build,*.dat,*.info,*.log,*.vcd,*.xml}
 
 .PHONY: lint lint-check lint-rtl lint-tests \

--- a/src/i3c.f
+++ b/src/i3c.f
@@ -1,8 +1,3 @@
-+incdir+${CALIPTRA_ROOT}/src/libs/rtl
-+incdir+${CALIPTRA_ROOT}/src/caliptra_prim/rtl
-+incdir+${CALIPTRA_ROOT}/src/axi/rtl
-+incdir+${I3C_ROOT_DIR}/src
-+incdir+${I3C_ROOT_DIR}/src/libs
 ${CALIPTRA_ROOT}/src/caliptra_prim/rtl/caliptra_prim_pkg.sv
 ${CALIPTRA_ROOT}/src/caliptra_prim/rtl/caliptra_prim_util_pkg.sv
 ${CALIPTRA_ROOT}/src/caliptra_prim/rtl/caliptra_prim_count_pkg.sv
@@ -10,7 +5,6 @@ ${CALIPTRA_ROOT}/src/caliptra_prim_generic/rtl/caliptra_prim_generic_flop.sv
 ${CALIPTRA_ROOT}/src/caliptra_prim/rtl/caliptra_prim_flop.sv
 ${CALIPTRA_ROOT}/src/caliptra_prim/rtl/caliptra_prim_flop_2sync.sv
 ${CALIPTRA_ROOT}/src/caliptra_prim/rtl/caliptra_prim_assert.sv
-${CALIPTRA_ROOT}/src/caliptra_prim/rtl/caliptra_prim_assert_dummy_macros.svh
 ${CALIPTRA_ROOT}/src/caliptra_prim/rtl/caliptra_prim_fifo_sync_cnt.sv
 ${CALIPTRA_ROOT}/src/caliptra_prim/rtl/caliptra_prim_fifo_sync.sv
 ${CALIPTRA_ROOT}/src/libs/rtl/ahb_defines_pkg.sv

--- a/tools/reg_gen/gen_axi_csr_tracker.py
+++ b/tools/reg_gen/gen_axi_csr_tracker.py
@@ -96,6 +96,7 @@ _SV_FOOTER = """\
 
 endmodule : axi_csr_tracker
 
+`ifdef I3C_USE_AXI
 bind axi_adapter axi_csr_tracker u_axi_csr_tracker (
     .clk_i          (clk_i),
     .rst_ni         (rst_ni),
@@ -105,6 +106,7 @@ bind axi_adapter axi_csr_tracker u_axi_csr_tracker (
     .s_cpuif_wr_data(s_cpuif_wr_data),
     .s_cpuif_rd_data(s_cpuif_rd_data)
 );
+`endif // I3C_USE_AXI
 
 `endif // VERILATOR
 `endif // SYNTHESIS

--- a/tools/simulators/Makefile.xcelium
+++ b/tools/simulators/Makefile.xcelium
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+
+ifeq (, $(shell which xrun))
+    $(warning WARNING: SIMULATOR: Xcelium (xrun) is not in PATH.)
+endif
+

--- a/verification/cocotb/common.mk
+++ b/verification/cocotb/common.mk
@@ -7,7 +7,6 @@ TRACK_FSM       ?= 1
 
 # Paths
 CURDIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
-I3C_ROOT := $(abspath $(CURDIR)/../..)
 CFGDIR :=
 CONFIG :=
 $(info From common.mk, CURDIR is $(CURDIR))
@@ -21,8 +20,7 @@ COMMON_SOURCES += $(TEST_DIR)/sim_build/i3c_config.vh
 VERILOG_INCLUDE_DIRS= \
     $(CALIPTRA_ROOT)/src/libs/rtl \
     $(CALIPTRA_ROOT)/src/caliptra_prim/rtl \
-    $(I3C_ROOT)/src \
-    $(I3C_ROOT)/src/libs/axi \
+    $(I3C_ROOT_DIR)/src \
     $(I3C_ROOT_DIR)/src/libs
 
 $(info VERILOG_SOURCES = $(VERILOG_SOURCES))
@@ -58,17 +56,22 @@ ifeq ($(SIM), verilator)
     EXTRA_ARGS += -Wno-DECLFILENAME -Wno-TIMESCALEMOD
 endif
 
+# Switch between Verdi FSDB PLI and "classic" waveform dumping
+VERDI_PLI ?= 1
+
 ifeq ($(SIM), vcs)
-    EXTRA_ARGS += +vcs+lic+wait
-    COMPILE_ARGS += -deraceclockdata +libext+.sv +libext+.v
-    COMPILE_ARGS += $(foreach dir,$(VERILOG_INCLUDE_DIRS),-y $(dir))
     COMPILE_ARGS += -assert svaext
-    COMPILE_ARGS += -debug_access+all +memcbk -assert svaext
     COMPILE_ARGS += -Xcflags='-Wno-error=implicit-function-declaration -Wno-error=int-conversion'
+    ifeq ($(VERDI_PLI), 1)
+        COMPILE_ARGS += -P $(VERDI_HOME)/share/PLI/VCS/LINUX64/novas.tab $(VERDI_HOME)/share/PLI/VCS/LINUX64/pli.a
+    else
+        COMPILE_ARGS += -debug_access+all
     COMPILE_ARGS += -kdb +vcs+fsdbon
-    # Verdi FSDB PLI for waveform dumping
-    COMPILE_ARGS += -P $(VERDI_HOME)/share/PLI/VCS/LINUX64/novas.tab $(VERDI_HOME)/share/PLI/VCS/LINUX64/pli.a
+    endif
+    ifeq ($(WAVES), 1)
+        # Sim args seem to work for both wave dumping types (?)
     SIM_ARGS += +fsdbfile+dump.fsdb +fsdb+all=on +fsdb+mda=on
+    endif
     EXTRA_ARGS += +vcs+lic+wait
 
     # Opt-in FSM state transition logging: make ... TRACK_FSM=1
@@ -78,6 +81,14 @@ ifeq ($(SIM), vcs)
 
     ifneq ($(COVERAGE_TYPE),)
         EXTRA_ARGS += -cm line+cond+fsm+tgl+branch -lca
+    endif
+endif
+
+ifeq ($(SIM), xcelium)
+    ifeq ($(WAVES), 1)
+        SIM_ARGS += -input "@database -open cocotb_waves -default"
+        SIM_ARGS += -input "@probe -database cocotb_waves -create $(TOPLEVEL) -all -depth all"
+        SIM_ARGS += -input "@run" -input "@exit"
     endif
 endif
 
@@ -113,10 +124,10 @@ all: sim convert-vpd2vcd
 
 endif
 
-CFG_FILE ?= $(I3C_ROOT)/i3c_core_configs.yaml## Path: YAML file holding configuration of the I3C RTL
+CFG_FILE ?= $(I3C_ROOT_DIR)/i3c_core_configs.yaml## Path: YAML file holding configuration of the I3C RTL
 CFG_NAME ?= axi## Valid configuration name from the YAML configuration file
 
 $(TEST_DIR)/sim_build/i3c_config.vh:
-	pushd $(I3C_ROOT) && CFG_FILE=$(CFG_FILE) CFG_NAME=$(CFG_NAME) make config && popd
+	pushd $(I3C_ROOT_DIR) && CFG_FILE=$(CFG_FILE) CFG_NAME=$(CFG_NAME) make config && popd
 	mkdir -p $(TEST_DIR)/sim_build
 	touch $(TEST_DIR)/sim_build/i3c_config.vh

--- a/verification/cocotb/common/bus2csr.py
+++ b/verification/cocotb/common/bus2csr.py
@@ -29,8 +29,10 @@ async def setup_dut(clk, rst_n, clk_period: Tuple[int, str]) -> None:
     """
     Setup clock & reset the unit
     """
-    await cocotb.start(Clock(clk, *clk_period).start())
+    clk.value = 0
     rst_n.value = 0
+    await Timer(1, units="ps")
+    await cocotb.start(Clock(clk, *clk_period).start())
     await ClockCycles(clk, 10)
     await RisingEdge(clk)
     await Timer(1, units="ns")

--- a/verification/cocotb/top/lib_i3c_top/i3c_test_wrapper.sv
+++ b/verification/cocotb/top/lib_i3c_top/i3c_test_wrapper.sv
@@ -210,6 +210,7 @@ i3c_wrapper xi3c_wrapper (
     .rlast_o(rlast),
     .rvalid_o(rvalid),
     .rready_i(rready),
+    .ruser_o(),
 
     .awaddr_i(awaddr),
     .awburst_i(awburst),
@@ -226,11 +227,13 @@ i3c_wrapper xi3c_wrapper (
     .wlast_i(wlast),
     .wvalid_i(wvalid),
     .wready_o(wready),
+    .wuser_i('0),
 
     .bresp_o(bresp),
     .bid_o(bid),
     .bvalid_o(bvalid),
     .bready_i(bready),
+    .buser_o(),
 
 `ifdef AXI_ID_FILTERING
       .disable_id_filtering_i(disable_id_filtering_i),


### PR DESCRIPTION
This PR includes various small fixes to the environment/Makefiles. It tidies up some of the options for VCS and fixes a few miscellaneous issue to make the cocotb simulations work with Cadence Xcelium.

Most notably, it changes the way the main DUT clock is started in cocotb. This finally does away with the erratic assertion firing at time 0 fs, which for some reason did not cause simulation failure with VCS (but does so with Xcelium).