### PR TITLE
Add missing cocotb test symlinks and noxfile entries

### DIFF
--- a/verification/cocotb/common/bus2csr.py
+++ b/verification/cocotb/common/bus2csr.py
@@ -21,7 +21,7 @@ from reg_map import reg_map
 import cocotb
 from cocotb.clock import Clock
 from cocotb.handle import SimHandleBase
-from cocotb.triggers import ClockCycles, RisingEdge, Timer, with_timeout
+from cocotb.triggers import ClockCycles, Lock, RisingEdge, Timer, with_timeout
 
 
 # Helpers
@@ -134,6 +134,9 @@ class AHBTestInterface(FrontBusTestInterface):
         # Cocotb-ahb-specific construct for simulation purposes
         self.wrapper = InterconnectWrapper()
 
+        # Serialize AHB bus access; SimSimpleManager is not reentrant
+        self._bus_lock = Lock()
+
     async def register_test_interfaces(self, *args, **kw):
         # Clocks & resets
         self.AHBManager.register_clock(self.clk).register_reset(self.rst_n, True)
@@ -161,9 +164,10 @@ class AHBTestInterface(FrontBusTestInterface):
         """Send a read request & await the response for 'timeout' in 'units'."""
         if arid:
             self.dut._log.debug(f"AHB doesn't support user id, ignoring arid={arid}")
-        self.AHBManager.read(addr, size)
-        await with_timeout(self.AHBManager.transfer_done(), timeout, units)
-        read = self.AHBManager.get_rsp(addr, self.data_byte_width)
+        async with self._bus_lock:
+            self.AHBManager.read(addr, size)
+            await with_timeout(self.AHBManager.transfer_done(), timeout, units)
+            read = self.AHBManager.get_rsp(addr, self.data_byte_width)
         return read
 
     async def write_csr(
@@ -184,8 +188,9 @@ class AHBTestInterface(FrontBusTestInterface):
             data = data + [0 for _ in range(size - data_len)]
         # Write strobe is not supported by DUT's AHB-Lite; enable all bytes
         strb = [1 for _ in range(size)]
-        self.AHBManager.write(addr, len(strb), data, strb)
-        await with_timeout(self.AHBManager.transfer_done(), timeout, units)
+        async with self._bus_lock:
+            self.AHBManager.write(addr, len(strb), data, strb)
+            await with_timeout(self.AHBManager.transfer_done(), timeout, units)
 
 
 # Generic axi2csr test interface

--- a/verification/cocotb/noxfile.py
+++ b/verification/cocotb/noxfile.py
@@ -304,6 +304,12 @@ def i2c_target_fsm_verify(session, test_group, test_name, coverage, simulator):
         "test_target_reset",
         "test_ccc",
         "test_csr_access",
+        "test_bypass",
+        "test_empty_queue_read",
+        "test_ibi",
+        "test_ibi_multi_queue",
+        "test_te_errors",
+        "test_tsco_violation",
     ],
 )
 @nox.parametrize("coverage", coverage_types)
@@ -326,6 +332,11 @@ def i3c_ahb_verify(session, test_group, test_name, coverage, simulator):
         "test_ccc",
         "test_csr_access",
         "test_bypass",
+        "test_empty_queue_read",
+        "test_ibi",
+        "test_ibi_multi_queue",
+        "test_te_errors",
+        "test_tsco_violation",
     ],
 )
 @nox.parametrize("coverage", coverage_types)

--- a/verification/cocotb/top/i3c_ahb/test_bus_stall.py
+++ b/verification/cocotb/top/i3c_ahb/test_bus_stall.py
@@ -1,0 +1,1 @@
+../lib_i3c_top/test_bus_stall.py

--- a/verification/cocotb/top/i3c_ahb/test_te_errors.py
+++ b/verification/cocotb/top/i3c_ahb/test_te_errors.py
@@ -1,0 +1,1 @@
+../lib_i3c_top/test_te_errors.py

--- a/verification/cocotb/top/i3c_axi/test_bus_stall.py
+++ b/verification/cocotb/top/i3c_axi/test_bus_stall.py
@@ -1,0 +1,1 @@
+../lib_i3c_top/test_bus_stall.py

--- a/verification/cocotb/top/lib_i3c_top/test_bypass.py
+++ b/verification/cocotb/top/lib_i3c_top/test_bypass.py
@@ -453,7 +453,8 @@ async def test_image_activated(dut):
         tb.reg_map.I3C_EC.SOCMGMTIF.REC_INTF_REG_W1C_ACCESS.RECOVERY_CTRL_ACTIVATE_REC_IMG,
         0xF,
     )
-    await RisingEdge(tb.clk)
+    # Wait for register propagation: SoC Mgmt swmod -> RECOVERY_CTRL latch -> combinational output
+    await ClockCycles(tb.clk, 2)
 
     # Check if image_activated is asserted
     assert bool(
@@ -474,6 +475,8 @@ async def test_image_activated(dut):
         tb.reg_map.I3C_EC.SECFWRECOVERYIF.RECOVERY_CTRL.ACTIVATE_REC_IMG,
         0xFF,
     )
+    # Wait for register propagation through CSR pipeline
+    await ClockCycles(tb.clk, 2)
 
     # Check if image_activated is deasserted
     assert not bool(
@@ -618,8 +621,8 @@ async def test_recovery_flow(dut):
         assert recovery_ctrl == 0, f"RECOVERY_CTRL mismatch: expected 0, got {recovery_ctrl}"
 
         # Write 0 to Indirect FIFO Control
-        await tb.write_csr(tb.reg_map.I3C_EC.SECFWRECOVERYIF.INDIRECT_FIFO_CTRL_0.base_addr, 0x0, 4)
-        await tb.write_csr(tb.reg_map.I3C_EC.SECFWRECOVERYIF.INDIRECT_FIFO_CTRL_1.base_addr, 0x0, 4)
+        await tb.write_csr(tb.reg_map.I3C_EC.SECFWRECOVERYIF.INDIRECT_FIFO_CTRL_0.base_addr, int2dword(0x0), 4)
+        await tb.write_csr(tb.reg_map.I3C_EC.SECFWRECOVERYIF.INDIRECT_FIFO_CTRL_1.base_addr, int2dword(0x0), 4)
 
         # Write 1 to Indirect FIFO Control Reset field
         await tb.write_csr_field(


### PR DESCRIPTION
Add missing symlinks in i3c_axi (test_bus_stall) and i3c_ahb (test_bus_stall, test_te_errors) so all lib_i3c_top tests are available in both config directories. Update noxfile.py to include test_empty_queue_read, test_ibi, test_ibi_multi_queue, test_te_errors, test_tsco_violation in i3c_axi_verify, and those plus test_bypass in i3c_ahb_verify.