### PR TITLE
Make i3c.f self-sufficient again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ __pycache__
 verisium_debug*
 *.shm
 *xrun.history
+*xrun.key
 novas.*
 verdiLog
 *.xml

--- a/src/i3c.f
+++ b/src/i3c.f
@@ -1,10 +1,13 @@
++incdir+${CALIPTRA_ROOT}/src/libs/rtl
++incdir+${CALIPTRA_ROOT}/src/caliptra_prim/rtl
++incdir+${I3C_ROOT_DIR}/src
++incdir+${I3C_ROOT_DIR}/src/libs
 ${CALIPTRA_ROOT}/src/caliptra_prim/rtl/caliptra_prim_pkg.sv
 ${CALIPTRA_ROOT}/src/caliptra_prim/rtl/caliptra_prim_util_pkg.sv
 ${CALIPTRA_ROOT}/src/caliptra_prim/rtl/caliptra_prim_count_pkg.sv
 ${CALIPTRA_ROOT}/src/caliptra_prim_generic/rtl/caliptra_prim_generic_flop.sv
 ${CALIPTRA_ROOT}/src/caliptra_prim/rtl/caliptra_prim_flop.sv
 ${CALIPTRA_ROOT}/src/caliptra_prim/rtl/caliptra_prim_flop_2sync.sv
-${CALIPTRA_ROOT}/src/caliptra_prim/rtl/caliptra_prim_assert.sv
 ${CALIPTRA_ROOT}/src/caliptra_prim/rtl/caliptra_prim_fifo_sync_cnt.sv
 ${CALIPTRA_ROOT}/src/caliptra_prim/rtl/caliptra_prim_fifo_sync.sv
 ${CALIPTRA_ROOT}/src/libs/rtl/ahb_defines_pkg.sv

--- a/verification/cocotb/block/block_common.mk
+++ b/verification/cocotb/block/block_common.mk
@@ -1,4 +1,10 @@
 BLOCK_DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 export PYTHONPATH := $(PYTHONPATH):$(BLOCK_DIR)/lib_hci_queues:$(BLOCK_DIR)/lib_adapter
 
+VERILOG_INCLUDE_DIRS= \
+    $(CALIPTRA_ROOT)/src/libs/rtl \
+    $(CALIPTRA_ROOT)/src/caliptra_prim/rtl \
+    $(I3C_ROOT_DIR)/src \
+    $(I3C_ROOT_DIR)/src/libs
+
 include $(BLOCK_DIR)/../common.mk

--- a/verification/cocotb/common.mk
+++ b/verification/cocotb/common.mk
@@ -17,12 +17,6 @@ export PYTHONPATH := $(PYTHONPATH):$(CURDIR)/common
 # Add empty file to common sources to enforce configuration build before running the tests
 COMMON_SOURCES += $(TEST_DIR)/sim_build/i3c_config.vh
 
-VERILOG_INCLUDE_DIRS= \
-    $(CALIPTRA_ROOT)/src/libs/rtl \
-    $(CALIPTRA_ROOT)/src/caliptra_prim/rtl \
-    $(I3C_ROOT_DIR)/src \
-    $(I3C_ROOT_DIR)/src/libs
-
 $(info VERILOG_SOURCES = $(VERILOG_SOURCES))
 VERILOG_SOURCES := $(COMMON_SOURCES) $(VERILOG_SOURCES)
 $(info VERILOG_SOURCES = $(VERILOG_SOURCES))


### PR DESCRIPTION
Undoes a change in https://github.com/chipsalliance/i3c-core/pull/168 that removed the required include files from `i3c.f` and instead used a cocotb native env variable. This caused problems when the project was referenced by other flows as external dependency.