### PR TITLE
Remove recovery_mode_enter signal to fix combo loop

### DIFF
--- a/src/ctrl/controller.sv
+++ b/src/ctrl/controller.sv
@@ -256,8 +256,6 @@ module controller
     output logic escalated_reset_o,
 
     output logic err_o,
-    input  logic recovery_mode_enter_i,
-
     // Individual TE error outputs for interrupt reporting
     output logic te0_err_o,
     output logic te1_err_o,
@@ -674,7 +672,6 @@ module controller
     .peripheral_reset_o,
     .peripheral_reset_done_i,
     .escalated_reset_o,
-    .recovery_mode_enter_i,
     .te0_err_o,
     .te1_err_o,
     .te2_err_o,

--- a/src/ctrl/controller_standby.sv
+++ b/src/ctrl/controller_standby.sv
@@ -187,8 +187,6 @@ module controller_standby
     output logic escalated_reset_o,
 
     output logic err_o,
-    input  logic recovery_mode_enter_i,
-
     // Individual TE error outputs for interrupt reporting
     output logic te0_err_o,
     output logic te1_err_o,
@@ -540,7 +538,6 @@ module controller_standby
     .peripheral_reset_o,
     .peripheral_reset_done_i,
     .escalated_reset_o,
-    .recovery_mode_enter_i,
     .virtual_device_sel_o,
     .xfer_in_progress_o,
     .in_hdr_mode_o

--- a/src/ctrl/controller_standby_i3c.sv
+++ b/src/ctrl/controller_standby_i3c.sv
@@ -194,8 +194,6 @@ module controller_standby_i3c
   input  logic peripheral_reset_done_i,
   output logic escalated_reset_o,
 
-  // recovery mode
-  input  logic recovery_mode_enter_i,
   output logic virtual_device_sel_o,
   output logic xfer_in_progress_o,
   output logic in_hdr_mode_o
@@ -691,7 +689,6 @@ module controller_standby_i3c
     .tx_byte_valid_o           (tx_fifo_rvalid),
     .tx_byte_ready_i           (tx_fifo_rready),
 
-    .recovery_mode_enter_i     (recovery_mode_enter_i),
     .tx_end_o                  (tx_pr_end_o)
   );
 

--- a/src/ctrl/descriptor_tx.sv
+++ b/src/ctrl/descriptor_tx.sv
@@ -40,10 +40,7 @@ module descriptor_tx import i3c_pkg::*; #(
   input  logic      tx_start_i,
   output logic      tx_end_o,
   input  logic      tx_abort_i,
-  output logic      tx_desc_avail_o,
-
-  // recovery mode
-  input  logic recovery_mode_enter_i
+  output logic      tx_desc_avail_o
 );
 
   logic [TtiTxDescDataWidth-1:0] tx_descriptor;
@@ -59,7 +56,7 @@ module descriptor_tx import i3c_pkg::*; #(
   logic flush;
 
   assign tti_tx_desc_queue_rready_o = tti_tx_desc_queue_rvalid_i && !descriptor_valid && tx_start_i
-                                      && !(flush || tx_abort_i || recovery_mode_enter_i);
+                                      && !(flush || tx_abort_i);
 
   assign tx_desc_avail_o = tti_tx_desc_queue_rvalid_i;
 
@@ -68,7 +65,7 @@ module descriptor_tx import i3c_pkg::*; #(
       tx_descriptor    <= '0;
       descriptor_valid <= '0;
     end else begin
-      if (tx_end || tx_abort_i || recovery_mode_enter_i) begin
+      if (tx_end || tx_abort_i ) begin
         tx_descriptor    <= '0;
         descriptor_valid <= '0;
       end else if (tti_tx_desc_queue_rready_o) begin
@@ -83,7 +80,7 @@ module descriptor_tx import i3c_pkg::*; #(
       flush <= 1'b0;
     end else begin
       if (!flush) begin
-        if ((byte_counter != 16'h0) && (tx_abort_i || recovery_mode_enter_i)) begin
+        if ((byte_counter != 16'h0) && tx_abort_i ) begin
           flush <= 1'b1;
         end
       end else begin

--- a/src/i3c.sv
+++ b/src/i3c.sv
@@ -563,7 +563,6 @@ module i3c
   logic te5_err;
   logic framing_err;
 
-  logic recovery_mode_enter;
   logic virtual_device_sel;
   logic xfer_in_progress;
   logic in_hdr_mode;
@@ -787,8 +786,6 @@ module i3c
       .escalated_reset_o,
 
       .err_o(controller_error),
-      .recovery_mode_enter_i(recovery_mode_enter),
-
       .te0_err_o(te0_err),
       .te1_err_o(te1_err),
       .te2_err_o(te2_err),
@@ -1287,7 +1284,6 @@ module i3c
       // Received I2C/I3C address along with RnW# bit
       .ctl_bus_addr_i(rx_bus_addr),
       .ctl_bus_addr_valid_i(rx_bus_addr_valid),
-      .recovery_mode_enter_o(recovery_mode_enter),
       .virtual_device_sel_i(virtual_device_sel),
       .xfer_in_progress_i(xfer_in_progress),
       .pec_err_det_en_i(hwif_tti_out.TARGET_ERR_CTRL.RI_PEC_ERR_DET_EN.value),

--- a/src/recovery/recovery_handler.sv
+++ b/src/recovery/recovery_handler.sv
@@ -207,7 +207,6 @@ module recovery_handler
     // Recovery status
     output logic payload_available_o,
     output logic image_activated_o,
-    output logic recovery_mode_enter_o,
     input  logic virtual_device_sel_i,
     input  logic xfer_in_progress_i,
 
@@ -1096,8 +1095,7 @@ module recovery_handler
       .indirect_fifo_overflow_err_o,
       .rx_desc_wvalid_i(ctl_tti_rx_desc_queue_wvalid_i),
       .rx_desc_wdata_i (ctl_tti_rx_desc_queue_wdata_i),
-      .exec_pending_o(recovery_exec_pending),
-      .recovery_mode_enter_o
+      .exec_pending_o(recovery_exec_pending)
   );
 
   //----------------------------------------------------------------------------

--- a/src/recovery/recovery_receiver.sv
+++ b/src/recovery/recovery_receiver.sv
@@ -223,7 +223,6 @@ module recovery_receiver
     output logic readonly_err_o,
     output logic unsupported_err_o,
     output logic exec_pending_o,
-    output logic recovery_mode_enter_o,
     output logic rx_fifo_overflow_err_o,       // RX FIFO overflow error (always reported)
     output logic indirect_fifo_overflow_err_o, // INDIRECT_FIFO overflow error
 
@@ -536,13 +535,6 @@ module recovery_receiver
       premature_stop_q <= 1'b0;
     end
   end
-
-  //----------------------------------------------------------------------------
-  // Recovery Mode Enter Pulse
-  //----------------------------------------------------------------------------
-  // Generate a single-cycle pulse when transitioning from Idle to RxCmd.
-  // This signals the start of a new recovery command to downstream logic.
-  assign recovery_mode_enter_o = (state_q == Idle) && (state_d == RxCmd);
 
   //----------------------------------------------------------------------------
   // Next State Logic

--- a/verification/cocotb/block/ctrl_descriptor_tx/test_descriptor_tx.py
+++ b/verification/cocotb/block/ctrl_descriptor_tx/test_descriptor_tx.py
@@ -12,7 +12,6 @@ async def setup(dut):
     """ """
     await ClockCycles(dut.clk_i, 10)
     dut.tti_tx_desc_queue_rvalid_i.value = 0
-    dut.recovery_mode_enter_i.value = 0
     dut.tti_tx_queue_rvalid_i.value = 0
     dut.tti_tx_queue_empty_i.value = 1
     dut.tx_abort_i.value = 0

--- a/verification/cocotb/common.mk
+++ b/verification/cocotb/common.mk
@@ -62,11 +62,11 @@ VERDI_PLI ?= 1
 ifeq ($(SIM), vcs)
     COMPILE_ARGS += -assert svaext
     COMPILE_ARGS += -Xcflags='-Wno-error=implicit-function-declaration -Wno-error=int-conversion'
+    COMPILE_ARGS += -kdb
     ifeq ($(VERDI_PLI), 1)
         COMPILE_ARGS += -P $(VERDI_HOME)/share/PLI/VCS/LINUX64/novas.tab $(VERDI_HOME)/share/PLI/VCS/LINUX64/pli.a
     else
-        COMPILE_ARGS += -debug_access+all
-    COMPILE_ARGS += -kdb +vcs+fsdbon
+        COMPILE_ARGS += -debug_access+all +vcs+fsdbon
     endif
     ifeq ($(WAVES), 1)
         # Sim args seem to work for both wave dumping types (?)

--- a/verification/cocotb/top/lib_i3c_top/i3c_bus_monitor.py
+++ b/verification/cocotb/top/lib_i3c_top/i3c_bus_monitor.py
@@ -604,7 +604,7 @@ class I3cBusMonitor:
             return
 
         if self._is_addressed_to_dut or self._is_broadcast:
-            # ENTDAA: Sr + 7'h7E/R ACK → enter DAA data phase (S5.1.4.2)
+            # ENTDAA: Sr + 7'h7E/R ACK -> enter DAA data phase (S5.1.4.2)
             if self._is_entdaa and self._is_broadcast and self._rnw == 1:
                 self._phase = BusPhase.ENTDAA
                 self._entdaa_bit_count = 0
@@ -801,7 +801,7 @@ class I3cBusMonitor:
         Controller drives ACK low in OD; NACK = passive (not driving).
 
         Check 6 scheduling: If ACKed (SDA=0), schedule a tSCO handoff check
-        for the Target→PP transition to MDB (S5.1.2.3.2).
+        for the Target->PP transition to MDB (S5.1.2.3.2).
         """
         # OD mode check: DUT should not be driving PP during IBI ACK/NACK
         if self._dut_is_driving() and self._dut_is_pp():

--- a/verification/cocotb/top/lib_i3c_top/i3c_controller_fixed.py
+++ b/verification/cocotb/top/lib_i3c_top/i3c_controller_fixed.py
@@ -6,7 +6,7 @@ This module provides extensions to the I3cController from cocotbext-i3c that add
 arbitration-aware IBI handling, chaining, and stress testing.
 
 Key Features:
-    - Arbitration-aware write_addr_header: detects IBI during S→0x7E phase
+    - Arbitration-aware write_addr_header: detects IBI during S->0x7E phase
       per I3C spec Sec.5.1.2.2.1 and handles it inline
     - Automatic IBI retry in i3c_write/i3c_read/i3c_ccc_write/i3c_ccc_read
     - One-shot IBI chaining knobs: CCC, Private Write, skip_data, max_data
@@ -33,7 +33,7 @@ from cocotb.triggers import Event, FallingEdge, Timer, NextTimeStep
 class IbiArbitrationEvent(Exception):
     pass
 
-# Max retries when IBI keeps firing during transfer Start→0x7E
+# Max retries when IBI keeps firing during transfer Start->0x7E
 _MAX_IBI_RETRIES = 10
 
 
@@ -62,7 +62,7 @@ class I3cControllerFixed(I3cController):
     # =========================================================================
 
     def set_ibi_chain_ccc(self, ccc, ccc_data=None, ccc_addr=None):
-        """Configure: after next IBI ACK/NACK, chain Sr→CCC before STOP."""
+        """Configure: after next IBI ACK/NACK, chain Sr->CCC before STOP."""
         assert self._ibi_chain_write_addr is None, \
             "Cannot set CCC chain while write chain is active"
         self._ibi_chain_ccc = ccc
@@ -70,7 +70,7 @@ class I3cControllerFixed(I3cController):
         self._ibi_chain_ccc_addr = ccc_addr
 
     def set_ibi_chain_write(self, addr, data):
-        """Configure: after next IBI ACK/NACK, chain Sr→Private Write before STOP."""
+        """Configure: after next IBI ACK/NACK, chain Sr->Private Write before STOP."""
         assert self._ibi_chain_ccc is None, \
             "Cannot set write chain while CCC chain is active"
         self._ibi_chain_write_addr = addr
@@ -145,7 +145,7 @@ class I3cControllerFixed(I3cController):
         """Drive a bit in open-drain and read back the bus value.
 
         Per I3C spec Sec.5.1.2.2.1: if the device drives Hi-Z (1) but reads
-        Low (0), another device is driving → arbitration lost.
+        Low (0), another device is driving -> arbitration lost.
 
         Returns:
             (arb_ok, bus_value): arb_ok is False if we lost arbitration.
@@ -265,7 +265,7 @@ class I3cControllerFixed(I3cController):
         return result
 
     async def _execute_chain_ccc(self, chain, result):
-        """Execute Sr→CCC chain after IBI handling."""
+        """Execute Sr->CCC chain after IBI handling."""
         await self.send_start()
         # Use base class send_byte for 0x7E after Sr (not arbitrable)
         await I3cController.write_addr_header(self, I3C_RSVD_BYTE)
@@ -292,7 +292,7 @@ class I3cControllerFixed(I3cController):
         await self.send_stop()
 
     async def _execute_chain_write(self, chain, result):
-        """Execute Sr→Private Write chain after IBI handling."""
+        """Execute Sr->Private Write chain after IBI handling."""
         await self.send_start()
         await I3cController.write_addr_header(self, I3C_RSVD_BYTE)
         await self.send_start()
@@ -383,7 +383,7 @@ class I3cControllerFixed(I3cController):
         inject_tbit_err: bool = False,
         send_rsvd: bool = True,
     ) -> I3cPWResp:
-        """I3C Private Write with automatic IBI retry during S→0x7E."""
+        """I3C Private Write with automatic IBI retry during S->0x7E."""
         await self.take_bus_control()
         self.log_info(f"I3C: Write data ({mode.name}) {data} @ {hex(addr)}")
 
@@ -427,7 +427,7 @@ class I3cControllerFixed(I3cController):
         mode: I3cXferMode = I3cXferMode.PRIVATE,
         send_rsvd: bool = True,
     ) -> I3cPRResp:
-        """I3C Private Read with automatic IBI retry during S→0x7E."""
+        """I3C Private Read with automatic IBI retry during S->0x7E."""
         await self.take_bus_control()
         data = bytearray()
         self.log_info(f"I3C: Read data ({mode.name}) @ {hex(addr)}")
@@ -470,7 +470,7 @@ class I3cControllerFixed(I3cController):
         stop: bool = True,
         pull_scl_low: bool = False,
     ) -> Iterable[bool]:
-        """Issue CCC Write with automatic IBI retry during S→0x7E."""
+        """Issue CCC Write with automatic IBI retry during S->0x7E."""
         await self.take_bus_control()
         is_broadcast = ccc <= 0x7F
 
@@ -525,7 +525,7 @@ class I3cControllerFixed(I3cController):
         defining_byte: Optional[int] = None,
         stop: bool = True,
     ) -> Iterable[tuple]:
-        """Issue directed CCC Read with automatic IBI retry during S→0x7E."""
+        """Issue directed CCC Read with automatic IBI retry during S->0x7E."""
         if isinstance(addr, int):
             addr = [addr]
 
@@ -942,7 +942,7 @@ class I3cControllerFixed(I3cController):
         Execute ENTDAA from the controller side.
 
         Protocol:
-          S + 7E/W + ACK → 0x07 + T-bit
+          S + 7E/W + ACK -> 0x07 + T-bit
           For each target:
             Sr + 7E/R + ACK
             Read 64 bits (PID+BCR+DCR) via recv_bit_od

--- a/verification/cocotb/top/lib_i3c_top/te_error_monitor.py
+++ b/verification/cocotb/top/lib_i3c_top/te_error_monitor.py
@@ -232,7 +232,7 @@ class PostTe2DataIntegrityMonitor:
 
     Uses clock-edge sampling (not RisingEdge on te2_err) to match RTL
     behavior: the te2_err_priv_wr signal can glitch for one delta cycle
-    during the RxPWriteData→RxPWriteTbit FSM transition when the stale
+    during the RxPWriteData->RxPWriteTbit FSM transition when the stale
     byte-done coincides with the new state_q.  All RTL consumers of
     te2_err are registered, so the glitch is harmless in hardware.
     Sampling at the clock edge filters these transient glitches.

--- a/verification/cocotb/top/lib_i3c_top/test_ccc.py
+++ b/verification/cocotb/top/lib_i3c_top/test_ccc.py
@@ -1138,7 +1138,7 @@ async def test_ccc_rstact_vt_detect(dut):
 @cocotb.test()
 async def test_ccc_rstact_vt_detect_no_reset_arm(dut):
     """
-    Verify DB=0x04 does not arm a reset action: default peripheral→escalation
+    Verify DB=0x04 does not arm a reset action: default peripheral->escalation
     path still works after sending RSTACT with VT detect defining byte.
     """
     log = logging.getLogger("test_ccc_rstact_vt_detect_no_reset_arm")
@@ -1158,7 +1158,7 @@ async def test_ccc_rstact_vt_detect_no_reset_arm(dut):
         i3c_controller, RSTACT_DEF_BYTE.VIRTUAL_TARGET_DETECT,
         "direct", tgt_addr)
 
-    # 1st reset pattern → default peripheral reset (rstact not armed)
+    # 1st reset pattern -> default peripheral reset (rstact not armed)
     await i3c_controller.send_target_reset_pattern()
     await ClockCycles(tb.clk, 10)
     log.info(f"1st pattern: peripheral_reset_o={int(dut.peripheral_reset_o)}, "
@@ -1172,7 +1172,7 @@ async def test_ccc_rstact_vt_detect_no_reset_arm(dut):
     dut.peripheral_reset_done_i.value = 0
     await ClockCycles(tb.clk, 10)
 
-    # 2nd reset pattern → escalated reset (no intervening RSTACT/GETSTATUS)
+    # 2nd reset pattern -> escalated reset (no intervening RSTACT/GETSTATUS)
     await i3c_controller.send_target_reset_pattern()
     await ClockCycles(tb.clk, 10)
     log.info(f"2nd pattern: peripheral_reset_o={int(dut.peripheral_reset_o)}, "
@@ -1295,7 +1295,7 @@ async def test_ccc_getcaps(dut):
     for tgt_addr in [DYNAMIC_ADDR, VIRT_DYNAMIC_ADDR]:
         is_virt = (tgt_addr == VIRT_DYNAMIC_ADDR)
 
-        # No defining byte → 3 bytes (default GETCAPS)
+        # No defining byte -> 3 bytes (default GETCAPS)
         responses = await i3c_controller.i3c_ccc_read(
             ccc=CCC.DIRECT.GETCAPS, addr=tgt_addr, count=3)
         data = responses[0][1]
@@ -1305,14 +1305,14 @@ async def test_ccc_getcaps(dut):
         assert data[2] == expected_byte2, \
             f"GETCAPS byte2: expected 0x{expected_byte2:02X}, got 0x{data[2]:02X}"
 
-        # DB=0x00 → same 3 bytes
+        # DB=0x00 -> same 3 bytes
         responses = await i3c_controller.i3c_ccc_read(
             ccc=CCC.DIRECT.GETCAPS, addr=tgt_addr, count=3, defining_byte=0x00)
         data = responses[0][1]
         assert data[0] == 0x00 and data[1] == 0x01 and data[2] == expected_byte2, \
             f"GETCAPS DB=0x00: expected [00,01,{expected_byte2:02X}], got {[hex(b) for b in data]}"
 
-        # DB=0x93 → 1 byte (TESTCAP: 0x35)
+        # DB=0x93 -> 1 byte (TESTCAP: 0x35)
         responses = await i3c_controller.i3c_ccc_read(
             ccc=CCC.DIRECT.GETCAPS, addr=tgt_addr, count=1, defining_byte=0x93)
         data = responses[0][1]
@@ -1398,17 +1398,17 @@ async def test_ccc_rstact_read_action(dut):
             f"rst_action_o after arm 0x02: expected 0x02, got 0x{int(rst_action_sig):02X}"
         await i3c_controller.send_stop()
 
-        # Read with DB=0x00 in new frame → arm cleared by START → 0x80
+        # Read with DB=0x00 in new frame -> arm cleared by START -> 0x80
         val = await read_rstact(i3c_controller, 0x00, tgt_addr)
         assert val == 0x80, \
             f"RSTACT read after START: expected 0x80 (cleared), got 0x{val:02X}"
 
-        # Read recovery time (DB=0x81) → should return 0xFF
+        # Read recovery time (DB=0x81) -> should return 0xFF
         val = await read_rstact(i3c_controller, 0x81, tgt_addr)
         assert val == 0xFF, \
             f"RSTACT read DB=0x81: expected 0xFF, got 0x{val:02X}"
 
-        # Read recovery time (DB=0x82) → should return 0xFF
+        # Read recovery time (DB=0x82) -> should return 0xFF
         val = await read_rstact(i3c_controller, 0x82, tgt_addr)
         assert val == 0xFF, \
             f"RSTACT read DB=0x82: expected 0xFF, got 0x{val:02X}"
@@ -1517,7 +1517,7 @@ async def test_ccc_rstact_arm_clear_on_start(dut):
         ccc=CCC.DIRECT.GETSTATUS, addr=random.choice([DA, VDA]), count=2)
     # The START at beginning of this CCC read cleared rstact_armed
 
-    # Send target reset pattern → should get DEFAULT behavior (peripheral reset)
+    # Send target reset pattern -> should get DEFAULT behavior (peripheral reset)
     await i3c_controller.i3c_ccc_write(
         ccc=CCC.BCAST.RSTACT, defining_byte=0x01, stop=False)
     await i3c_controller.send_target_reset_pattern()
@@ -1583,8 +1583,8 @@ async def test_ccc_unknown_broadcast(dut):
 @cocotb.test()
 async def test_ccc_addr_lifecycle(dut):
     """
-    Full address lifecycle: RSTDAA → SETDASA → verify → SETNEWDA → verify →
-    RSTDAA → verify cleared. Tests both main and virtual targets.
+    Full address lifecycle: RSTDAA -> SETDASA -> verify -> SETNEWDA -> verify ->
+    RSTDAA -> verify cleared. Tests both main and virtual targets.
     """
     log = logging.getLogger("test_ccc_addr_lifecycle")
 
@@ -1597,7 +1597,7 @@ async def test_ccc_addr_lifecycle(dut):
     vda_reg = tb.reg_map.I3C_EC.STDBYCTRLMODE.STBY_CR_VIRT_DEVICE_ADDR
 
     # Step 1: SETDASA to assign initial addresses
-    log.info(f"SETDASA: main={SA}→{DA1}, virt={VSA}→{VDA1}")
+    log.info(f"SETDASA: main={SA}->{DA1}, virt={VSA}->{VDA1}")
     await i3c_controller.i3c_ccc_write(
         ccc=CCC.DIRECT.SETDASA, directed_data=[(SA, [DA1 << 1])], stop=False)
     await i3c_controller.i3c_ccc_write(
@@ -1613,7 +1613,7 @@ async def test_ccc_addr_lifecycle(dut):
     assert virt_da == VDA1 and virt_valid == 1, f"Virt DA: {virt_da} valid={virt_valid}"
 
     # Step 2: SETNEWDA to change addresses
-    log.info(f"SETNEWDA: main={DA1}→{DA2}, virt={VDA1}→{VDA2}")
+    log.info(f"SETNEWDA: main={DA1}->{DA2}, virt={VDA1}->{VDA2}")
     await i3c_controller.i3c_ccc_write(
         ccc=CCC.DIRECT.SETNEWDA, directed_data=[(DA1, [DA2 << 1])], stop=False)
     await i3c_controller.i3c_ccc_write(
@@ -1649,7 +1649,7 @@ async def test_ccc_chain_bcast(dut):
     i3c_controller, _, tb = await test_setup(dut)
     await ClockCycles(tb.clk, 50)
 
-    # Chain: SETMWL → SETMRL (broadcast, no STOP between them)
+    # Chain: SETMWL -> SETMRL (broadcast, no STOP between them)
     mwl_val = random.randint(0, 0xFFFF)
     mrl_val = random.randint(0, 0xFFFF)
     ibil_val = random.randint(0, 0xFF)
@@ -1684,7 +1684,7 @@ async def test_ccc_chain_direct(dut):
         dynamic_addr=DYNAMIC_ADDR, virtual_dynamic_addr=VIRT_DYNAMIC_ADDR)
     await ClockCycles(tb.clk, 50)
 
-    # Chain: SETMWL to main → SETMWL to VT (both in one frame)
+    # Chain: SETMWL to main -> SETMWL to VT (both in one frame)
     mwl_val = random.randint(0, 0xFFFF)
     await i3c_controller.i3c_ccc_write(
         ccc=CCC.DIRECT.SETMWL,
@@ -1728,8 +1728,8 @@ async def test_ccc_enthdr_all_codes(dut):
 async def test_ccc_te5_wrong_direction(dut):
     """
     TE5 error: wrong R/W direction for direct CCC.
-    - GET CCC sent with W direction → NACK
-    - SET CCC sent with R direction → NACK
+    - GET CCC sent with W direction -> NACK
+    - SET CCC sent with R direction -> NACK
     """
     (STATIC_ADDR, VIRT_STATIC_ADDR, DYNAMIC_ADDR, VIRT_DYNAMIC_ADDR) = \
         random.sample(VALID_I3C_ADDRESSES, 4)
@@ -1740,13 +1740,13 @@ async def test_ccc_te5_wrong_direction(dut):
     await ClockCycles(tb.clk, 50)
 
     for tgt_addr in [DYNAMIC_ADDR, VIRT_DYNAMIC_ADDR]:
-        # GET CCC with Write direction → NACK
+        # GET CCC with Write direction -> NACK
         acks = await i3c_controller.i3c_ccc_write(
             ccc=CCC.DIRECT.GETBCR, directed_data=[(tgt_addr, [0x00])])
         assert acks[0] == False, \
             f"GETBCR with W direction to 0x{tgt_addr:02X} should NACK"
 
-        # SET CCC with Read direction → NACK
+        # SET CCC with Read direction -> NACK
         responses = await i3c_controller.i3c_ccc_read(
             ccc=CCC.DIRECT.SETMWL, addr=tgt_addr, count=2)
         assert responses[0][0] == False, \
@@ -2099,8 +2099,8 @@ async def test_ccc_setdasa_padding_err(dut):
     await tb.write_csr_field(err_intr_addr, framing_stat_field, 1)
     await ClockCycles(tb.clk, 5)
 
-    # ---- Test 1: SETDASA with bad padding bit → framing error, address NOT applied ----
-    log.info(f"SETDASA with bad padding: addr={STATIC_ADDR:#x} → DA={DYNAMIC_ADDR:#x} | 1")
+    # ---- Test 1: SETDASA with bad padding bit -> framing error, address NOT applied ----
+    log.info(f"SETDASA with bad padding: addr={STATIC_ADDR:#x} -> DA={DYNAMIC_ADDR:#x} | 1")
     bad_data_byte = (DYNAMIC_ADDR << 1) | 1  # bit[0]=1 is the error
     await i3c_controller.i3c_ccc_write(
         ccc=CCC.DIRECT.SETDASA, directed_data=[(STATIC_ADDR, [bad_data_byte])])
@@ -2125,8 +2125,8 @@ async def test_ccc_setdasa_padding_err(dut):
     await tb.write_csr_field(err_intr_addr, framing_stat_field, 1)
     await ClockCycles(tb.clk, 5)
 
-    # ---- Test 2: Good SETDASA → should work normally ----
-    log.info(f"SETDASA with good padding: addr={STATIC_ADDR:#x} → DA={DYNAMIC_ADDR:#x}")
+    # ---- Test 2: Good SETDASA -> should work normally ----
+    log.info(f"SETDASA with good padding: addr={STATIC_ADDR:#x} -> DA={DYNAMIC_ADDR:#x}")
     good_data_byte = (DYNAMIC_ADDR << 1)  # bit[0]=0
     await i3c_controller.i3c_ccc_write(
         ccc=CCC.DIRECT.SETDASA, directed_data=[(STATIC_ADDR, [good_data_byte])], stop=False)
@@ -2140,10 +2140,10 @@ async def test_ccc_setdasa_padding_err(dut):
     da_val = await tb.read_csr_field(da_reg_addr, da_field)
     assert da_val == DYNAMIC_ADDR, f"DA should be {DYNAMIC_ADDR:#x}, got {da_val:#x}"
 
-    # ---- Test 3: SETNEWDA with bad padding bit → framing error, address unchanged ----
+    # ---- Test 3: SETNEWDA with bad padding bit -> framing error, address unchanged ----
     NEW_ADDR = random.choice([a for a in VALID_I3C_ADDRESSES
                               if a not in (STATIC_ADDR, VIRT_STATIC_ADDR, DYNAMIC_ADDR, VIRT_DYNAMIC_ADDR)])
-    log.info(f"SETNEWDA with bad padding: DA={DYNAMIC_ADDR:#x} → {NEW_ADDR:#x} | 1")
+    log.info(f"SETNEWDA with bad padding: DA={DYNAMIC_ADDR:#x} -> {NEW_ADDR:#x} | 1")
     bad_data_byte = (NEW_ADDR << 1) | 1
     await i3c_controller.i3c_ccc_write(
         ccc=CCC.DIRECT.SETNEWDA, directed_data=[(DYNAMIC_ADDR, [bad_data_byte])])
@@ -2357,8 +2357,8 @@ async def test_ccc_entdaa_te3_te4(dut):
     """
     Verify TE3 and TE4 error handling during ENTDAA.
 
-    TE3: Parity error on assigned address → target NACKs, retries on next Sr+7E/R.
-    TE4: Invalid reserved byte (not 7E/R) → target NACKs, waits for STOP.
+    TE3: Parity error on assigned address -> target NACKs, retries on next Sr+7E/R.
+    TE4: Invalid reserved byte (not 7E/R) -> target NACKs, waits for STOP.
 
     """
     log = logging.getLogger("test_ccc_entdaa_te3_te4")
@@ -2441,7 +2441,7 @@ async def test_ccc_entdaa_te3_te4(dut):
 async def test_ccc_entdaa_arb_lost(dut):
     """
     Verify ENTDAA arbitration-lost path: when arbitration_lost_i is asserted
-    during ID bit transmission, the DUT enters LostArbitration → WaitStart and
+    during ID bit transmission, the DUT enters LostArbitration -> WaitStart and
     retries on the next Sr+7E/R round.
 
     Uses cocotb signal force on the internal arbitration_lost_i signal.
@@ -2722,12 +2722,12 @@ async def test_ccc_getstatus_abort_then_chain_setmwl(dut):
     followed by a different CCC must NOT clear the error.
 
     Bus sequence (no STOP between abort and new CCC):
-      S → 0x7E/W → GETSTATUS → Sr → ADDR/R → byte0 → Sr(abort)
-        → 0x7E/W → SETMWL → Sr → ADDR/W → byte0 → byte1 → STOP
+      S -> 0x7E/W -> GETSTATUS -> Sr -> ADDR/R -> byte0 -> Sr(abort)
+        -> 0x7E/W -> SETMWL -> Sr -> ADDR/W -> byte0 -> byte1 -> STOP
 
     RTL path exercised:
-      ccc.sv TxDataTbit → Sr → RxTargetAddr → TxTargetAddrAck (0x7E/W)
-        → NextCCC → WaitCCC → new SETMWL processing → DoneCCC
+      ccc.sv TxDataTbit -> Sr -> RxTargetAddr -> TxTargetAddrAck (0x7E/W)
+        -> NextCCC -> WaitCCC -> new SETMWL processing -> DoneCCC
       get_status_done_o must NOT fire because command_code changed to SETMWL.
     """
     log = logging.getLogger("test_ccc_getstatus_abort_chain")
@@ -3954,7 +3954,7 @@ async def test_ccc_entdaa_stop_in_ackrsvdbyte(dut):
         dut, STATIC_ADDR, VIRT_STATIC_ADDR)
     await ClockCycles(tb.clk, 50)
 
-    # Raw ENTDAA: S + 7E/W + 0x07 + Sr + 7E/R + ACK bit → STOP during ACK
+    # Raw ENTDAA: S + 7E/W + 0x07 + Sr + 7E/R + ACK bit -> STOP during ACK
     log.info("ENTDAA with STOP during AckRsvdByte")
     await i3c_controller.take_bus_control()
     await i3c_controller.send_start()

--- a/verification/cocotb/top/lib_i3c_top/test_i3c_target.py
+++ b/verification/cocotb/top/lib_i3c_top/test_i3c_target.py
@@ -1352,7 +1352,7 @@ async def test_priv_write_stop_during_tbit(dut):
 
     # Use byte value with LSB=0 so SDA is LOW after 8th data bit
     complete_data = [0xDE, 0xAD, 0xBE, 0xEF, 0xCA]
-    abort_byte = 0xFE  # bits: 11111110, LSB=0 → SDA=0 after 8 data bits
+    abort_byte = 0xFE  # bits: 11111110, LSB=0 -> SDA=0 after 8 data bits
 
     await i3c_controller.take_bus_control()
     await i3c_controller.send_start()
@@ -1370,11 +1370,11 @@ async def test_priv_write_stop_during_tbit(dut):
 
     # SCL is HIGH, SDA is LOW (abort_byte LSB=0).
     # Create STOP without providing a SCL posedge for the T-bit:
-    # SDA LOW→HIGH while SCL is HIGH = STOP condition.
+    # SDA LOW->HIGH while SCL is HIGH = STOP condition.
     # The bus_rx_flow never gets a SCL posedge for the T-bit, so bus_rx_rsp.done
     # does NOT fire. The FSM is in RxPWriteTbit when bus_stop_det_i fires.
     await Timer(1, "ns")
-    i3c_controller.sda = 1  # SDA rising → STOP detected by bus_monitor
+    i3c_controller.sda = 1  # SDA rising -> STOP detected by bus_monitor
     await Timer(100, "ns")
 
     # Fix BFM state to reflect bus idle
@@ -1432,7 +1432,7 @@ async def test_priv_write_sr_during_tbit(dut):
 
     complete_data = [0xDE, 0xAD, 0xBE, 0xEF, 0xCA]
     # Use byte value with LSB=1 so SDA is HIGH after 8th data bit
-    abort_byte = 0xAB  # bits: 10101011, LSB=1 → SDA=1 after 8 data bits
+    abort_byte = 0xAB  # bits: 10101011, LSB=1 -> SDA=1 after 8 data bits
 
     await i3c_controller.take_bus_control()
     await i3c_controller.send_start()
@@ -1449,9 +1449,9 @@ async def test_priv_write_sr_during_tbit(dut):
 
     # SCL is HIGH, SDA is HIGH (abort_byte LSB=1).
     # Create Sr without providing a SCL posedge for the T-bit:
-    # SDA HIGH→LOW while SCL is HIGH = START/RESTART condition.
+    # SDA HIGH->LOW while SCL is HIGH = START/RESTART condition.
     await Timer(1, "ns")
-    i3c_controller.sda = 0  # SDA falling → RESTART detected by bus_monitor
+    i3c_controller.sda = 0  # SDA falling -> RESTART detected by bus_monitor
     await Timer(100, "ns")
 
     # Complete the bus frame with STOP

--- a/verification/cocotb/top/lib_i3c_top/test_ibi.py
+++ b/verification/cocotb/top/lib_i3c_top/test_ibi.py
@@ -652,13 +652,13 @@ async def test_ibi_initiation_bus_available_vs_start(dut):
     # Queue IBI, then immediately issue a controller Start (before Bus Available).
     # DUT enters RxFByteArb on this Start and drives its IBI address.
     # It loses arbitration on the RnW bit (DUT=1 vs controller=0) but
-    # exercises the Bus Start initiation path (Idle → RxFByteArb).
+    # exercises the Bus Start initiation path (Idle -> RxFByteArb).
     # After the write's STOP + Bus Available, DUT retries via IbiDriveAddr.
     mdb_b = 0xB2
     data_b = [0x02]
     await send_ibi(tb, mdb_b, data_b)
 
-    # Bare Start → TARGET_ADDRESS+W: DUT arbitrates, loses on RnW bit
+    # Bare Start -> TARGET_ADDRESS+W: DUT arbitrates, loses on RnW bit
     write_data_b = [0x00]
     await i3c_controller.i3c_write(TARGET_ADDRESS, write_data_b, send_rsvd=False)
 
@@ -902,8 +902,8 @@ async def test_ibi_arb_loss_address(dut):
     address phase. RTL sets ibi_inhibit — DUT must NOT retry on the next
     Start, only after Bus Available condition.
     """
-    DUT_ADDR = 0x60   # Higher address → lower priority
-    VIP_ADDR = 0x20   # Lower address → wins arbitration
+    DUT_ADDR = 0x60   # Higher address -> lower priority
+    VIP_ADDR = 0x20   # Lower address -> wins arbitration
 
     i3c_controller, i3c_target_vip, tb = await test_setup(
         dut, static_addr=DUT_ADDR,
@@ -969,7 +969,7 @@ async def test_ibi_arb_loss_rnw_bit(dut):
     # Controller writes to DUT's own address without 0x7E header.
     # DUT enters RxFByteArb and drives (TARGET_ADDRESS<<1|1);
     # controller drives (TARGET_ADDRESS<<1|0). Bits 7-1 match,
-    # bit 0 differs → DUT loses on RnW.
+    # bit 0 differs -> DUT loses on RnW.
     write_data = [0xDE, 0xAD]
     resp = await i3c_controller.i3c_write(
         TARGET_ADDRESS, write_data, send_rsvd=False,
@@ -998,7 +998,7 @@ async def test_ibi_arb_loss_rnw_bit(dut):
 
 
 # =============================================================================
-# Test 15: NACK → Sr → Private Write (Flow 4)
+# Test 15: NACK -> Sr -> Private Write (Flow 4)
 # =============================================================================
 
     await tb.teardown()
@@ -1006,9 +1006,9 @@ async def test_ibi_arb_loss_rnw_bit(dut):
 @cocotb.test()
 async def test_ibi_nack_sr_private_write(dut):
     """
-    Flow 4: Controller NACKs IBI then chains Sr → Private Write to the
+    Flow 4: Controller NACKs IBI then chains Sr -> Private Write to the
     target within the same bus frame. Target must NOT attempt IBI on
-    the chained Repeated Start (WaitRestart→RxFByte, not RxFByteArb).
+    the chained Repeated Start (WaitRestart->RxFByte, not RxFByteArb).
     """
     i3c_controller, _, tb = await test_setup(dut)
     await init_ibi(i3c_controller, tb)
@@ -1017,7 +1017,7 @@ async def test_ibi_nack_sr_private_write(dut):
     data = [0x55, 0x66]
     await send_ibi(tb, mdb, data)
 
-    # NACK IBI, then Sr → Private Write to target
+    # NACK IBI, then Sr -> Private Write to target
     write_payload = [0xDE, 0xAD]
     i3c_controller.enable_ibi(False)
     i3c_controller.set_ibi_chain_write(TARGET_ADDRESS, write_payload)
@@ -1048,7 +1048,7 @@ async def test_ibi_nack_sr_private_write(dut):
 
 
 # =============================================================================
-# Test 16: NACK → Sr → Directed DISEC (Flow 6)
+# Test 16: NACK -> Sr -> Directed DISEC (Flow 6)
 # =============================================================================
 
     await tb.teardown()
@@ -1056,7 +1056,7 @@ async def test_ibi_nack_sr_private_write(dut):
 @cocotb.test()
 async def test_ibi_nack_sr_directed_disec(dut):
     """
-    Flow 6: Controller NACKs IBI then chains Sr → Directed DISEC with
+    Flow 6: Controller NACKs IBI then chains Sr -> Directed DISEC with
     DISINT to the target. Uses CCC 0x81 (directed SET) with addr+W
     direction. Verifies IBI_EN clears and target stops retrying.
     """
@@ -1067,7 +1067,7 @@ async def test_ibi_nack_sr_directed_disec(dut):
     data = [0xCA, 0xFE]
     await send_ibi(tb, mdb, data)
 
-    # NACK IBI, then Sr → Directed DISEC (CCC 0x81, SET → addr+W)
+    # NACK IBI, then Sr -> Directed DISEC (CCC 0x81, SET -> addr+W)
     i3c_controller.enable_ibi(False)
     i3c_controller.set_ibi_chain_ccc(
         CCC.DIRECT.DISEC,
@@ -1167,12 +1167,12 @@ async def test_ibi_accept_no_mdb_stop(dut):
 async def test_ibi_accept_no_mdb_sr_ccc(dut):
     """
     Flow 8: Our target always sends MDB (BCR[2]=1). Controller ACKs but
-    sends Sr → CCC without reading MDB. Target should report a non-success
+    sends Sr -> CCC without reading MDB. Target should report a non-success
     IBI status since the MDB was never consumed.
 
     DESIGN CHOICE: This I3C target does not support IBIs without MDB
     (BCR[2]=0 mode). When the controller violates the BCR[2]=1 contract
-    by sending Sr → CCC before reading the MDB, the IBI status is not
+    by sending Sr -> CCC before reading the MDB, the IBI status is not
     updated and the orphaned IBI re-fires. This is expected behavior
     for an unsupported flow.
 
@@ -1187,7 +1187,7 @@ async def test_ibi_accept_no_mdb_sr_ccc(dut):
     data = [0x22]
     await send_ibi(tb, mdb, data)
 
-    # ACK but refuse to read MDB, chain Sr → CCC instead
+    # ACK but refuse to read MDB, chain Sr -> CCC instead
     i3c_controller.set_ibi_skip_data(True)
     i3c_controller.set_ibi_chain_ccc(CCC.BCAST.ENEC, ccc_data=[0x0B])
 
@@ -1211,14 +1211,14 @@ async def test_ibi_accept_no_mdb_sr_ccc(dut):
 
 
 # =============================================================================
-# Test 19: ACK, tbit abort, Sr → CCC (Flow 12)
+# Test 19: ACK, tbit abort, Sr -> CCC (Flow 12)
 # =============================================================================
 
 @cocotb.test()
 async def test_ibi_tbit_abort_sr_ccc(dut):
     """
     Flow 12: Controller ACKs IBI, reads partial data (T-bit abort by
-    stopping early), then chains Sr → CCC. The target should report
+    stopping early), then chains Sr -> CCC. The target should report
     IbiPartialData status and the CCC should execute correctly.
     """
     i3c_controller, _, tb = await test_setup(dut)
@@ -1228,7 +1228,7 @@ async def test_ibi_tbit_abort_sr_ccc(dut):
     full_data = [0xCA, 0xFE, 0xBA, 0xBE, 0xDD, 0xEE]
     await send_ibi(tb, mdb, full_data)
 
-    # ACK and read only MDB + 2 data bytes, then Sr → GETSTATUS
+    # ACK and read only MDB + 2 data bytes, then Sr -> GETSTATUS
     i3c_controller.set_ibi_max_data(2)
     i3c_controller.set_ibi_chain_ccc(
         CCC.DIRECT.GETSTATUS,
@@ -1328,7 +1328,7 @@ async def test_ibi_retry_ctr_fw_reset(dut):
     data = [0xAA, 0xBB]
     await send_ibi(tb, mdb, data)
 
-    # NACK attempt 1 → counter becomes 1
+    # NACK attempt 1 -> counter becomes 1
     i3c_controller.enable_ibi(False)
 
     result = await i3c_controller.wait_for_ibi_event()
@@ -1342,7 +1342,7 @@ async def test_ibi_retry_ctr_fw_reset(dut):
         1,
     )
 
-    # NACK attempt 2 → counter becomes 1 again (was reset to 0)
+    # NACK attempt 2 -> counter becomes 1 again (was reset to 0)
     result = await i3c_controller.wait_for_ibi_event()
     assert result["ack"] is False, f"IBI ACK mismatch: expected False, got {result['ack']}"
 
@@ -1493,9 +1493,9 @@ async def test_rxfbytearb_collision_blind_drive(dut):
     DUT enters RxFByteArb driving IBI byte {0x5A, 1} = 0xB5.  Controller
     drives a write to the same address: {0x5A, 0} = 0xB4.  Bits 7..1
     match; at bit 0 the DUT drives 1 (IBI/read) but reads 0 (controller
-    write) → DUT loses arbitration.
+    write) -> DUT loses arbitration.
 
-    After arb loss the DUT transitions RxFByteArb → RxFByte → CheckFByte
+    After arb loss the DUT transitions RxFByteArb -> RxFByte -> CheckFByte
     and processes the controller's valid byte (addr 0x5A, Write).  Since
     0x5A matches the DUT's own address, the DUT ACKs and accepts the
     private write data.  After Bus Available the DUT retries IBI.
@@ -1510,7 +1510,7 @@ async def test_rxfbytearb_collision_blind_drive(dut):
     # Controller writes to DUT's own address without 0x7E header.
     # DUT enters RxFByteArb driving {TARGET_ADDRESS<<1|1};
     # controller drives {TARGET_ADDRESS<<1|0}.  Bits 7-1 match,
-    # bit 0 differs → DUT loses on RnW (0 dominant in OD).
+    # bit 0 differs -> DUT loses on RnW (0 dominant in OD).
     write_data = [0xCA, 0xFE]
     resp = await i3c_controller.i3c_write(
         TARGET_ADDRESS, write_data, send_rsvd=False,
@@ -1539,7 +1539,7 @@ async def test_rxfbytearb_collision_blind_drive(dut):
 
 
 # =============================================================================
-# Test: IbiFailureRetry from Idle — flush ignored → interrupt flood
+# Test: IbiFailureRetry from Idle — flush ignored -> interrupt flood
 # =============================================================================
 
     await tb.teardown()


### PR DESCRIPTION
The recovery_mode_enter signal routed from the recovery handeler -> descriptor_tx was not nessasary as the descriptor_tx is properly reset whenever you get to the end of a private read or there is an abort. This was excess logic that caused a combo loop in the desgin.