### PR TITLE
Fix snapshot csr_data to prevent TX PEC/bus data race

### DIFF
--- a/doc/source/ccc.md
+++ b/doc/source/ccc.md
@@ -78,6 +78,42 @@ limits on Private Read or Private Write transfers. See {doc}`firmware_guide` for
 details on firmware responsibilities.
 ```
 
+## Multi-Byte CCC Register Atomicity
+
+Several Direct GET CCCs return multi-byte values. The CCC state machine
+transmits these byte-by-byte, selecting each byte from the source signal
+combinationally as it is needed. There is no snapshot or shadow register;
+the source is re-read on every byte. If the underlying CSR is modified
+mid-transfer, remaining bytes will reflect the new value while
+already-transmitted bytes retain the old value.
+
+| CCC | Bytes | Source | Updated By |
+|-----|-------|--------|------------|
+| GETBCR | 1 | `STBY_CR_DEVICE_CHAR.BCR_*` | FW |
+| GETDCR | 1 | `STBY_CR_DEVICE_CHAR.DCR` | FW |
+| GETSTATUS | 2 | `TTI.INTERRUPT_STATUS`, `TTI.STATUS` | HW |
+| GETMWL | 2 | Internal flop | SETMWL CCC |
+| GETMRL | 3 | Internal flop | SETMRL CCC |
+| GETPID | 6 | `STBY_CR_DEVICE_CHAR.PID_HI` + `STBY_CR_DEVICE_PID_LO.PID_LO` | FW |
+
+**GETPID**: The 48-bit PID is assembled combinationally from two CSR
+registers (`STBY_CR_DEVICE_CHAR` and `STBY_CR_DEVICE_PID_LO`). If firmware
+writes either register while a GETPID CCC is in progress, the byte being
+transmitted in that cycle and all subsequent bytes will use the new register
+value. Firmware should write both PID registers before the Target receives
+a dynamic address (before ENTDAA / SETDASA / SETAASA), since GETPID is
+only issued after address assignment.
+
+**GETMWL / GETMRL**: These read internal flops that are only written by the
+SETMWL / SETMRL CCC handler. Since only one CCC can be active on the bus at
+a time, GET and SET cannot overlap. These registers are read-only to firmware
+(`sw = r`).
+
+For SET CCCs, **SETMRL** commits MRL (bytes 0-1) and IBIL (byte 2) to
+`STBY_CR_MRL` on separate clock cycles. A firmware read of `STBY_CR_MRL`
+between those two updates sees the new MRL with the stale IBIL. **SETMWL**
+commits both MWL bytes to `STBY_CR_MWL` in a single cycle.
+
 ## CCC Error Handling
 
 The core detects errors during CCC processing:

--- a/src/recovery/recovery_receiver.sv
+++ b/src/recovery/recovery_receiver.sv
@@ -353,8 +353,9 @@ module recovery_receiver
   logic capture_pec;
   logic set_cmd_is_rd;
   logic latch_pec_from_len;
-  logic load_csr_sel;
-  logic inc_csr_sel;
+  logic load_csr_sel;    // Loads csr_sel/csr_end (CmdDispatch)
+  logic inc_csr_sel;     // Advances csr_sel at DWORD boundaries
+  logic load_csr_data;   // Delayed pulse: captures csr_data 1 cycle after csr_sel settles
   logic load_csr_length;
 
   //----------------------------------------------------------------------------
@@ -1210,11 +1211,16 @@ module recovery_receiver
     if (!rst_ni) begin
       csr_sel <= CSR_INVALID;
       csr_end <= CSR_INVALID;
+      load_csr_data <= '0;
     end else if (load_csr_sel) begin
       csr_sel <= csr_sel_next;
       csr_end <= csr_end_next;
+      load_csr_data <= 1'b1;
     end else if (inc_csr_sel && (csr_sel < csr_end)) begin
       csr_sel <= csr_e'(csr_sel + 8'd1);
+      load_csr_data <= 1'b1;
+    end else begin
+      load_csr_data <= '0;
     end
   end
 
@@ -1438,10 +1444,12 @@ module recovery_receiver
     endcase
   end
 
+  // Capture csr_data one cycle after csr_sel settles to ensure
+  // csr_data_next (driven by case(csr_sel)) sees the correct selector.
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       csr_data <= '0;
-    end else begin
+    end else if (load_csr_data) begin
       csr_data <= csr_data_next;
     end
   end

--- a/verification/cocotb/common.mk
+++ b/verification/cocotb/common.mk
@@ -50,21 +50,13 @@ ifeq ($(SIM), verilator)
     EXTRA_ARGS += -Wno-DECLFILENAME -Wno-TIMESCALEMOD
 endif
 
-# Switch between Verdi FSDB PLI and "classic" waveform dumping
-VERDI_PLI ?= 1
-
 ifeq ($(SIM), vcs)
     COMPILE_ARGS += -assert svaext
     COMPILE_ARGS += -Xcflags='-Wno-error=implicit-function-declaration -Wno-error=int-conversion'
     COMPILE_ARGS += -kdb
-    ifeq ($(VERDI_PLI), 1)
-        COMPILE_ARGS += -P $(VERDI_HOME)/share/PLI/VCS/LINUX64/novas.tab $(VERDI_HOME)/share/PLI/VCS/LINUX64/pli.a
-    else
-        COMPILE_ARGS += -debug_access+all +vcs+fsdbon
-    endif
+    COMPILE_ARGS += -debug_access+all +vcs+fsdbon
     ifeq ($(WAVES), 1)
-        # Sim args seem to work for both wave dumping types (?)
-    SIM_ARGS += +fsdbfile+dump.fsdb +fsdb+all=on +fsdb+mda=on
+        SIM_ARGS += +fsdbfile+dump.fsdb +fsdb+all=on +fsdb+mda=on
     endif
     EXTRA_ARGS += +vcs+lic+wait
 

--- a/verification/cocotb/top/lib_i3c_top/common.py
+++ b/verification/cocotb/top/lib_i3c_top/common.py
@@ -1,10 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 """Shared constants and helpers for I3C Target cocotb tests."""
 
+import random
+
 import cocotb
 from cocotb.triggers import Timer
 
-# Canonical I3C address list — single source of truth
+from ccc import CCC
+
+# Canonical I3C address list -- single source of truth
 # 0x23 is excluded: it is hardcoded as the I3CTarget sim model address
 # and selecting it for DUT addresses causes bus contention.
 VALID_I3C_ADDRESSES = (
@@ -28,3 +32,232 @@ def log_seed(dut):
     """Log the random seed for reproducibility."""
     seed = cocotb.plusargs.get("seed", None)
     dut._log.info(f"Random seed: {seed or 'unknown (set via RANDOM_SEED plusarg)'}")
+
+
+# =============================================================================
+# CCC helpers
+#
+# Generic wrappers around common CCC commands.  Each function takes an
+# i3c_controller and target address(es) explicitly so they can be reused
+# from any test file.
+#
+# GET helpers return the raw data bytes (bytearray) and assert ACK.
+# SET helpers return True/False indicating whether the target ACKed.
+# All helpers log the CCC name, address, and returned data.
+# =============================================================================
+
+# Valid event-enable bit patterns for ENEC / DISEC
+ENEC_DISEC_PATTERNS = [0x01, 0x02, 0x08, 0x03, 0x09, 0x0A, 0x0B]
+
+
+async def do_getstatus(i3c_controller, addr):
+    """Send directed GETSTATUS.  Returns 2-byte status (bytearray)."""
+    responses = await i3c_controller.i3c_ccc_read(
+        ccc=CCC.DIRECT.GETSTATUS, addr=addr, count=2)
+    ack, data = responses[0]
+    assert ack, f"GETSTATUS NACK addr=0x{addr:02X}"
+    cocotb.log.info(f"GETSTATUS addr=0x{addr:02X} -> {data.hex()}")
+    return data
+
+
+async def do_getbcr(i3c_controller, addr):
+    """Send directed GETBCR.  Returns 1-byte BCR (bytearray)."""
+    responses = await i3c_controller.i3c_ccc_read(
+        ccc=CCC.DIRECT.GETBCR, addr=addr, count=1)
+    ack, data = responses[0]
+    assert ack, f"GETBCR NACK addr=0x{addr:02X}"
+    cocotb.log.info(f"GETBCR addr=0x{addr:02X} -> {data.hex()}")
+    return data
+
+
+async def do_getdcr(i3c_controller, addr):
+    """Send directed GETDCR.  Returns 1-byte DCR (bytearray)."""
+    responses = await i3c_controller.i3c_ccc_read(
+        ccc=CCC.DIRECT.GETDCR, addr=addr, count=1)
+    ack, data = responses[0]
+    assert ack, f"GETDCR NACK addr=0x{addr:02X}"
+    cocotb.log.info(f"GETDCR addr=0x{addr:02X} -> {data.hex()}")
+    return data
+
+
+async def do_getmwl(i3c_controller, addr):
+    """Send directed GETMWL.  Returns 2-byte MWL (bytearray)."""
+    responses = await i3c_controller.i3c_ccc_read(
+        ccc=CCC.DIRECT.GETMWL, addr=addr, count=2)
+    ack, data = responses[0]
+    assert ack, f"GETMWL NACK addr=0x{addr:02X}"
+    cocotb.log.info(f"GETMWL addr=0x{addr:02X} -> {data.hex()}")
+    return data
+
+
+async def do_getmrl(i3c_controller, addr):
+    """Send directed GETMRL.  Returns 3-byte MRL (bytearray)."""
+    responses = await i3c_controller.i3c_ccc_read(
+        ccc=CCC.DIRECT.GETMRL, addr=addr, count=3)
+    ack, data = responses[0]
+    assert ack, f"GETMRL NACK addr=0x{addr:02X}"
+    cocotb.log.info(f"GETMRL addr=0x{addr:02X} -> {data.hex()}")
+    return data
+
+
+async def do_getpid(i3c_controller, addr):
+    """Send directed GETPID.  Returns 6-byte PID (bytearray)."""
+    responses = await i3c_controller.i3c_ccc_read(
+        ccc=CCC.DIRECT.GETPID, addr=addr, count=6)
+    ack, data = responses[0]
+    assert ack, f"GETPID NACK addr=0x{addr:02X}"
+    cocotb.log.info(f"GETPID addr=0x{addr:02X} -> {data.hex()}")
+    return data
+
+
+async def do_getcaps(i3c_controller, addr):
+    """Send directed GETCAPS (no defining byte, 3 bytes).  Returns bytearray."""
+    responses = await i3c_controller.i3c_ccc_read(
+        ccc=CCC.DIRECT.GETCAPS, addr=addr, count=3)
+    ack, data = responses[0]
+    assert ack, f"GETCAPS NACK addr=0x{addr:02X}"
+    cocotb.log.info(f"GETCAPS addr=0x{addr:02X} -> {data.hex()}")
+    return data
+
+
+async def do_setmwl_direct(i3c_controller, addr, val=None):
+    """Send directed SETMWL.  Returns True if ACKed, False otherwise."""
+    if val is None:
+        val = random.randint(0, 0xFFFF)
+    acks = await i3c_controller.i3c_ccc_write(
+        ccc=CCC.DIRECT.SETMWL,
+        directed_data=[(addr, [(val >> 8) & 0xFF, val & 0xFF])])
+    ok = bool(acks and acks[0])
+    cocotb.log.info(f"SETMWL direct addr=0x{addr:02X} val=0x{val:04X} ack={ok}")
+    return ok
+
+
+async def do_setmrl_direct(i3c_controller, addr, val=None, ibil=None):
+    """Send directed SETMRL.  Returns True if ACKed, False otherwise."""
+    if val is None:
+        val = random.randint(0, 0xFFFF)
+    if ibil is None:
+        ibil = random.randint(0, 0xFF)
+    acks = await i3c_controller.i3c_ccc_write(
+        ccc=CCC.DIRECT.SETMRL,
+        directed_data=[(addr, [(val >> 8) & 0xFF, val & 0xFF, ibil])])
+    ok = bool(acks and acks[0])
+    cocotb.log.info(
+        f"SETMRL direct addr=0x{addr:02X} mrl=0x{val:04X} "
+        f"ibil=0x{ibil:02X} ack={ok}")
+    return ok
+
+
+async def do_enec_direct(i3c_controller, addr, pattern=None):
+    """Send directed ENEC.  Returns True if ACKed, False otherwise."""
+    if pattern is None:
+        pattern = random.choice(ENEC_DISEC_PATTERNS)
+    acks = await i3c_controller.i3c_ccc_write(
+        ccc=CCC.DIRECT.ENEC, directed_data=[(addr, [pattern])])
+    ok = bool(acks and acks[0])
+    cocotb.log.info(f"ENEC direct addr=0x{addr:02X} pattern=0x{pattern:02X} ack={ok}")
+    return ok
+
+
+async def do_disec_direct(i3c_controller, addr, pattern=None):
+    """Send directed DISEC.  Returns True if ACKed, False otherwise."""
+    if pattern is None:
+        pattern = random.choice(ENEC_DISEC_PATTERNS)
+    acks = await i3c_controller.i3c_ccc_write(
+        ccc=CCC.DIRECT.DISEC, directed_data=[(addr, [pattern])])
+    ok = bool(acks and acks[0])
+    cocotb.log.info(
+        f"DISEC direct addr=0x{addr:02X} pattern=0x{pattern:02X} ack={ok}")
+    return ok
+
+
+async def do_rstact_direct(i3c_controller, addr, defining_byte=None):
+    """Send directed RSTACT.  Returns True if ACKed, False otherwise."""
+    if defining_byte is None:
+        defining_byte = random.choice([0x00, 0x01, 0x02])
+    acks = await i3c_controller.i3c_ccc_write(
+        ccc=CCC.DIRECT.RSTACT, defining_byte=defining_byte,
+        directed_data=[(addr, [])], stop=True)
+    ok = bool(acks and acks[0])
+    cocotb.log.info(
+        f"RSTACT direct addr=0x{addr:02X} db=0x{defining_byte:02X} ack={ok}")
+    return ok
+
+
+async def do_setmwl_bcast(i3c_controller, val=None):
+    """Send broadcast SETMWL.  Returns True (broadcast has no per-target ACK)."""
+    if val is None:
+        val = random.randint(0, 0xFFFF)
+    await i3c_controller.i3c_ccc_write(
+        ccc=CCC.BCAST.SETMWL,
+        broadcast_data=[(val >> 8) & 0xFF, val & 0xFF])
+    cocotb.log.info(f"SETMWL bcast val=0x{val:04X}")
+    return True
+
+
+async def do_setmrl_bcast(i3c_controller, val=None, ibil=None):
+    """Send broadcast SETMRL.  Returns True (broadcast has no per-target ACK)."""
+    if val is None:
+        val = random.randint(0, 0xFFFF)
+    if ibil is None:
+        ibil = random.randint(0, 0xFF)
+    await i3c_controller.i3c_ccc_write(
+        ccc=CCC.BCAST.SETMRL,
+        broadcast_data=[(val >> 8) & 0xFF, val & 0xFF, ibil])
+    cocotb.log.info(f"SETMRL bcast mrl=0x{val:04X} ibil=0x{ibil:02X}")
+    return True
+
+
+async def do_enec_bcast(i3c_controller, pattern=None):
+    """Send broadcast ENEC.  Returns True (broadcast has no per-target ACK)."""
+    if pattern is None:
+        pattern = random.choice(ENEC_DISEC_PATTERNS)
+    await i3c_controller.i3c_ccc_write(
+        ccc=CCC.BCAST.ENEC, broadcast_data=[pattern])
+    cocotb.log.info(f"ENEC bcast pattern=0x{pattern:02X}")
+    return True
+
+
+async def do_disec_bcast(i3c_controller, pattern=None):
+    """Send broadcast DISEC.  Returns True (broadcast has no per-target ACK)."""
+    if pattern is None:
+        pattern = random.choice(ENEC_DISEC_PATTERNS)
+    await i3c_controller.i3c_ccc_write(
+        ccc=CCC.BCAST.DISEC, broadcast_data=[pattern])
+    cocotb.log.info(f"DISEC bcast pattern=0x{pattern:02X}")
+    return True
+
+
+def build_ccc_stress_table(i3c_controller, targets):
+    """Build a weighted CCC command table for stress testing.
+
+    Returns a list of zero-argument coroutine functions.  Each picks a random
+    target from *targets* (for directed CCCs) and sends one CCC.
+    SET CCCs appear twice for higher weight (more race opportunity).
+    """
+    get_table = [
+        lambda c=i3c_controller, t=targets: do_getstatus(c, random.choice(t)),
+        lambda c=i3c_controller, t=targets: do_getbcr(c, random.choice(t)),
+        lambda c=i3c_controller, t=targets: do_getdcr(c, random.choice(t)),
+        lambda c=i3c_controller, t=targets: do_getmwl(c, random.choice(t)),
+        lambda c=i3c_controller, t=targets: do_getmrl(c, random.choice(t)),
+        lambda c=i3c_controller, t=targets: do_getpid(c, random.choice(t)),
+        lambda c=i3c_controller, t=targets: do_getcaps(c, random.choice(t)),
+    ]
+
+    set_directed = [
+        lambda c=i3c_controller, t=targets: do_setmwl_direct(c, random.choice(t)),
+        lambda c=i3c_controller, t=targets: do_setmrl_direct(c, random.choice(t)),
+        lambda c=i3c_controller, t=targets: do_enec_direct(c, random.choice(t)),
+        lambda c=i3c_controller, t=targets: do_disec_direct(c, random.choice(t)),
+        lambda c=i3c_controller, t=targets: do_rstact_direct(c, random.choice(t)),
+    ]
+
+    set_bcast = [
+        lambda c=i3c_controller: do_setmwl_bcast(c),
+        lambda c=i3c_controller: do_setmrl_bcast(c),
+        lambda c=i3c_controller: do_enec_bcast(c),
+        lambda c=i3c_controller: do_disec_bcast(c),
+    ]
+
+    return get_table + set_directed * 2 + set_bcast * 2

--- a/verification/cocotb/top/lib_i3c_top/test_ccc.py
+++ b/verification/cocotb/top/lib_i3c_top/test_ccc.py
@@ -17,7 +17,10 @@ from cocotb.handle import Force, Release
 from cocotb.triggers import ClockCycles, RisingEdge, Event
 from cocotb.regression import TestFactory
 
-from common import VALID_I3C_ADDRESSES, log_seed
+from common import (
+    VALID_I3C_ADDRESSES, log_seed, build_ccc_stress_table,
+    do_getbcr, do_enec_direct,
+)
 
 TGT_ADR = 0x5A
 
@@ -4017,5 +4020,149 @@ async def test_ccc_entdaa_stop_in_sendnack(dut):
         ccc=CCC.DIRECT.GETBCR, addr=DYNAMIC_ADDR, count=1)
     assert responses[0][0] == True, \
         "Recovery failed after ENTDAA SendNack STOP"
+
+    await tb.teardown()
+
+
+# =============================================================================
+# CCC + CSR Concurrent Stress Test
+# =============================================================================
+
+
+@cocotb.test(timeout_time=3000, timeout_unit="us")
+async def test_ccc_csr_concurrent_stress(dut):
+    """
+    Stress test: concurrent random FW (AXI) and I3C CCC accesses to
+    CCC-affected CSRs.
+
+    FW randomly reads/writes CCC-related CSRs via AXI in the background
+    while I3C performs 50 random supported CCC operations (GET and SET).
+    GET CCCs verify ACK; SET CCCs send random valid data.
+
+    Goal: expose data races, coherency bugs, or FSM hangs under concurrent
+    access from both interfaces.
+    """
+    log = logging.getLogger("test_ccc_csr_concurrent_stress")
+
+    (STATIC_ADDR, VIRT_STATIC_ADDR, DYNAMIC_ADDR, VIRT_DYNAMIC_ADDR) = \
+        random.sample(VALID_I3C_ADDRESSES, 4)
+    i3c_controller, _, tb = await test_setup(
+        dut, STATIC_ADDR, VIRT_STATIC_ADDR,
+        dynamic_addr=DYNAMIC_ADDR, virtual_dynamic_addr=VIRT_DYNAMIC_ADDR)
+    await ClockCycles(tb.clk, 50)
+
+    targets = [DYNAMIC_ADDR, VIRT_DYNAMIC_ADDR]
+
+    # ------------------------------------------------------------------
+    # CCC command table (from common.py)
+    # ------------------------------------------------------------------
+    CCC_TABLE = build_ccc_stress_table(i3c_controller, targets)
+
+    # ------------------------------------------------------------------
+    # FW CSR tables
+    # ------------------------------------------------------------------
+    SM = tb.reg_map.I3C_EC.STDBYCTRLMODE
+    TTI = tb.reg_map.I3C_EC.TTI
+
+    # FW writable CSRs: (addr, mask, safe_max_or_fixed)
+    # Write random value & mask into the field bits.
+    FW_WRITE_CSRS = [
+        # TTI.CONTROL event enable bits (IBI_EN=bit12, CRR_EN=bit11, HJ_EN=bit10)
+        # Write full register with random event bits, keep IBI_RETRY_NUM=0
+        (TTI.CONTROL.base_addr, 0x1C00, None),
+        # STBY_CR_DEVICE_CHAR: BCR_VAR(bits[28:24]), DCR(bits[23:16]), PID_HI(bits[15:1])
+        (SM.STBY_CR_DEVICE_CHAR.base_addr, 0x3FFFFFFE, None),
+        # STBY_CR_DEVICE_PID_LO
+        (SM.STBY_CR_DEVICE_PID_LO.base_addr, 0xFFFFFFFF, None),
+        # STBY_CR_VIRTUAL_DEVICE_CHAR
+        (SM.STBY_CR_VIRTUAL_DEVICE_CHAR.base_addr, 0x3FFFFFFE, None),
+        # STBY_CR_VIRTUAL_DEVICE_PID_LO
+        (SM.STBY_CR_VIRTUAL_DEVICE_PID_LO.base_addr, 0xFFFFFFFF, None),
+        # STBY_CR_CCC_CONFIG_GETCAPS
+        (SM.STBY_CR_CCC_CONFIG_GETCAPS.base_addr, 0x0F07, None),
+        # STBY_CR_CCC_CONFIG_RSTACT_PARAMS: RESET_TIME_PERIPHERAL(bits[15:8]),
+        # RESET_TIME_TARGET(bits[23:16]). Avoid RESET_DYNAMIC_ADDR(bit31).
+        (SM.STBY_CR_CCC_CONFIG_RSTACT_PARAMS.base_addr, 0x00FFFF00, None),
+        # STBY_CR_INTR_STATUS: W1C bits (write 1 to clear)
+        (SM.STBY_CR_INTR_STATUS.base_addr, 0x000FFFFF, None),
+        # TARGET_ERR_CTRL: TE0-TE5 det_en bits
+        (TTI.TARGET_ERR_CTRL.base_addr, 0x3F, None),
+    ]
+
+    # FW readable CSRs (all CCC-affected registers)
+    FW_READ_CSRS = [
+        TTI.CONTROL.base_addr,
+        TTI.STATUS.base_addr,
+        SM.STBY_CR_MWL.base_addr,
+        SM.STBY_CR_MRL.base_addr,
+        SM.STBY_CR_DEVICE_CHAR.base_addr,
+        SM.STBY_CR_DEVICE_PID_LO.base_addr,
+        SM.STBY_CR_VIRTUAL_DEVICE_CHAR.base_addr,
+        SM.STBY_CR_VIRTUAL_DEVICE_PID_LO.base_addr,
+        SM.STBY_CR_CCC_CONFIG_GETCAPS.base_addr,
+        SM.STBY_CR_CCC_CONFIG_RSTACT_PARAMS.base_addr,
+        SM.STBY_CR_DEVICE_ADDR.base_addr,
+        SM.STBY_CR_VIRT_DEVICE_ADDR.base_addr,
+        SM.STBY_CR_INTR_STATUS.base_addr,
+        SM.STBY_CR_STATUS.base_addr,
+        TTI.TARGET_ERR_CTRL.base_addr,
+        TTI.TARGET_ERR_INTR_STATUS.base_addr,
+        TTI.TARGET_ERR_CNT_TE0.base_addr,
+        TTI.TARGET_ERR_CNT_TE1.base_addr,
+        TTI.TARGET_ERR_CNT_TE2.base_addr,
+        TTI.TARGET_ERR_CNT_TE3.base_addr,
+        TTI.TARGET_ERR_CNT_TE4.base_addr,
+        TTI.TARGET_ERR_CNT_TE5.base_addr,
+    ]
+
+    # ------------------------------------------------------------------
+    # FW background task: random AXI reads/writes until stopped
+    # ------------------------------------------------------------------
+    stop_fw = Event()
+    fw_ops = [0]
+
+    async def fw_background():
+        while not stop_fw.is_set():
+            if random.random() < 0.5:
+                # FW write (masked to safe field bits)
+                addr, mask, fixed_val = random.choice(FW_WRITE_CSRS)
+                if fixed_val is not None:
+                    val = fixed_val
+                else:
+                    val = random.randint(0, 0xFFFFFFFF) & mask
+                await tb.write_csr(addr, int2dword(val), 4)
+            else:
+                # FW read
+                addr = random.choice(FW_READ_CSRS)
+                await tb.read_csr(addr, 4)
+            fw_ops[0] += 1
+            delay = random.randint(1, 10)
+            await ClockCycles(tb.clk, delay)
+
+    cocotb.start_soon(fw_background())
+
+    # ------------------------------------------------------------------
+    # I3C foreground: 50 random CCC operations
+    # ------------------------------------------------------------------
+    NUM_CCC_OPS = 50
+    for i in range(NUM_CCC_OPS):
+        handler = random.choice(CCC_TABLE)
+        result = await handler()
+        log.info(f"CCC op {i}: result={result}")
+
+    # ------------------------------------------------------------------
+    # Stop FW background, post-test validation
+    # ------------------------------------------------------------------
+    stop_fw.set()
+    await ClockCycles(tb.clk, 50)
+
+    log.info(f"Done: {NUM_CCC_OPS} CCC ops, {fw_ops[0]} FW ops")
+
+    # Verify target is still functional
+    await do_getbcr(i3c_controller, DYNAMIC_ADDR)
+    await do_getbcr(i3c_controller, VIRT_DYNAMIC_ADDR)
+
+    # Re-enable all events for clean teardown
+    await do_enec_direct(i3c_controller, DYNAMIC_ADDR, pattern=0x0B)
 
     await tb.teardown()

--- a/verification/cocotb/top/lib_i3c_top/test_recovery.py
+++ b/verification/cocotb/top/lib_i3c_top/test_recovery.py
@@ -2604,7 +2604,7 @@ async def test_recovery_flow(dut):
         for data_ptr in range(0, image_size, xfer_size * 4):
 
             # Poll INDIRECT_FIFO_STATUS
-            MAX_FIFO_POLLS = 500
+            MAX_FIFO_POLLS = 2000
             for _poll in range(MAX_FIFO_POLLS):
                 status = dword2int(
                     await tb.read_csr(
@@ -8386,5 +8386,267 @@ async def test_ri_indirect_fifo_overflow_irq(dut):
     # Verify irq_o goes LOW
     assert irq.value == 0, f"irq_o should be LOW after clearing status, got {int(irq.value)}"
     dut._log.info("PASS: irq_o went LOW after clearing status (toggle 0->1->0 verified)")
+
+    await tb.teardown()
+
+
+@cocotb.test()
+async def test_recovery_tx_pec_csr_data_race(dut):
+    """
+    Prosecutor test: PEC coherency under concurrent FW CSR writes.
+
+    Exposes a race in recovery_receiver.sv where csr_data updates live during
+    a TX response. bus_tx_flow captures data early in each byte while the PEC
+    calculator latches tx_data_o (driven from live csr_data) at byte end.
+    A FW write between those two events causes bus data != PEC input.
+
+    Strategy: FW toggles RECOVERY_STATUS every few clocks in the background
+    while the controller performs 100 reads of the same register. Any PEC
+    mismatch proves the race.
+
+    Spec ref: OCP Recovery v1.1 Section 8.4
+    """
+
+    i3c_controller, i3c_target, tb, recovery = await initialize(dut, timeout=2000)
+
+    # Assign dynamic addresses
+    await i3c_controller.i3c_ccc_write(
+        ccc=CCC.DIRECT.SETDASA, directed_data=[(STATIC_ADDR, [DYNAMIC_ADDR << 1])]
+    )
+    await i3c_controller.i3c_ccc_write(
+        ccc=CCC.DIRECT.SETDASA,
+        directed_data=[(VIRT_STATIC_ADDR, [VIRT_DYNAMIC_ADDR << 1])],
+    )
+
+    recovery_status_addr = tb.reg_map.I3C_EC.SECFWRECOVERYIF.RECOVERY_STATUS.base_addr
+
+    # Seed RECOVERY_STATUS with a known value
+    await tb.write_csr(recovery_status_addr, int2dword(0x01), 4)
+    await ClockCycles(tb.clk, 10)
+
+    # Background task: constantly toggle RECOVERY_STATUS between two values
+    stop_writes = Event()
+
+    async def fw_csr_writer():
+        """Toggle RECOVERY_STATUS between 0x01 and 0x0102 every 5 clocks."""
+        toggle = False
+        while not stop_writes.is_set():
+            val = 0x0102 if toggle else 0x01
+            await tb.write_csr(recovery_status_addr, int2dword(val), 4)
+            toggle = not toggle
+            await ClockCycles(tb.clk, 5)
+
+    cocotb.start_soon(fw_csr_writer())
+
+    # Perform up to 25 reads of RECOVERY_STATUS while FW is writing.
+    # Fail immediately on first PEC mismatch.
+    num_reads = 25
+
+    for i in range(num_reads):
+        data, pec_ok = await recovery.command_read(
+            VIRT_DYNAMIC_ADDR, I3cRecoveryInterface.Command.RECOVERY_STATUS
+        )
+
+        assert data is not None, (
+            f"Read {i}: Unexpected NACK on RECOVERY_STATUS read"
+        )
+        assert len(data) == 2, (
+            f"Read {i}: Expected 2 data bytes, got {len(data)}: "
+            f"{[hex(b) for b in data]}"
+        )
+        if not pec_ok:
+            # Compute expected PEC for the bus data we actually received
+            addr_r = (VIRT_DYNAMIC_ADDR << 1) | 1
+            len_bytes = [len(data) & 0xFF, (len(data) >> 8) & 0xFF]
+            expected_pec = int(recovery.pec_calc.checksum(
+                bytes([addr_r] + len_bytes + data)
+            ))
+            # Compute PEC for the alternate toggled value (the likely stale value)
+            alt_val = 0x0102 if data[0] != 0x02 else 0x01
+            alt_data = [alt_val & 0xFF, (alt_val >> 8) & 0xFF]
+            alt_pec = int(recovery.pec_calc.checksum(
+                bytes([addr_r] + len_bytes + alt_data)
+            ))
+            assert False, (
+                f"Read {i}: PEC MISMATCH. "
+                f"Bus data={[hex(b) for b in data]}, "
+                f"expected PEC=0x{expected_pec:02X}, "
+                f"PEC for alternate value {[hex(b) for b in alt_data]}=0x{alt_pec:02X}. "
+                f"DUT likely computed PEC from new csr_data while bus sent old."
+            )
+        dut._log.info(f"Read {i}: OK data={[hex(b) for b in data]}")
+
+    stop_writes.set()
+    await ClockCycles(tb.clk, 20)
+    dut._log.info(f"All {num_reads} reads passed PEC check")
+
+    await tb.teardown()
+
+
+@cocotb.test()
+async def test_recovery_ri_csr_concurrent_stress(dut):
+    """
+    Stress test: concurrent random FW (AXI) and I3C accesses to RI CSRs.
+
+    FW randomly reads/writes RI CSRs via AXI in the background while I3C
+    performs 50 random read/write operations via the recovery protocol.
+    Every I3C read checks PEC, data length, and NACK status.
+
+    Goal: expose data races, coherency bugs, or FSM hangs under concurrent
+    access from both interfaces.
+    """
+
+    i3c_controller, i3c_target, tb, recovery = await initialize(dut, timeout=3000)
+
+    # Assign dynamic addresses
+    await i3c_controller.i3c_ccc_write(
+        ccc=CCC.DIRECT.SETDASA, directed_data=[(STATIC_ADDR, [DYNAMIC_ADDR << 1])]
+    )
+    await i3c_controller.i3c_ccc_write(
+        ccc=CCC.DIRECT.SETDASA,
+        directed_data=[(VIRT_STATIC_ADDR, [VIRT_DYNAMIC_ADDR << 1])],
+    )
+
+    # Put device in recovery mode
+    await tb.write_csr(
+        tb.reg_map.I3C_EC.SECFWRECOVERYIF.DEVICE_STATUS_0.base_addr,
+        int2dword(0x03), 4,
+    )
+    await ClockCycles(tb.clk, 10)
+
+    # -- I3C command table: (command_code, expected_read_bytes, i3c_writable) --
+    I3C_CMDS = [
+        (I3cRecoveryInterface.Command.PROT_CAP,          15, False),
+        (I3cRecoveryInterface.Command.DEVICE_ID,          24, False),
+        (I3cRecoveryInterface.Command.DEVICE_STATUS,       7, False),
+        (I3cRecoveryInterface.Command.DEVICE_RESET,        3, True),
+        (I3cRecoveryInterface.Command.RECOVERY_CTRL,       3, True),
+        (I3cRecoveryInterface.Command.RECOVERY_STATUS,     2, False),
+        (I3cRecoveryInterface.Command.HW_STATUS,           4, False),
+        (I3cRecoveryInterface.Command.INDIRECT_FIFO_CTRL,  6, True),
+        (I3cRecoveryInterface.Command.INDIRECT_FIFO_STATUS, 20, False),
+    ]
+
+    # -- FW CSR table: (addr, safe_write_max) --
+    # safe_write_max constrains random values to avoid bad device states.
+    # DEVICE_STATUS_0 is excluded -- it must stay 0x03 (RecoveryMode) or
+    # recovery-only commands will be NACKed.
+    RI = tb.reg_map.I3C_EC.SECFWRECOVERYIF
+    FW_CSRS = [
+        (RI.DEVICE_STATUS_0.base_addr,      0x03, 0x03),  # always write 0x03
+        (RI.DEVICE_STATUS_1.base_addr,      0xFF, None),
+        (RI.DEVICE_RESET.base_addr,         0x07, None),
+        (RI.RECOVERY_CTRL.base_addr,        0x0F, None),
+        (RI.RECOVERY_STATUS.base_addr,      0x03, None),   # DEV_REC_STATUS <= 3
+        (RI.HW_STATUS.base_addr,            0xFF, None),
+        (RI.INDIRECT_FIFO_CTRL_1.base_addr, 0xFF, None),   # IMAGE_SIZE
+    ]
+
+    # Also include read-only FW CSRs for read traffic
+    FW_READ_CSRS = [
+        RI.PROT_CAP_0.base_addr,
+        RI.PROT_CAP_1.base_addr,
+        RI.PROT_CAP_2.base_addr,
+        RI.PROT_CAP_3.base_addr,
+        RI.DEVICE_ID_0.base_addr,
+        RI.DEVICE_STATUS_0.base_addr,
+        RI.DEVICE_RESET.base_addr,
+        RI.RECOVERY_CTRL.base_addr,
+        RI.RECOVERY_STATUS.base_addr,
+        RI.HW_STATUS.base_addr,
+        RI.INDIRECT_FIFO_CTRL_0.base_addr,
+        RI.INDIRECT_FIFO_CTRL_1.base_addr,
+        RI.INDIRECT_FIFO_STATUS_0.base_addr,
+        RI.INDIRECT_FIFO_STATUS_3.base_addr,
+        RI.INDIRECT_FIFO_STATUS_4.base_addr,
+    ]
+
+    # -----------------------------------------------------------------------
+    # FW background task: random AXI reads/writes until stopped
+    # -----------------------------------------------------------------------
+    stop_fw = Event()
+    fw_ops = 0
+
+    async def fw_background():
+        nonlocal fw_ops
+        while not stop_fw.is_set():
+            if random.random() < 0.5:
+                # FW write
+                addr, safe_max, fixed_val = random.choice(FW_CSRS)
+                val = fixed_val if fixed_val is not None else random.randint(0, safe_max)
+                await tb.write_csr(addr, int2dword(val), 4)
+            else:
+                # FW read
+                addr = random.choice(FW_READ_CSRS)
+                await tb.read_csr(addr, 4)
+            fw_ops += 1
+            delay = random.randint(1, 10)
+            await ClockCycles(tb.clk, delay)
+
+    cocotb.start_soon(fw_background())
+
+    # -----------------------------------------------------------------------
+    # I3C foreground: 50 random read/write operations
+    # -----------------------------------------------------------------------
+    NUM_I3C_OPS = 50
+    i3c_reads = 0
+    i3c_writes = 0
+
+    for i in range(NUM_I3C_OPS):
+        cmd_code, exp_rd_len, writable = random.choice(I3C_CMDS)
+
+        # Decide read vs write: always read if not writable, else 50/50
+        do_write = writable and random.random() < 0.5
+
+        if do_write:
+            # Generate random data of the correct length
+            write_data = [random.randint(0, 0x0F) for _ in range(exp_rd_len)]
+            await recovery.command_write(
+                VIRT_DYNAMIC_ADDR, cmd_code, write_data
+            )
+            i3c_writes += 1
+            dut._log.info(f"I3C op {i}: WRITE cmd={cmd_code} len={exp_rd_len}")
+        else:
+            data, pec_ok = await recovery.command_read(
+                VIRT_DYNAMIC_ADDR, cmd_code
+            )
+            i3c_reads += 1
+
+            assert data is not None, (
+                f"I3C op {i}: Unexpected NACK on cmd={cmd_code}"
+            )
+            assert len(data) == exp_rd_len, (
+                f"I3C op {i}: cmd={cmd_code} expected {exp_rd_len}B, "
+                f"got {len(data)}B: {[hex(b) for b in data]}"
+            )
+            assert pec_ok, (
+                f"I3C op {i}: PEC MISMATCH cmd={cmd_code} "
+                f"data={[hex(b) for b in data]}"
+            )
+            dut._log.info(
+                f"I3C op {i}: READ cmd={cmd_code} len={len(data)} pec=OK"
+            )
+
+    # -----------------------------------------------------------------------
+    # Stop FW background, check results
+    # -----------------------------------------------------------------------
+    stop_fw.set()
+    await ClockCycles(tb.clk, 50)
+
+    dut._log.info(
+        f"Done: {NUM_I3C_OPS} I3C ops ({i3c_reads} reads, {i3c_writes} writes), "
+        f"{fw_ops} FW ops"
+    )
+
+    # Check no protocol errors were flagged
+    status = dword2int(
+        await tb.read_csr(RI.DEVICE_STATUS_0.base_addr, 4)
+    )
+    prot_err = (status >> 8) & 0xFF
+    if prot_err != 0:
+        dut._log.warning(
+            f"DEVICE_STATUS_0.PROT_ERROR=0x{prot_err:02X} (may be from "
+            f"I3C writes to read-only regs -- non-fatal)"
+        )
 
     await tb.teardown()

--- a/verification/testplan/top/target_ccc.hjson
+++ b/verification/testplan/top/target_ccc.hjson
@@ -727,5 +727,19 @@
       tests: ["ccc_stop_during_target_read"]
       tags: ["top"]
     }
+    {
+      name: ccc_csr_concurrent_stress
+      desc:
+        '''
+        Stress test: concurrent random FW (AXI) and I3C CCC accesses to
+        CCC-affected CSRs. FW randomly reads/writes CCC-related CSRs via AXI
+        in the background while I3C performs 50 random supported CCC operations
+        (GET and SET). GET CCCs verify ACK; SET CCCs send random valid data.
+        Goal: expose data races, coherency bugs, or FSM hangs under concurrent
+        access from both interfaces.
+        '''
+      tests: ["ccc_csr_concurrent_stress"]
+      tags: ["top"]
+    }
   ]
 }

--- a/verification/testplan/top/target_recovery.hjson
+++ b/verification/testplan/top/target_recovery.hjson
@@ -714,5 +714,33 @@
       tests: ["recovery_unsupported_cmd_irq"]
       tags: ["top"]
     }
+    {
+      name: recovery_tx_pec_csr_data_race
+      desc:
+        '''
+        PEC coherency under concurrent FW CSR writes. FW toggles
+        RECOVERY_STATUS every few clocks in the background while
+        the controller performs reads of the same register via I3C.
+        Verifies that PEC is always correct despite concurrent AXI
+        writes, proving csr_data snapshot integrity.
+        Spec ref: OCP Recovery v1.1 Section 8.4.
+        '''
+      tests: ["recovery_tx_pec_csr_data_race"]
+      tags: ["top"]
+    }
+    {
+      name: recovery_ri_csr_concurrent_stress
+      desc:
+        '''
+        Stress test: concurrent random FW (AXI) and I3C accesses to
+        recovery interface CSRs. FW randomly reads/writes RI CSRs via
+        AXI in the background while I3C performs random read/write
+        operations via the recovery protocol. Every I3C read checks
+        PEC, data length, and NACK status. Exposes data races,
+        coherency bugs, or FSM hangs under concurrent access.
+        '''
+      tests: ["recovery_ri_csr_concurrent_stress"]
+      tags: ["top"]
+    }
   ]
 }


### PR DESCRIPTION
Add load_csr_data delayed pulse to capture csr_data one cycle after csr_sel updates, ensuring csr_data_next reads from the settled selector. Previously csr_data tracked live register values every clock, allowing FW writes to change tx_data_o between bus capture and PEC computation. The original gating attempt (load_csr_sel || inc_csr_sel) had a pipeline mismatch: both csr_sel and csr_data loaded on the same edge, but csr_data_next is case(csr_sel) which still held the old value.

Also simplify common.mk FSDB generation by removing VERDI_PLI toggle in favor of VCS native FSDB support, and add cocotb test test_recovery_tx_pec_csr_data_race that exercises the race by toggling RECOVERY_STATUS from FW during concurrent I3C reads.