### PR TITLE
[cocotb] refactor block makefiles and update wave conversion

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -79,7 +79,7 @@ pytest-html==4.1.1
 pytest-md==0.2.0
 pytest-metadata==3.1.1
 pytest-timeout==2.3.1
-python-constraint==1.4.0
+python-constraint==1.3.1
 python-dateutil==2.9.0.post0
 python-markdown-math==0.8
 pyuvm==2.9.1

--- a/setenv.sh
+++ b/setenv.sh
@@ -9,3 +9,6 @@ fi
 # Useful for running tests directly in verification/block
 export I3C_ROOT_DIR=$( cd "$( dirname "$script_path" )" &> /dev/null && pwd )
 export CALIPTRA_ROOT=${I3C_ROOT_DIR}/third_party/caliptra-rtl
+
+export CALIPTRA_PRIM_MODULE_PREFIX=caliptra_prim_generic
+export CALIPTRA_PRIM_ROOT=${CALIPTRA_ROOT}/src/caliptra_prim_generic

--- a/verification/cocotb/block/axi_adapter/Makefile
+++ b/verification/cocotb/block/axi_adapter/Makefile
@@ -15,10 +15,9 @@ override PLUSARGS := $(strip +FrontendBusInterface=AXI $(PLUSARGS))
 MODULE      ?= $(subst $(space),$(comma),$(subst .py,,$(TEST_FILES)))
 TOPLEVEL     = axi_adapter_wrapper
 
-VERILOG_SOURCES  = \
-    $(CALIPTRA_ROOT)/src/caliptra_prim/rtl/caliptra_prim_pkg.sv \
-    $(CALIPTRA_ROOT)/src/caliptra_prim/rtl/caliptra_prim_util_pkg.sv \
-    $(CALIPTRA_ROOT)/src/caliptra_prim/rtl/caliptra_prim_count_pkg.sv \
+include $(TEST_DIR)/../../caliptra_common.mk
+
+VERILOG_SOURCES += \
     $(SRC_DIR)/i3c_pkg.sv \
     $(CALIPTRA_ROOT)/src/axi/rtl/axi_pkg.sv \
     $(CALIPTRA_ROOT)/src/axi/rtl/axi_if.sv \

--- a/verification/cocotb/block/axi_adapter_id_filter/Makefile
+++ b/verification/cocotb/block/axi_adapter_id_filter/Makefile
@@ -17,10 +17,9 @@ TOPLEVEL = axi_adapter_wrapper
 CFG_NAME = axi
 CFG_FILE = $(TEST_DIR)/i3c_cfg.yaml
 
-VERILOG_SOURCES  = \
-    $(CALIPTRA_ROOT)/src/caliptra_prim/rtl/caliptra_prim_pkg.sv \
-    $(CALIPTRA_ROOT)/src/caliptra_prim/rtl/caliptra_prim_util_pkg.sv \
-    $(CALIPTRA_ROOT)/src/caliptra_prim/rtl/caliptra_prim_count_pkg.sv \
+include $(TEST_DIR)/../../caliptra_common.mk
+
+VERILOG_SOURCES  += \
     $(SRC_DIR)/i3c_pkg.sv \
     $(CALIPTRA_ROOT)/src/axi/rtl/axi_pkg.sv \
     $(CALIPTRA_ROOT)/src/axi/rtl/axi_if.sv \

--- a/verification/cocotb/block/hci_queues_ahb/Makefile
+++ b/verification/cocotb/block/hci_queues_ahb/Makefile
@@ -26,6 +26,7 @@ VERILOG_SOURCES += \
     $(SRC_DIR)/csr/I3CCSR.sv \
     $(SRC_DIR)/hci/ahb_if.sv \
     $(SRC_DIR)/hci/dxt.sv \
+    $(SRC_DIR)/interrupt.sv \
     $(SRC_DIR)/hci/queues/write_queue.sv \
     $(SRC_DIR)/hci/queues/read_queue.sv \
     $(SRC_DIR)/hci/tti.sv \

--- a/verification/cocotb/block/hci_queues_axi/Makefile
+++ b/verification/cocotb/block/hci_queues_axi/Makefile
@@ -32,6 +32,7 @@ VERILOG_SOURCES += \
     $(SRC_DIR)/libs/axi_sub/i3c_axi_sub_wr.sv \
     $(SRC_DIR)/hci/axi_adapter.sv \
     $(SRC_DIR)/hci/dxt.sv \
+    $(SRC_DIR)/interrupt.sv \
     $(SRC_DIR)/hci/queues/write_queue.sv \
     $(SRC_DIR)/hci/queues/read_queue.sv \
     $(SRC_DIR)/hci/queues.sv \

--- a/verification/cocotb/block/i2c_standby_controller/Makefile
+++ b/verification/cocotb/block/i2c_standby_controller/Makefile
@@ -14,13 +14,11 @@ TOPLEVEL     = controller_standby_i2c_harness
 
 EXTRA_ARGS += -Wno-WIDTHTRUNC -Wno-WIDTHEXPAND -Wno-PINCONNECTEMPTY -Wno-UNUSEDPARAM
 
-VERILOG_SOURCES  = \
-    $(CALIPTRA_ROOT)/src/caliptra_prim/rtl/caliptra_prim_assert.sv \
+include $(TEST_DIR)/../../caliptra_common.mk
+
+VERILOG_SOURCES  += \
     $(CALIPTRA_ROOT)/src/caliptra_prim/rtl/caliptra_prim_assert_dummy_macros.svh \
-    ${CALIPTRA_ROOT}/src/caliptra_prim/rtl/caliptra_prim_pkg.sv \
-    ${CALIPTRA_ROOT}/src/caliptra_prim/rtl/caliptra_prim_util_pkg.sv \
     ${CALIPTRA_ROOT}/src/caliptra_prim/rtl/caliptra_prim_count_pkg.sv \
-    $(CALIPTRA_ROOT)/src/caliptra_prim/rtl/caliptra_prim_util_pkg.sv \
     $(CALIPTRA_ROOT)/src/libs/rtl/ahb_defines_pkg.sv \
     $(CALIPTRA_ROOT)/src/axi/rtl/axi_pkg.sv \
     $(CALIPTRA_ROOT)/src/axi/rtl/axi_if.sv \
@@ -44,6 +42,7 @@ VERILOG_SOURCES  = \
     ${SRC_DIR}/hci/ahb_if.sv \
     ${SRC_DIR}/hci/axi_adapter.sv \
     ${SRC_DIR}/hci/dxt.sv \
+    ${SRC_DIR}/interrupt.sv \
     ${SRC_DIR}/hci/tti.sv \
     ${SRC_DIR}/hci/queues.sv \
     ${SRC_DIR}/hci/hci.sv \

--- a/verification/cocotb/caliptra_common.mk
+++ b/verification/cocotb/caliptra_common.mk
@@ -4,6 +4,10 @@ CALIPTRA_SOURCES = \
 	$(CALIPTRA_ROOT)/src/caliptra_prim/rtl/caliptra_prim_assert.sv \
 	$(CALIPTRA_ROOT)/src/caliptra_prim_generic/rtl/caliptra_prim_generic_flop.sv \
 	$(CALIPTRA_ROOT)/src/caliptra_prim/rtl/caliptra_prim_flop.sv \
-	$(CALIPTRA_ROOT)/src/caliptra_prim/rtl/caliptra_prim_flop_2sync.sv
+	$(CALIPTRA_ROOT)/src/caliptra_prim/rtl/caliptra_prim_flop_2sync.sv \
+	$(CALIPTRA_ROOT)/src/caliptra_prim/rtl/caliptra_prim_fifo_sync.sv \
+	$(CALIPTRA_ROOT)/src/caliptra_prim/rtl/caliptra_prim_count_pkg.sv \
+	$(CALIPTRA_ROOT)/src/caliptra_prim/rtl/caliptra_prim_count.sv \
+	$(CALIPTRA_ROOT)/src/caliptra_prim/rtl/caliptra_prim_fifo_sync_cnt.sv
 
 VERILOG_SOURCES += $(CALIPTRA_SOURCES)

--- a/verification/cocotb/common.mk
+++ b/verification/cocotb/common.mk
@@ -2,7 +2,7 @@
 
 TOPLEVEL_LANG    = verilog
 SIM             ?= verilator
-WAVES           ?= 1
+WAVES           ?= 0
 TRACK_FSM       ?= 1
 
 # Paths
@@ -102,11 +102,25 @@ include $(shell cocotb-config --makefiles)/Makefile.sim
 
 ifeq ($(SIM), vcs)
 
-.PHONY: convert-vpd2vcd
-convert-vpd2vcd: $(COCOTB_RESULTS_FILE)
-	vpd2vcd -full64 dump.vpd dump.vcd +splitpacked
+.PHONY: convert-waves2vcd
+convert-waves2vcd: $(COCOTB_RESULTS_FILE)
+	@if [ -f dump.vpd ]; then \
+		echo "Converting dump.vpd to dump.vcd..."; \
+		vpd2vcd -full64 dump.vpd dump.vcd +splitpacked; \
+	elif [ -f dump.fsdb ]; then \
+		if command -v fsdb2vcd >/dev/null 2>&1; then \
+			echo "Converting dump.fsdb to dump.vcd..."; \
+			fsdb2vcd dump.fsdb -o dump.vcd; \
+		else \
+			echo "Warning: dump.fsdb found but fsdb2vcd not in PATH. Skipping VCD conversion."; \
+		fi \
+	fi
 
-all: sim convert-vpd2vcd
+ifeq ($(WAVES), 1)
+all: sim convert-waves2vcd
+else
+all: sim
+endif
 
 endif
 


### PR DESCRIPTION
Refactored verification/cocotb/block/*/Makefile to use shared caliptra_common.mk instead of hardcoding CALIPTRA_ROOT sources.

Added interrupt.sv to block Makefiles where it was missing.

Added caliptra_prim_fifo_sync.sv and caliptra_prim_fifo_sync_cnt.sv to caliptra_common.mk.

Changed the default for WAVES to 0 in common.mk.

Updated convert-waves2vcd in common.mk to handle both .vpd (VCS) and .fsdb (Verdi) formats, and check for fsdb2vcd in the PATH before attempting conversion.