### PR TITLE
Fix ahb test issues

### DIFF
--- a/verification/cocotb/block/ctrl_i3c_bus_monitor/test_i3c_bus_monitor.py
+++ b/verification/cocotb/block/ctrl_i3c_bus_monitor/test_i3c_bus_monitor.py
@@ -20,6 +20,9 @@ async def setup(dut):
     dut.t_r_i.value = 0x02
     dut.t_f_i.value = 0x02
     dut.is_in_hdr_mode_i.value = 0
+    dut.is_in_hdr_err_mode_i.value = 0
+    dut.hdr_timeout_en_i.value = 0
+    dut.t_hdr_timeout_i.value = 0
     await ClockCycles(dut.clk_i, 10)
 
 

--- a/verification/cocotb/block/hci_queues_ahb/Makefile
+++ b/verification/cocotb/block/hci_queues_ahb/Makefile
@@ -20,7 +20,6 @@ include $(TEST_DIR)/../../caliptra_common.mk
 
 VERILOG_SOURCES += \
     $(CALIPTRA_ROOT)/src/libs/rtl/ahb_defines_pkg.sv \
-    $(CALIPTRA_ROOT)/src/caliptra_prim/rtl/caliptra_prim_count_pkg.sv \
     $(SRC_DIR)/i3c_pkg.sv \
     $(SRC_DIR)/csr/I3CCSR_pkg.sv \
     $(SRC_DIR)/csr/I3CCSR.sv \

--- a/verification/cocotb/common/bus2csr.py
+++ b/verification/cocotb/common/bus2csr.py
@@ -8,6 +8,7 @@ from random import choice, randint
 from typing import List, Tuple
 
 # AHB
+from cocotb_AHB.AHB_common.AHB_types import IRESP
 from cocotb_AHB.AHB_common.InterconnectInterface import InterconnectWrapper
 from cocotb_AHB.drivers.DutSubordinate import DUTSubordinate
 from cocotb_AHB.drivers.SimSimpleManager import SimSimpleManager
@@ -21,7 +22,7 @@ from reg_map import reg_map
 import cocotb
 from cocotb.clock import Clock
 from cocotb.handle import SimHandleBase
-from cocotb.triggers import ClockCycles, Lock, RisingEdge, Timer, with_timeout
+from cocotb.triggers import ClockCycles, Lock, ReadOnly, ReadWrite, RisingEdge, Timer, with_timeout
 
 
 # Helpers
@@ -161,12 +162,43 @@ class AHBTestInterface(FrontBusTestInterface):
     async def read_csr(
         self, addr: int, size: int = 4, arid=None, timeout: int = 1, units: str = "us"
     ) -> List[int]:
-        """Send a read request & await the response for 'timeout' in 'units'."""
+        """Send a read request & await the response for 'timeout' in 'units'.
+
+        A background coroutine samples DUT response signals (hrdata) at the
+        ReadOnly phase every cycle.  This guarantees settled combinational
+        values regardless of the simulator's VPI scheduling region, working
+        around VCS builds where a ReadWrite-phase read may return stale data.
+        """
         if arid:
             self.dut._log.debug(f"AHB doesn't support user id, ignoring arid={arid}")
         async with self._bus_lock:
+            captured_hrdata = [0]
+
+            async def _readonly_sampler():
+                """Continuously sample hrdata at ReadOnly when hreadyout is asserted."""
+                while True:
+                    await ReadOnly()
+                    try:
+                        if int(self.dut.hreadyout.value) == 1:
+                            captured_hrdata[0] = int(self.dut.hrdata.value)
+                    except ValueError:
+                        pass  # X/Z values during reset
+                    await RisingEdge(self.clk)
+
+            sampler = await cocotb.start(_readonly_sampler())
             self.AHBManager.read(addr, size)
-            await with_timeout(self.AHBManager.transfer_done(), timeout, units)
+            try:
+                await with_timeout(self.AHBManager.transfer_done(), timeout, units)
+            finally:
+                sampler.kill()
+
+            # Patch framework responses with ReadOnly-sampled data, then use
+            # the framework's own byte-extraction logic (get_rsp) to return
+            # the correctly-ordered byte list.
+            for i, rsp in enumerate(self.AHBManager.responses):
+                self.AHBManager.responses[i] = IRESP(
+                    hRData=captured_hrdata[0], hResp=rsp.hResp, hExOkay=rsp.hExOkay
+                )
             read = self.AHBManager.get_rsp(addr, self.data_byte_width)
         return read
 


### PR DESCRIPTION
1. Remove caliptra_prim_count_pkg include file from hci_queues_ahb/axi block makefiles
2. Fix csr read data mismatches by sampling data in the read-only phase of vcs sim
3. Add new ports of i3c_bus_monitor to setup() and initialize them to avoid x-prop