### PR TITLE
fixing VCS sampling issue for AHB config

### DIFF
--- a/verification/cocotb/block/ahb_if/ahb_if_wrapper.sv
+++ b/verification/cocotb/block/ahb_if/ahb_if_wrapper.sv
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // This wrapper module provides compliance to cocotb-AHB
 // AHB signal naming convention
+
+`include "ahb_slv_sif.sv"
+
 module ahb_if_wrapper
   import I3CCSR_pkg::I3CCSR_DATA_WIDTH;
   import I3CCSR_pkg::I3CCSR_MIN_ADDR_WIDTH;
@@ -47,7 +50,7 @@ module ahb_if_wrapper
       .AhbDataWidth(AhbDataWidth),
       .AhbAddrWidth(AhbAddrWidth)
   ) i3c_ahb_if (
-      .hclk_i(hclk),
+      .hclk_i(~hclk),
       .hreset_n_i(hreset_n),
       .haddr_i(haddr),
       .hburst_i(hburst),
@@ -83,7 +86,7 @@ module ahb_if_wrapper
 
   // Connect to I3C CSRs to test SW access
   I3CCSR i3c_csr (
-      .clk(hclk),
+      .clk(~hclk),
       .rst(~hreset_n),
 
       .s_cpuif_req(s_cpuif_req),

--- a/verification/cocotb/top/lib_i3c_top/i3c_test_wrapper.sv
+++ b/verification/cocotb/top/lib_i3c_top/i3c_test_wrapper.sv
@@ -115,7 +115,7 @@ logic clk_i;
 logic rst_ni;
 
 `ifdef I3C_USE_AHB
-assign clk_i = hclk;
+assign clk_i = ~hclk;
 assign rst_ni = hreset_n;
 `elsif I3C_USE_AXI
 assign clk_i = aclk;

--- a/verification/cocotb/top/lib_i3c_top/test_ibi_multi_queue.py
+++ b/verification/cocotb/top/lib_i3c_top/test_ibi_multi_queue.py
@@ -567,7 +567,7 @@ async def test_ibi_multi_queue_flush_large_payload(dut):
         # Now force it to max to hit `data_cnt_q[7:2] == '1`
         desc_ibi.data_cnt_q.value = Force(252)
         desc_ibi.data_len.value = Force(255)
-        await ClockCycles(tb.clk, 2)
+        await ClockCycles(tb.clk, 10)
 
         # Release
         desc_ibi.data_cnt_q.value = Release()

--- a/verification/cocotb/top/lib_i3c_top/test_ibi_multi_queue.py
+++ b/verification/cocotb/top/lib_i3c_top/test_ibi_multi_queue.py
@@ -567,7 +567,7 @@ async def test_ibi_multi_queue_flush_large_payload(dut):
         # Now force it to max to hit `data_cnt_q[7:2] == '1`
         desc_ibi.data_cnt_q.value = Force(252)
         desc_ibi.data_len.value = Force(255)
-        await ClockCycles(tb.clk, 1)
+        await ClockCycles(tb.clk, 2)
 
         # Release
         desc_ibi.data_cnt_q.value = Release()


### PR DESCRIPTION
All testcase of i3c_ahb with verilator passing.
 
This will fix testcases with VCS.
Design and TB has inverted clock which has helped to resolve race condition