### PR TITLE
Pin uv version

### DIFF
--- a/.ci.yml
+++ b/.ci.yml
@@ -1,4 +1,0 @@
-include:
-  - project: chipsalliance-ci-scripts
-    file: i3c-core.yaml
-    ref: main

--- a/.github/workflows/tests-and-docs.yml
+++ b/.github/workflows/tests-and-docs.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Install Python dependencies
         run: |
-          python -m pip install uv
+          python -m pip install "uv==0.11.33"
           uv sync
 
       - name: Generate timing docs
@@ -661,7 +661,7 @@ jobs:
 
       - name: Setup Python environment (uv)
         run: |
-          python3 -m pip install uv
+          python3 -m pip install "uv==0.11.33"
           uv sync
           uv pip install -r doc/requirements.txt
 

--- a/activate.sh
+++ b/activate.sh
@@ -24,7 +24,7 @@ pyenv virtualenv ${PYTHON_VERSION} ${VENV_NAME} || true
 pyenv shell ${VENV_NAME}
 python --version
 pip install --upgrade pip
-python -m pip install uv
+python -m pip install "uv==0.11.33"
 pyenv rehash
 uv sync
 . .venv/bin/activate


### PR DESCRIPTION
uv 0.12.0 and newer break the current CI setup. Pin uv to the latest known working version.
