### PR TITLE
Rewrite `csr_cfg_t` type parameter passing

### DIFF
--- a/.github/workflows/tests-and-docs.yml
+++ b/.github/workflows/tests-and-docs.yml
@@ -34,7 +34,7 @@ permissions:
 
 env:
   DEBIAN_FRONTEND: "noninteractive"
-  VERILATOR_VERSION: "v5.050"
+  VERILATOR_VERSION: "f149dd304c8ed3cdd1bfa34b6f31fca664440420"  # v5.051-devel
   WAVES: "0"
 
 jobs:
@@ -278,8 +278,9 @@ jobs:
       - name: Build Verilator (if not cached)
         if: steps.cache-verilator.outputs.cache-hit != 'true'
         run: |
-          git clone https://github.com/verilator/verilator -b ${{ env.VERILATOR_VERSION }}
+          git clone https://github.com/verilator/verilator
           cd verilator
+          git checkout ${{ env.VERILATOR_VERSION }}
           autoconf
           ./configure --prefix=$HOME/verilator-install
           make -j$(nproc)
@@ -366,8 +367,9 @@ jobs:
       - name: Build Verilator (if not cached)
         if: steps.cache-verilator.outputs.cache-hit != 'true'
         run: |
-          git clone https://github.com/verilator/verilator -b ${{ env.VERILATOR_VERSION }}
+          git clone https://github.com/verilator/verilator
           cd verilator
+          git checkout ${{ env.VERILATOR_VERSION }}
           autoconf
           ./configure --prefix=$HOME/verilator-install
           make -j$(nproc)
@@ -454,8 +456,9 @@ jobs:
       - name: Build Verilator (if not cached)
         if: steps.cache-verilator.outputs.cache-hit != 'true'
         run: |
-          git clone https://github.com/verilator/verilator -b ${{ env.VERILATOR_VERSION }}
+          git clone https://github.com/verilator/verilator
           cd verilator
+          git checkout ${{ env.VERILATOR_VERSION }}
           autoconf
           ./configure --prefix=$HOME/verilator-install
           make -j$(nproc)
@@ -547,8 +550,9 @@ jobs:
       - name: Build Verilator (if not cached)
         if: steps.cache-verilator.outputs.cache-hit != 'true'
         run: |
-          git clone https://github.com/verilator/verilator -b ${{ env.VERILATOR_VERSION }}
+          git clone https://github.com/verilator/verilator
           cd verilator
+          git checkout ${{ env.VERILATOR_VERSION }}
           autoconf
           ./configure --prefix=$HOME/verilator-install
           make -j$(nproc)
@@ -630,8 +634,9 @@ jobs:
       - name: Build Verilator (if not cached)
         if: steps.cache-verilator.outputs.cache-hit != 'true'
         run: |
-          git clone https://github.com/verilator/verilator -b ${{ env.VERILATOR_VERSION }}
+          git clone https://github.com/verilator/verilator
           cd verilator
+          git checkout ${{ env.VERILATOR_VERSION }}
           autoconf
           ./configure --prefix=$HOME/verilator-install
           make -j$(nproc)
@@ -718,8 +723,9 @@ jobs:
       - name: Build Verilator (if not cached)
         if: steps.cache-verilator.outputs.cache-hit != 'true'
         run: |
-          git clone https://github.com/verilator/verilator -b ${{ env.VERILATOR_VERSION }}
+          git clone https://github.com/verilator/verilator
           cd verilator
+          git checkout ${{ env.VERILATOR_VERSION }}
           autoconf
           ./configure --prefix=$HOME/verilator-install
           make -j$(nproc)

--- a/src/csr/cfg_extractor.svh
+++ b/src/csr/cfg_extractor.svh
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+
+`ifndef I3C_CSR_CFG_EXTRACTOR_DEF
+`define I3C_CSR_CFG_EXTRACTOR_DEF
+class csr_cfg_extractor #(
+    type T
+);
+  typedef T::hwif_out_t hwif_out_t;
+  typedef T::hwif_in_t hwif_in_t;
+  typedef T::base_out_t base_out_t;
+  typedef T::base_in_t base_in_t;
+  typedef T::pio_out_t pio_out_t;
+  typedef T::pio_in_t pio_in_t;
+  typedef T::ec_out_t ec_out_t;
+  typedef T::ec_in_t ec_in_t;
+  typedef T::secfwrecoveryif_out_t secfwrecoveryif_out_t;
+  typedef T::secfwrecoveryif_in_t secfwrecoveryif_in_t;
+  typedef T::stdby_out_t stdby_out_t;
+  typedef T::stdby_in_t stdby_in_t;
+  typedef T::socmgmt_out_t socmgmt_out_t;
+  typedef T::socmgmt_in_t socmgmt_in_t;
+  typedef T::ctrlcfg_out_t ctrlcfg_out_t;
+  typedef T::ctrlcfg_in_t ctrlcfg_in_t;
+  typedef T::tti_in_t tti_in_t;
+  typedef T::tti_out_t tti_out_t;
+  typedef T::dat_out_t dat_out_t;
+  typedef T::dat_in_t dat_in_t;
+  typedef T::dct_out_t dct_out_t;
+  typedef T::dct_in_t dct_in_t;
+endclass
+`endif  // I3C_CSR_CFG_EXTRACTOR_DEF

--- a/src/ctrl/configuration.sv
+++ b/src/ctrl/configuration.sv
@@ -10,12 +10,14 @@
 module configuration #(
     parameter bit ControllerEn = 1'b0,
     parameter bit TargetEn = 1'b1,
-    parameter type csr_cfg_t = i3c_pkg::target_csr_t
+    parameter type csr_cfg_t = i3c_pkg::target_csr_t,
+
+    parameter type hwif_out_t = i3c_pkg::csr_cfg_extractor#(csr_cfg_t)::hwif_out_t
 ) (
     input logic clk_i,
     input logic rst_ni,
 
-    input csr_cfg_t::hwif_out_t hwif_out_i,
+    input hwif_out_t hwif_out_i,
 
     output logic phy_en_o,
     output logic [1:0] phy_mux_select_o,

--- a/src/ctrl/controller.sv
+++ b/src/ctrl/controller.sv
@@ -12,6 +12,9 @@ module controller
     parameter bit ControllerEn = 0,
     parameter bit TargetEn = 1,
     parameter type csr_cfg_t = target_csr_t,
+    parameter type hwif_out_t = csr_cfg_extractor#(csr_cfg_t)::hwif_out_t,
+    parameter type secfwrecoveryif_out_t = csr_cfg_extractor#(csr_cfg_t)::secfwrecoveryif_out_t,
+
     parameter int unsigned DatAw = i3c_pkg::DatAw,
     parameter int unsigned DctAw = i3c_pkg::DctAw,
 
@@ -219,8 +222,8 @@ module controller
     output logic ctrl_irq_o,
 
     // Controller configuration
-    input csr_cfg_t::hwif_out_t hwif_out_i,
-    input csr_cfg_t::secfwrecoveryif_out_t hwif_rec_i,
+    input hwif_out_t hwif_out_i,
+    input secfwrecoveryif_out_t hwif_rec_i,
 
     // Status update signals
     output ibi_status_e ibi_status_o,

--- a/src/hci/csri.sv
+++ b/src/hci/csri.sv
@@ -4,6 +4,23 @@ module csri
     parameter bit ControllerEn = 0,
     parameter bit TargetEn = 1,
     parameter type csr_cfg_t = target_csr_t,
+
+    parameter type hwif_out_t = csr_cfg_extractor#(csr_cfg_t)::hwif_out_t,
+    parameter type hwif_in_t = csr_cfg_extractor#(csr_cfg_t)::hwif_in_t,
+    parameter type base_out_t = csr_cfg_extractor#(csr_cfg_t)::base_out_t,
+    parameter type base_in_t = csr_cfg_extractor#(csr_cfg_t)::base_in_t,
+    parameter type pio_out_t = csr_cfg_extractor#(csr_cfg_t)::pio_out_t,
+    parameter type pio_in_t = csr_cfg_extractor#(csr_cfg_t)::pio_in_t,
+    parameter type secfwrecoveryif_out_t = csr_cfg_extractor#(csr_cfg_t)::secfwrecoveryif_out_t,
+    parameter type secfwrecoveryif_in_t = csr_cfg_extractor#(csr_cfg_t)::secfwrecoveryif_in_t,
+    parameter type socmgmt_out_t = csr_cfg_extractor#(csr_cfg_t)::socmgmt_out_t,
+    parameter type socmgmt_in_t = csr_cfg_extractor#(csr_cfg_t)::socmgmt_in_t,
+    parameter type tti_in_t = csr_cfg_extractor#(csr_cfg_t)::tti_in_t,
+    parameter type tti_out_t = csr_cfg_extractor#(csr_cfg_t)::tti_out_t,
+    parameter type dat_out_t = csr_cfg_extractor#(csr_cfg_t)::dat_out_t,
+    parameter type dat_in_t = csr_cfg_extractor#(csr_cfg_t)::dat_in_t,
+    parameter type dct_out_t = csr_cfg_extractor#(csr_cfg_t)::dct_out_t,
+    parameter type dct_in_t = csr_cfg_extractor#(csr_cfg_t)::dct_in_t,
     parameter int unsigned CsrDataWidth = 32,
     parameter int unsigned CsrAddrWidth = 12
 ) (
@@ -11,34 +28,34 @@ module csri
     input rst_ni, // active low reset
 
     // Target Transaction Interface CSRs
-    input  csr_cfg_t::tti_in_t  hwif_tti_i,
-    output csr_cfg_t::tti_out_t hwif_tti_o,
+    input  tti_in_t  hwif_tti_i,
+    output tti_out_t hwif_tti_o,
 
     // Recovery interface CSRs
-    input  csr_cfg_t::secfwrecoveryif_in_t  hwif_rec_i,
-    output csr_cfg_t::secfwrecoveryif_out_t hwif_rec_o,
+    input  secfwrecoveryif_in_t  hwif_rec_i,
+    output secfwrecoveryif_out_t hwif_rec_o,
 
     // SoC Management CSR Interface
-    input  csr_cfg_t::socmgmt_in_t  hwif_socmgmt_i,
-    output csr_cfg_t::socmgmt_out_t hwif_socmgmt_o,
+    input  socmgmt_in_t  hwif_socmgmt_i,
+    output socmgmt_out_t hwif_socmgmt_o,
 
     // PIO CONTROL CSR interface
-    input  csr_cfg_t::pio_in_t  hwif_pio_control_i,
-    output csr_cfg_t::pio_out_t hwif_pio_control_o,
+    input  pio_in_t  hwif_pio_control_i,
+    output pio_out_t hwif_pio_control_o,
 
     // I3C BASE CSR interface
-    input  csr_cfg_t::base_in_t  hwif_base_i,
-    output csr_cfg_t::base_out_t hwif_base_o,
+    input  base_in_t  hwif_base_i,
+    output base_out_t hwif_base_o,
 
     // DAT CSR interface
-    input  csr_cfg_t::dat_in_t  dat_i,
-    output csr_cfg_t::dat_out_t dat_o,
+    input  dat_in_t  dat_i,
+    output dat_out_t dat_o,
 
     // DCT CSR interface
-    input  csr_cfg_t::dct_in_t  dct_i,
-    output csr_cfg_t::dct_out_t dct_o,
+    input  dct_in_t  dct_i,
+    output dct_out_t dct_o,
 
-    output csr_cfg_t::hwif_out_t hwif_out_o,
+    output hwif_out_t hwif_out_o,
 
     // I3C SW CSR access interface
     input  logic                    s_cpuif_req,
@@ -77,7 +94,7 @@ module csri
     input logic rst_action_valid_i
 );
 
-  csr_cfg_t::hwif_in_t hwif_in;
+  hwif_in_t hwif_in;
 
   // Propagate reset to CSRs
   assign hwif_in.rst_ni = rst_ni;

--- a/src/hci/dxt.sv
+++ b/src/hci/dxt.sv
@@ -7,6 +7,11 @@ module dxt
   import i3c_pkg::*;
 #(
     parameter type csr_cfg_t = target_csr_t,
+
+    parameter type dat_out_t = csr_cfg_extractor#(csr_cfg_t)::dat_out_t,
+    parameter type dat_in_t = csr_cfg_extractor#(csr_cfg_t)::dat_in_t,
+    parameter type dct_out_t = csr_cfg_extractor#(csr_cfg_t)::dct_out_t,
+    parameter type dct_in_t = csr_cfg_extractor#(csr_cfg_t)::dct_in_t,
     parameter int unsigned DatAw = 7,
     parameter int unsigned DctAw = 7
 ) (
@@ -26,12 +31,12 @@ module dxt
     output logic [    127:0] dct_rdata_hw_o,
 
     // DAT CSR interface
-    input  csr_cfg_t::dat_out_t csr_dat_hwif_i,
-    output csr_cfg_t::dat_in_t  csr_dat_hwif_o,
+    input  dat_out_t csr_dat_hwif_i,
+    output dat_in_t  csr_dat_hwif_o,
 
     // DCT CSR interface
-    input  csr_cfg_t::dct_out_t csr_dct_hwif_i,
-    output csr_cfg_t::dct_in_t  csr_dct_hwif_o,
+    input  dct_out_t csr_dct_hwif_i,
+    output dct_in_t  csr_dct_hwif_o,
 
     // DAT memory export interface
     input  dat_mem_src_t  dat_mem_src_i,

--- a/src/hci/hci.sv
+++ b/src/hci/hci.sv
@@ -4,6 +4,15 @@ module hci
   import i3c_pkg::*;
 #(
     parameter type csr_cfg_t = target_csr_t,
+
+    parameter type base_out_t = csr_cfg_extractor#(csr_cfg_t)::base_out_t,
+    parameter type base_in_t = csr_cfg_extractor#(csr_cfg_t)::base_in_t,
+    parameter type pio_out_t = csr_cfg_extractor#(csr_cfg_t)::pio_out_t,
+    parameter type pio_in_t = csr_cfg_extractor#(csr_cfg_t)::pio_in_t,
+    parameter type dat_out_t = csr_cfg_extractor#(csr_cfg_t)::dat_out_t,
+    parameter type dat_in_t = csr_cfg_extractor#(csr_cfg_t)::dat_in_t,
+    parameter type dct_out_t = csr_cfg_extractor#(csr_cfg_t)::dct_out_t,
+    parameter type dct_in_t = csr_cfg_extractor#(csr_cfg_t)::dct_in_t,
     parameter int unsigned DatAw = 7,
     parameter int unsigned DctAw = 7,
 
@@ -112,20 +121,20 @@ module hci
     input logic [HciIbiDataWidth-1:0] hci_ibi_wdata_i,
 
     // PIO CONTROL CSR interface
-    input  csr_cfg_t::pio_out_t hwif_pio_control_i,
-    output csr_cfg_t::pio_in_t  hwif_pio_control_o,
+    input  pio_out_t hwif_pio_control_i,
+    output pio_in_t  hwif_pio_control_o,
 
     // I3C BASE CSR interface
-    input  csr_cfg_t::base_out_t hwif_base_i,
-    output csr_cfg_t::base_in_t  hwif_base_o,
+    input  base_out_t hwif_base_i,
+    output base_in_t  hwif_base_o,
 
     // DAT CSR interface
-    input  csr_cfg_t::dat_out_t dat_i,
-    output csr_cfg_t::dat_in_t  dat_o,
+    input  dat_out_t dat_i,
+    output dat_in_t  dat_o,
 
     // DCT CSR interface
-    input  csr_cfg_t::dct_out_t dct_i,
-    output csr_cfg_t::dct_in_t  dct_o,
+    input  dct_out_t dct_i,
+    output dct_in_t  dct_o,
 
     // Error Interface from flow_active
     input i3c_irq_t ctrl_int_stat_i

--- a/src/hci/tti.sv
+++ b/src/hci/tti.sv
@@ -5,6 +5,9 @@ module tti
   import i3c_pkg::*;
 #(
     parameter type csr_cfg_t = target_csr_t,
+
+    parameter type tti_in_t = csr_cfg_extractor#(csr_cfg_t)::tti_in_t,
+    parameter type tti_out_t = csr_cfg_extractor#(csr_cfg_t)::tti_out_t,
     parameter int unsigned CsrDataWidth = 32,
 
     parameter int unsigned RxDescDataWidth = 32,
@@ -23,8 +26,8 @@ module tti
     input rst_ni, // active low reset
 
     // I3C CSR access interface
-    input  csr_cfg_t::tti_out_t hwif_tti_i,
-    output csr_cfg_t::tti_in_t  hwif_tti_o,
+    input  tti_out_t hwif_tti_i,
+    output tti_in_t  hwif_tti_o,
 
     // RX descriptors queue
     output logic                       rx_desc_queue_req_o,

--- a/src/i3c.sv
+++ b/src/i3c.sv
@@ -25,6 +25,22 @@ module i3c
     parameter bit ControllerEn = 0,
     parameter bit TargetEn = 1,
     parameter type csr_cfg_t = target_csr_t,
+
+    parameter type hwif_out_t = csr_cfg_extractor#(csr_cfg_t)::hwif_out_t,
+    parameter type base_out_t = csr_cfg_extractor#(csr_cfg_t)::base_out_t,
+    parameter type base_in_t = csr_cfg_extractor#(csr_cfg_t)::base_in_t,
+    parameter type pio_out_t = csr_cfg_extractor#(csr_cfg_t)::pio_out_t,
+    parameter type pio_in_t = csr_cfg_extractor#(csr_cfg_t)::pio_in_t,
+    parameter type secfwrecoveryif_out_t = csr_cfg_extractor#(csr_cfg_t)::secfwrecoveryif_out_t,
+    parameter type secfwrecoveryif_in_t = csr_cfg_extractor#(csr_cfg_t)::secfwrecoveryif_in_t,
+    parameter type socmgmt_out_t = csr_cfg_extractor#(csr_cfg_t)::socmgmt_out_t,
+    parameter type socmgmt_in_t = csr_cfg_extractor#(csr_cfg_t)::socmgmt_in_t,
+    parameter type tti_in_t = csr_cfg_extractor#(csr_cfg_t)::tti_in_t,
+    parameter type tti_out_t = csr_cfg_extractor#(csr_cfg_t)::tti_out_t,
+    parameter type dat_out_t = csr_cfg_extractor#(csr_cfg_t)::dat_out_t,
+    parameter type dat_in_t = csr_cfg_extractor#(csr_cfg_t)::dat_in_t,
+    parameter type dct_out_t = csr_cfg_extractor#(csr_cfg_t)::dct_out_t,
+    parameter type dct_in_t = csr_cfg_extractor#(csr_cfg_t)::dct_in_t,
 `ifdef I3C_USE_AHB
     parameter int unsigned AhbDataWidth = `AHB_DATA_WIDTH,
     parameter int unsigned AhbAddrWidth = `AHB_ADDR_WIDTH,
@@ -675,14 +691,14 @@ module i3c
 
   // CSR Interface
   // Target Transaction CSR Interface
-  csr_cfg_t::tti_out_t hwif_tti_out;
-  csr_cfg_t::tti_in_t hwif_tti_inp;
+  tti_out_t hwif_tti_out;
+  tti_in_t hwif_tti_inp;
 
-  csr_cfg_t::socmgmt_out_t hwif_socmgmt_out;
-  csr_cfg_t::socmgmt_in_t hwif_socmgmt_inp;
+  socmgmt_out_t hwif_socmgmt_out;
+  socmgmt_in_t hwif_socmgmt_inp;
 
-  csr_cfg_t::secfwrecoveryif_out_t hwif_rec_out;
-  csr_cfg_t::secfwrecoveryif_in_t hwif_rec_inp;
+  secfwrecoveryif_out_t hwif_rec_out;
+  secfwrecoveryif_in_t hwif_rec_inp;
 
   // tieoff unused signals
   if (TargetEn == 1'b0) begin : gen_target_tieoff_unused_csr_interfaces
@@ -695,20 +711,20 @@ module i3c
   end
 
   // PIO CONTROL CSR interface
-  csr_cfg_t::pio_in_t   hwif_pio_control_in;
-  csr_cfg_t::pio_out_t  hwif_pio_control_out;
+  pio_in_t   hwif_pio_control_in;
+  pio_out_t  hwif_pio_control_out;
 
   // I3C BASE CSR interface
-  csr_cfg_t::base_in_t  hwif_base_in;
-  csr_cfg_t::base_out_t hwif_base_out;
+  base_in_t  hwif_base_in;
+  base_out_t hwif_base_out;
 
   // DAT CSR interface
-  csr_cfg_t::dat_in_t   dat_in;
-  csr_cfg_t::dat_out_t  dat_out;
+  dat_in_t   dat_in;
+  dat_out_t  dat_out;
 
   // DCT CSR interface
-  csr_cfg_t::dct_in_t   dct_in;
-  csr_cfg_t::dct_out_t  dct_out;
+  dct_in_t   dct_in;
+  dct_out_t  dct_out;
 
   // tieoff unused signals
   if (ControllerEn == 1'b0) begin : gen_controller_tieoff_unused_csr_interfaces
@@ -725,7 +741,7 @@ module i3c
     assign dct_in              = '0;
   end
 
-  csr_cfg_t::hwif_out_t hwif_out;
+  hwif_out_t hwif_out;
 
   logic bypass_i3c_core;
 `ifndef DISABLE_LOOPBACK

--- a/src/i3c_pkg.sv
+++ b/src/i3c_pkg.sv
@@ -4,6 +4,7 @@ package i3c_pkg;
   `include "i3c_defines.svh"
   `include "ccc.svh"
   `include "csr/csr_types.svh"
+  `include "csr/cfg_extractor.svh"
   `define I3C_RSVD_ADDR 7'h7E
   `define I3C_RSVD_BYTE 8'hFC
 

--- a/src/recovery/recovery_handler.sv
+++ b/src/recovery/recovery_handler.sv
@@ -26,6 +26,11 @@ module recovery_handler
 #(
 
     parameter type csr_cfg_t = target_csr_t,
+
+    parameter type secfwrecoveryif_out_t = csr_cfg_extractor#(csr_cfg_t)::secfwrecoveryif_out_t,
+    parameter type secfwrecoveryif_in_t = csr_cfg_extractor#(csr_cfg_t)::secfwrecoveryif_in_t,
+    parameter type socmgmt_out_t = csr_cfg_extractor#(csr_cfg_t)::socmgmt_out_t,
+    parameter type socmgmt_in_t = csr_cfg_extractor#(csr_cfg_t)::socmgmt_in_t,
     parameter int unsigned TtiRxDescDataWidth = 32,
     parameter int unsigned TtiRxDescThldWidth = 8,
     parameter int unsigned TtiRxDescFifoDepth = 64,
@@ -190,12 +195,12 @@ module recovery_handler
 
     // ....................................................
     // SoC Managment CSR interface
-    input  csr_cfg_t::socmgmt_out_t hwif_socmgmt_i,
-    output csr_cfg_t::socmgmt_in_t  hwif_socmgmt_o,
+    input  socmgmt_out_t hwif_socmgmt_i,
+    output socmgmt_in_t  hwif_socmgmt_o,
 
     // Recovery CSR interface
-    input  csr_cfg_t::secfwrecoveryif_out_t hwif_rec_i,
-    output csr_cfg_t::secfwrecoveryif_in_t  hwif_rec_o,
+    input  secfwrecoveryif_out_t hwif_rec_i,
+    output secfwrecoveryif_in_t  hwif_rec_o,
 
     input logic bypass_i3c_core_i,
 

--- a/src/recovery/recovery_receiver.sv
+++ b/src/recovery/recovery_receiver.sv
@@ -95,12 +95,17 @@ module recovery_receiver
   import target_I3CCSR_pkg::*;
   import controller_and_target_I3CCSR_pkg::*;
 #(
-    parameter type         csr_cfg_t          = target_csr_t,
+    parameter type csr_cfg_t = target_csr_t,
+
+    parameter type secfwrecoveryif_out_t = csr_cfg_extractor#(csr_cfg_t)::secfwrecoveryif_out_t,
+    parameter type secfwrecoveryif_in_t = csr_cfg_extractor#(csr_cfg_t)::secfwrecoveryif_in_t,
+    parameter type socmgmt_out_t = csr_cfg_extractor#(csr_cfg_t)::socmgmt_out_t,
+    parameter type socmgmt_in_t = csr_cfg_extractor#(csr_cfg_t)::socmgmt_in_t,
     parameter int unsigned TtiRxDescDataWidth = 32,
     parameter int unsigned TtiTxDescDataWidth = 32,
     parameter int unsigned TtiRxDataDataWidth = 32,
-    parameter int unsigned CsrDataWidth       = 32,
-    parameter int unsigned IndirectFifoDepth  = 64
+    parameter int unsigned CsrDataWidth = 32,
+    parameter int unsigned IndirectFifoDepth = 64
 ) (
     //--------------------------------------------------------------------------
     // Clock and Reset
@@ -235,14 +240,14 @@ module recovery_receiver
     //--------------------------------------------------------------------------
     // Recovery CSR Interface
     //--------------------------------------------------------------------------
-    input  csr_cfg_t::secfwrecoveryif_out_t hwif_rec_i,
-    output csr_cfg_t::secfwrecoveryif_in_t  hwif_rec_o,
+    input  secfwrecoveryif_out_t hwif_rec_i,
+    output secfwrecoveryif_in_t  hwif_rec_o,
 
     //--------------------------------------------------------------------------
     // SoC Management CSR Interface (Bypass Mode)
     //--------------------------------------------------------------------------
-    input  csr_cfg_t::socmgmt_out_t hwif_socmgmt_i,
-    output csr_cfg_t::socmgmt_in_t  hwif_socmgmt_o
+    input  socmgmt_out_t hwif_socmgmt_i,
+    output socmgmt_in_t  hwif_socmgmt_o
 );
 
   //============================================================================

--- a/verification/cocotb/block/lib_adapter/axi_adapter_wrapper.sv
+++ b/verification/cocotb/block/lib_adapter/axi_adapter_wrapper.sv
@@ -9,6 +9,8 @@ module axi_adapter_wrapper
     parameter type csr_cfg_t = target_csr_t,
     parameter bit ControllerEn = 0,  // enables host controller configuration
     parameter bit TargetEn = 1,  // enables target configuration
+    parameter type hwif_out_t = csr_cfg_extractor#(csr_cfg_t)::hwif_out_t,
+    parameter type hwif_in_t = csr_cfg_extractor#(csr_cfg_t)::hwif_in_t,
     parameter int unsigned CsrAddrWidth = (ControllerEn && TargetEn) ? controller_and_target_I3CCSR_pkg::controller_and_target_I3CCSR_MIN_ADDR_WIDTH :
                                (ControllerEn)             ? controller_I3CCSR_pkg::controller_I3CCSR_MIN_ADDR_WIDTH :
                                                             target_I3CCSR_pkg::target_I3CCSR_MIN_ADDR_WIDTH,
@@ -166,8 +168,8 @@ module axi_adapter_wrapper
       .s_cpuif_wr_err(s_cpuif_wr_err)
   );
 
-  csr_cfg_t::hwif_in_t  hwif_in;
-  csr_cfg_t::hwif_out_t hwif_out;
+  hwif_in_t  hwif_in;
+  hwif_out_t hwif_out;
 
   assign hwif_in.rst_ni = areset_n;
 

--- a/verification/cocotb/top/lib_i3c_top/common.py
+++ b/verification/cocotb/top/lib_i3c_top/common.py
@@ -32,6 +32,40 @@ def log_seed(dut):
     seed = cocotb.plusargs.get("seed", None)
     dut._log.info(f"Random seed: {seed or 'unknown (set via RANDOM_SEED plusarg)'}")
 
+def resolve_path(parent, path_string):
+    """
+    Dynamically walks a hierarchical path string, automatically healing 
+    VCS squashed generate-block scopes.
+    
+    Usage:
+        sig = resolve_path(dut.xi3c_wrapper, "gen_target_config.i3c.xcontroller")
+    """
+    parts = path_string.split('.')
+    current = parent
+    
+    i = 0
+    while i < len(parts):
+        part = parts[i]
+        try:
+            # 1. Try standard IEEE traversal (Verilator / Normal hierarchy)
+            current = getattr(current, part)
+            i += 1
+        except AttributeError:
+            # 2. VCS Flattening Detected!
+            # If getattr fails, VCS likely squashed this scope with the next one.
+            if i + 1 < len(parts):
+                next_part = parts[i + 1]
+                # Try to fetch the combined "squashed" name using cocotb's native _id()
+                current = current._id(f"{part}.{next_part}", extended=False)
+                i += 2  # We successfully consumed two parts of the path, skip ahead!
+            else:
+                # We hit a genuine missing signal at the end of the path
+                raise AttributeError(
+                    f"VCS/VPI Error: Cannot resolve '{part}' inside '{current._name}'"
+                )
+                
+    return current
+
 
 # =============================================================================
 # CCC helpers

--- a/verification/cocotb/top/lib_i3c_top/te_error_monitor.py
+++ b/verification/cocotb/top/lib_i3c_top/te_error_monitor.py
@@ -14,6 +14,7 @@ on violation to fail the test.
 
 import cocotb
 from cocotb.triggers import RisingEdge, FallingEdge, ClockCycles, First
+from common import resolve_path
 
 
 # FSM state constants (from i3c_target_fsm.sv primary_state_e)
@@ -48,7 +49,7 @@ class TeErrorEventMonitor:
         self._expected_types = set()  # Error types the test expects to see
         self._unexpected_errors = []  # Accumulated unexpected errors for check()
 
-        i3c = getattr(dut, "xi3c_wrapper").gen_target_config.i3c
+        i3c = resolve_path(dut.xi3c_wrapper, "gen_target_config.i3c")
         self._te_signals = [
             i3c.te0_err,
             i3c.te1_err,
@@ -59,9 +60,7 @@ class TeErrorEventMonitor:
             i3c.framing_err,
         ]
 
-        fsm = (getattr(dut, "xi3c_wrapper").gen_target_config.i3c
-               .xcontroller.gen_target_controller_standby.xcontroller_standby
-               .xcontroller_standby_i3c.xi3c_target_fsm)
+        fsm = resolve_path(dut.xi3c_wrapper, "gen_target_config.i3c.xcontroller.gen_target_controller_standby.xcontroller_standby.xcontroller_standby_i3c.xi3c_target_fsm")
         self._state_d = fsm.state_d
 
         # Resolve clock
@@ -151,12 +150,11 @@ class HdrRecoveryMonitor:
         self.entry_count = 0
         self.recovery_count = 0
 
-        ccc = (getattr(dut, "xi3c_wrapper").gen_target_config.i3c
-               .xcontroller.gen_target_controller_standby.xcontroller_standby
-               .xcontroller_standby_i3c.xccc)
+        ccc = resolve_path(dut.xi3c_wrapper, "gen_target_config.i3c.xcontroller.gen_target_controller_standby.xcontroller_standby.xcontroller_standby_i3c.xccc")
+
         self._in_hdr_err_mode = ccc.in_hdr_err_mode_o
 
-        tti = getattr(dut, "xi3c_wrapper").gen_target_config.i3c.gen_target_tti.xtti
+        tti = resolve_path(dut.xi3c_wrapper, "gen_target_config.i3c.gen_target_tti.xtti")
         self._rx_data_write = tti.rx_data_queue_write_r
         self._rx_desc_write = tti.rx_desc_queue_write_r
 
@@ -247,12 +245,12 @@ class PostTe2DataIntegrityMonitor:
         self.violation_count = 0
         self._violations = []
 
-        i3c = getattr(dut, "xi3c_wrapper").gen_target_config.i3c
+        i3c = resolve_path(dut.xi3c_wrapper, "gen_target_config.i3c")
         self._te2_err = i3c.te2_err
-        self._rx_data_write = i3c.gen_target_tti.xtti.rx_data_queue_write_r
+        rx_data_write = resolve_path(i3c, "gen_target_tti.xtti.rx_data_queue_write_r")
+        self._rx_data_write = rx_data_write
 
-        fsm = (i3c.xcontroller.gen_target_controller_standby.xcontroller_standby
-               .xcontroller_standby_i3c.xi3c_target_fsm)
+        fsm = resolve_path(dut.xi3c_wrapper, "gen_target_config.i3c.xcontroller.gen_target_controller_standby.xcontroller_standby.xcontroller_standby_i3c.xi3c_target_fsm")
         self._state_d = fsm.state_d
 
         if hasattr(dut, 'aclk'):

--- a/verification/cocotb/top/lib_i3c_top/test_bus_timers.py
+++ b/verification/cocotb/top/lib_i3c_top/test_bus_timers.py
@@ -20,7 +20,7 @@ from interface import I3CTopTestInterface
 import cocotb
 from cocotb.triggers import ClockCycles, FallingEdge, ReadOnly, RisingEdge, Timer
 
-from common import VALID_I3C_ADDRESSES, log_seed
+from common import VALID_I3C_ADDRESSES, log_seed, resolve_path
 
 # =============================================================================
 # Constants
@@ -336,7 +336,7 @@ async def test_bus_edge_detectors(dut):
 
     i3c_controller, tb = await test_setup(dut)
 
-    SIG_STATE = dut.xi3c_wrapper.gen_target_config.i3c.xcontroller.xbus_monitor
+    SIG_STATE = resolve_path(dut.xi3c_wrapper, "gen_target_config.i3c.xcontroller.xbus_monitor")
     await i3c_controller.take_bus_control()
 
     async def check_edge_occurred(edge, timing):

--- a/verification/cocotb/top/lib_i3c_top/test_ccc.py
+++ b/verification/cocotb/top/lib_i3c_top/test_ccc.py
@@ -19,7 +19,7 @@ from cocotb.regression import TestFactory
 
 from common import (
     VALID_I3C_ADDRESSES, log_seed, build_ccc_stress_table,
-    do_getbcr, do_enec_direct,
+    do_getbcr, do_enec_direct, resolve_path
 )
 
 TGT_ADR = 0x5A
@@ -925,7 +925,7 @@ async def test_ccc_setmwl_direct(dut):
             ccc=command_set, directed_data=[(tgt_addr, [mwl_msb, mwl_lsb])])
 
         # Check CSR value
-        sig = dut.xi3c_wrapper.gen_target_config.i3c.xcontroller.xconfiguration.get_mwl_o.value
+        sig = resolve_path(dut.xi3c_wrapper, "gen_target_config.i3c.xcontroller.xconfiguration.get_mwl_o.value")
         assert mwl_val == int(sig), \
             f"SETMWL CSR mismatch: expected 0x{mwl_val:04X}, got 0x{int(sig):04X}"
 
@@ -974,7 +974,7 @@ async def test_ccc_setmrl_direct(dut):
             ccc=command_set, directed_data=[(tgt_addr, [mrl_msb, mrl_lsb, ibil])])
 
         # Check CSR value
-        sig = dut.xi3c_wrapper.gen_target_config.i3c.xcontroller.xconfiguration.get_mrl_o.value
+        sig = resolve_path(dut.xi3c_wrapper, "gen_target_config.i3c.xcontroller.xconfiguration.get_mrl_o.value")
         assert mrl_val == int(sig), \
             f"SETMRL CSR mismatch: expected 0x{mrl_val:04X}, got 0x{int(sig):04X}"
 
@@ -1029,7 +1029,7 @@ async def test_ccc_setmwl_bcast(dut):
     await i3c_controller.i3c_ccc_write(ccc=command, broadcast_data=[mwl_msb, mwl_lsb])
 
     # Check if MWL got written
-    sig = dut.xi3c_wrapper.gen_target_config.i3c.xcontroller.xconfiguration.get_mwl_o.value
+    sig = resolve_path(dut.xi3c_wrapper, "gen_target_config.i3c.xcontroller.xconfiguration.get_mwl_o.value")
     mwl = (mwl_msb << 8) | mwl_lsb
     assert mwl == int(sig), f"SETMWL register mismatch: CCC sent={mwl} RTL={int(sig)}"
 
@@ -1061,7 +1061,7 @@ async def test_ccc_setmrl_bcast(dut):
     await i3c_controller.i3c_ccc_write(ccc=command, broadcast_data=[mrl_msb, mrl_lsb, ibil])
 
     # Check if MRL got written
-    sig = dut.xi3c_wrapper.gen_target_config.i3c.xcontroller.xconfiguration.get_mrl_o.value
+    sig = resolve_path(dut.xi3c_wrapper, "gen_target_config.i3c.xcontroller.xconfiguration.get_mrl_o.value")
     mrl = (mrl_msb << 8) | mrl_lsb
     assert mrl == int(sig), f"SETMRL register mismatch: CCC sent={mrl} RTL={int(sig)}"
 
@@ -1124,7 +1124,7 @@ async def test_ccc_rstact(dut, type, rstact):
     )
 
     # Check if reset action got stored correctly in the logic after RSTACT CCC
-    sig = dut.xi3c_wrapper.gen_target_config.i3c.xcontroller.gen_target_controller_standby.xcontroller_standby.xcontroller_standby_i3c.rst_action_o
+    sig = resolve_path(dut.xi3c_wrapper, "gen_target_config.i3c.xcontroller.gen_target_controller_standby.xcontroller_standby.xcontroller_standby_i3c.rst_action_o")
     assert rst_action == int(sig), f"Expected rst_action_o={rst_action}, got {int(sig)}"
 
     # Check if RST_ACTION field in STBY_CR_CCC_CONFIG_RSTACT_PARAMS CSR was updated
@@ -1325,7 +1325,7 @@ async def test_ccc_direct_multiple_wr(dut):
         result = False
 
     # Check if MWL got written
-    sig = dut.xi3c_wrapper.gen_target_config.i3c.xcontroller.xconfiguration.get_mwl_o.value
+    sig = resolve_path(dut.xi3c_wrapper, "gen_target_config.i3c.xcontroller.xconfiguration.get_mwl_o.value")
     mwl = 0xA2
     if mwl != int(sig):
         dut._log.error(f"Written MWL mismatch ({mwl} vs. {int(sig)})")
@@ -1488,7 +1488,7 @@ async def test_ccc_rstact_read_action(dut):
         dynamic_addr=DYNAMIC_ADDR, virtual_dynamic_addr=VIRT_DYNAMIC_ADDR)
     await ClockCycles(tb.clk, 50)
 
-    rst_action_sig = dut.xi3c_wrapper.gen_target_config.i3c.xcontroller.gen_target_controller_standby.xcontroller_standby.xcontroller_standby_i3c.rst_action_o
+    rst_action_sig = resolve_path(dut.xi3c_wrapper, "gen_target_config.i3c.xcontroller.gen_target_controller_standby.xcontroller_standby.xcontroller_standby_i3c.rst_action_o")
 
     for tgt_addr in [DYNAMIC_ADDR, VIRT_DYNAMIC_ADDR]:
         # Arm peripheral reset (DB=0x01), check internal signal
@@ -1619,7 +1619,7 @@ async def test_ccc_rstact_arm_clear_on_start(dut):
     await i3c_controller.i3c_ccc_write(
         ccc=CCC.BCAST.RSTACT, defining_byte=0x02, stop=True)
 
-    rst_action_sig = dut.xi3c_wrapper.gen_target_config.i3c.xcontroller.gen_target_controller_standby.xcontroller_standby.xcontroller_standby_i3c.rst_action_o
+    rst_action_sig = resolve_path(dut.xi3c_wrapper, "gen_target_config.i3c.xcontroller.gen_target_controller_standby.xcontroller_standby.xcontroller_standby_i3c.rst_action_o")
 
     # Issue a private read (START + addr/R + data + STOP) — START clears arm
     responses = await i3c_controller.i3c_ccc_read(
@@ -1772,8 +1772,8 @@ async def test_ccc_chain_bcast(dut):
         broadcast_data=[(mrl_val >> 8) & 0xFF, mrl_val & 0xFF, ibil_val])
 
     # Verify both took effect
-    sig_mwl = int(dut.xi3c_wrapper.gen_target_config.i3c.xcontroller.xconfiguration.get_mwl_o.value)
-    sig_mrl = int(dut.xi3c_wrapper.gen_target_config.i3c.xcontroller.xconfiguration.get_mrl_o.value)
+    sig_mwl = int(resolve_path(dut.xi3c_wrapper, "gen_target_config.i3c.xcontroller.xconfiguration.get_mwl_o.value"))
+    sig_mrl = int(resolve_path(dut.xi3c_wrapper, "gen_target_config.i3c.xcontroller.xconfiguration.get_mrl_o.value"))
     assert sig_mwl == mwl_val, f"Chained SETMWL: expected 0x{mwl_val:04X}, got 0x{sig_mwl:04X}"
     assert sig_mrl == mrl_val, f"Chained SETMRL: expected 0x{mrl_val:04X}, got 0x{sig_mrl:04X}"
 
@@ -1802,7 +1802,7 @@ async def test_ccc_chain_direct(dut):
             (VIRT_DYNAMIC_ADDR, [(mwl_val >> 8) & 0xFF, mwl_val & 0xFF]),
         ])
 
-    sig_mwl = int(dut.xi3c_wrapper.gen_target_config.i3c.xcontroller.xconfiguration.get_mwl_o.value)
+    sig_mwl = int(resolve_path(dut.xi3c_wrapper, "gen_target_config.i3c.xcontroller.xconfiguration.get_mwl_o.value"))
     assert sig_mwl == mwl_val, f"Chained direct SETMWL: expected 0x{mwl_val:04X}, got 0x{sig_mwl:04X}"
 
     await tb.teardown()
@@ -2108,7 +2108,7 @@ async def test_ccc_abort_bcast_stop(dut):
         ccc=CCC.DIRECT.SETMWL,
         directed_data=[(DYNAMIC_ADDR, [(mwl_val >> 8) & 0xFF, mwl_val & 0xFF])])
 
-    sig_mwl = int(dut.xi3c_wrapper.gen_target_config.i3c.xcontroller.xconfiguration.get_mwl_o.value)
+    sig_mwl = int(resolve_path(dut.xi3c_wrapper, "gen_target_config.i3c.xcontroller.xconfiguration.get_mwl_o.value"))
     assert sig_mwl == mwl_val, \
         f"Recovery SETMWL: expected 0x{mwl_val:04X}, got 0x{sig_mwl:04X}"
 
@@ -2806,7 +2806,7 @@ async def test_ccc_entdaa_arb_lost(dut):
     await ClockCycles(tb.clk, 50)
 
     # Get handle to the arbitration_lost_i signal inside ccc_entdaa
-    entdaa_path = dut.xi3c_wrapper.gen_target_config.i3c.xcontroller.gen_target_controller_standby.xcontroller_standby.xcontroller_standby_i3c.xccc.xccc_entdaa
+    entdaa_path = resolve_path(dut.xi3c_wrapper, "gen_target_config.i3c.xcontroller.gen_target_controller_standby.xcontroller_standby.xcontroller_standby_i3c.xccc.xccc_entdaa")
     arb_lost_sig = entdaa_path.arbitration_lost_i
     state_sig = entdaa_path.state_q
 
@@ -2906,7 +2906,7 @@ async def test_ccc_getstatus_sr_abort_clears_protocol_err(dut):
         dynamic_addr=DYNAMIC_ADDR, virtual_dynamic_addr=VIRT_DYNAMIC_ADDR)
     await ClockCycles(tb.clk, 50)
 
-    err_o_sig = dut.xi3c_wrapper.gen_target_config.i3c.xcontroller.gen_target_controller_standby.xcontroller_standby.err_o
+    err_o_sig = resolve_path(dut.xi3c_wrapper, "gen_target_config.i3c.xcontroller.gen_target_controller_standby.xcontroller_standby.err_o")
 
     # Step 1: Trigger a Protocol Error via TE2 (bad T-bit on CCC defining byte)
     log.info("Step 1: Triggering TE2 error to set Protocol Error")
@@ -2985,10 +2985,9 @@ async def test_ccc_getstatus_sr_abort_done_assert(dut):
         dut, STATIC_ADDR, VIRT_STATIC_ADDR,
         dynamic_addr=DYNAMIC_ADDR, virtual_dynamic_addr=VIRT_DYNAMIC_ADDR)
 
-    err_o_sig = dut.xi3c_wrapper.gen_target_config.i3c.xcontroller.gen_target_controller_standby.xcontroller_standby.err_o
+    err_o_sig = resolve_path(dut.xi3c_wrapper, "gen_target_config.i3c.xcontroller.gen_target_controller_standby.xcontroller_standby.err_o")
     get_status_done_sig = (
-        dut.xi3c_wrapper.gen_target_config.i3c.xcontroller.gen_target_controller_standby.xcontroller_standby
-        .xcontroller_standby_i3c.xccc.get_status_done_o
+        resolve_path(dut.xi3c_wrapper, "gen_target_config.i3c.xcontroller.gen_target_controller_standby.xcontroller_standby.xcontroller_standby_i3c.xccc.get_status_done_o") 
     )
 
     # Step 1: Trigger a Protocol Error via TE2 to set err_o
@@ -3081,7 +3080,7 @@ async def test_ccc_setmwl_sr_abort_during_data(dut):
         dynamic_addr=DYNAMIC_ADDR, virtual_dynamic_addr=VIRT_DYNAMIC_ADDR)
     await ClockCycles(tb.clk, 50)
 
-    mwl_sig = dut.xi3c_wrapper.gen_target_config.i3c.xcontroller.xconfiguration.get_mwl_o
+    mwl_sig = resolve_path(dut.xi3c_wrapper, "gen_target_config.i3c.xcontroller.xconfiguration.get_mwl_o")
 
     # Step 1: Set MWL to a known value via normal SETMWL
     known_mwl = 0x0100
@@ -3185,8 +3184,8 @@ async def test_ccc_getstatus_abort_then_chain_setmwl(dut):
         dynamic_addr=DYNAMIC_ADDR, virtual_dynamic_addr=VIRT_DYNAMIC_ADDR)
     await ClockCycles(tb.clk, 50)
 
-    err_o_sig = dut.xi3c_wrapper.gen_target_config.i3c.xcontroller.gen_target_controller_standby.xcontroller_standby.err_o
-    mwl_sig = dut.xi3c_wrapper.gen_target_config.i3c.xcontroller.xconfiguration.get_mwl_o
+    err_o_sig = resolve_path(dut.xi3c_wrapper, "gen_target_config.i3c.xcontroller.gen_target_controller_standby.xcontroller_standby.err_o")
+    mwl_sig = resolve_path(dut.xi3c_wrapper, "gen_target_config.i3c.xcontroller.xconfiguration.get_mwl_o")
 
     # Step 1: Trigger a Protocol Error via TE2
     log.info("Step 1: Triggering TE2 error to set Protocol Error")

--- a/verification/cocotb/top/lib_i3c_top/test_empty_queue_read.py
+++ b/verification/cocotb/top/lib_i3c_top/test_empty_queue_read.py
@@ -23,7 +23,7 @@ from interface import I3CTopTestInterface
 import cocotb
 from cocotb.result import SimTimeoutError
 from cocotb.triggers import ClockCycles, Combine, RisingEdge, Timer
-from common import timeout_task, log_seed
+from common import timeout_task, log_seed, resolve_path
 
 STATIC_ADDR = 0x5A
 VIRT_STATIC_ADDR = 0x5B
@@ -335,7 +335,7 @@ async def test_concurrent_recovery_xfer_and_rx_desc_read(dut):
 
     async def axi_read_rx_desc():
         # Wait for recovery_pending to actually assert (I3C address phase must complete first)
-        recovery_pending = dut.xi3c_wrapper.gen_target_config.i3c.gen_target_recovery_handler.xrecovery_handler.recovery_pending
+        recovery_pending = resolve_path(dut.xi3c_wrapper, "gen_target_config.i3c.gen_target_recovery_handler.xrecovery_handler.recovery_pending")
         dut._log.info("[AXI] Waiting for recovery_pending to assert...")
         await RisingEdge(recovery_pending)
         dut._log.info("[AXI] recovery_pending is HIGH -- issuing AXI read")
@@ -374,7 +374,7 @@ async def test_concurrent_recovery_xfer_and_tx_desc_write(dut):
         dut._log.info(f"[I3C] PROT_CAP read done, pec_ok={pec_ok}")
 
     async def axi_write_tx_desc():
-        recovery_pending = dut.xi3c_wrapper.gen_target_config.i3c.gen_target_recovery_handler.xrecovery_handler.recovery_pending
+        recovery_pending = resolve_path(dut.xi3c_wrapper, "gen_target_config.i3c.gen_target_recovery_handler.xrecovery_handler.recovery_pending")
         dut._log.info("[AXI] Waiting for recovery_pending to assert...")
         await RisingEdge(recovery_pending)
         dut._log.info("[AXI] recovery_pending is HIGH -- issuing AXI write")
@@ -414,7 +414,7 @@ async def test_concurrent_recovery_xfer_and_all_queue_access(dut):
         dut._log.info(f"[I3C] PROT_CAP read done, pec_ok={pec_ok}")
 
     async def axi_queue_access():
-        recovery_pending = dut.xi3c_wrapper.gen_target_config.i3c.gen_target_recovery_handler.xrecovery_handler.recovery_pending
+        recovery_pending = resolve_path(dut.xi3c_wrapper, "gen_target_config.i3c.gen_target_recovery_handler.xrecovery_handler.recovery_pending")
         dut._log.info("[AXI] Waiting for recovery_pending to assert...")
         await RisingEdge(recovery_pending)
         dut._log.info("[AXI] recovery_pending is HIGH -- issuing AXI accesses")
@@ -474,8 +474,8 @@ async def test_recovery_write_rx_data_observation(dut):
     async def rx_data_monitor():
         """Watch tti_rx_depth; on >=1 DWORD, read RX_DATA_PORT via AXI."""
         nonlocal monitor_done
-        rx_depth = dut.xi3c_wrapper.gen_target_config.i3c.tti_rx_depth
-        rx_empty = dut.xi3c_wrapper.gen_target_config.i3c.tti_rx_empty
+        rx_depth = resolve_path(dut.xi3c_wrapper, "gen_target_config.i3c.tti_rx_depth")
+        rx_empty = resolve_path(dut.xi3c_wrapper, "gen_target_config.i3c.tti_rx_empty")
 
         dut._log.info("[MONITOR] Starting RX data queue monitor")
         dut._log.info(f"[MONITOR] Initial tti_rx_depth={int(rx_depth)}, tti_rx_empty={int(rx_empty)}")

--- a/verification/cocotb/top/lib_i3c_top/test_i3c_target.py
+++ b/verification/cocotb/top/lib_i3c_top/test_i3c_target.py
@@ -14,7 +14,7 @@ from utils import format_ibi_data, get_interrupt_status
 import cocotb
 from cocotb.triggers import ClockCycles, FallingEdge, RisingEdge, Timer
 from cocotbext_i3c.common import I3cState
-from common import VALID_I3C_ADDRESSES, timeout_task, log_seed
+from common import VALID_I3C_ADDRESSES, timeout_task, log_seed, resolve_path
 
 TARGET_ADDRESS = 0x5A
 
@@ -107,7 +107,7 @@ async def rx_agent(tb, data_transfers):
     for i, tx_length in enumerate(data_transfers):
 
         # Wait for the interrupt signal to go high
-        irq = tb.dut.xi3c_wrapper.gen_target_config.i3c.irq_o
+        irq = resolve_path(tb.dut.xi3c_wrapper, "gen_target_config.i3c.irq_o")
         if irq.value == 0:
             await RisingEdge(irq)
 
@@ -129,7 +129,7 @@ async def rx_agent(tb, data_transfers):
         assert err_stat == 0, "Unexpected error detected"
 
         # Wait for the interrupt signal to go low
-        irq = tb.dut.xi3c_wrapper.gen_target_config.i3c.irq_o
+        irq = resolve_path(tb.dut.xi3c_wrapper, "gen_target_config.i3c.irq_o")
         if irq.value != 0:
             await FallingEdge(irq)
 

--- a/verification/cocotb/top/lib_i3c_top/test_ibi.py
+++ b/verification/cocotb/top/lib_i3c_top/test_ibi.py
@@ -24,7 +24,7 @@ import cocotb
 from cocotb.regression import TestFactory
 from cocotb.result import SimTimeoutError
 from cocotb.triggers import ClockCycles, RisingEdge, Timer, with_timeout
-from common import timeout_task, log_seed
+from common import timeout_task, log_seed, resolve_path
 
 # =============================================================================
 # Constants
@@ -1568,12 +1568,7 @@ async def test_ibi_flush_from_idle_interrupt_flood(dut):
     await init_ibi(i3c_controller, tb, retry_num=0)
 
     # Internal signal handles
-    standby = (
-        dut.xi3c_wrapper.gen_target_config
-        .i3c.xcontroller.gen_target_controller_standby
-        .xcontroller_standby
-        .xcontroller_standby_i3c
-    )
+    standby = (resolve_path(dut.xi3c_wrapper, "gen_target_config.i3c.xcontroller.gen_target_controller_standby.xcontroller_standby.xcontroller_standby_i3c"))
     fsm = standby.xi3c_target_fsm
     desc_ibi = standby.u_descriptor_ibi
 
@@ -1997,7 +1992,7 @@ async def test_descriptor_ibi_flush_one_word(dut):
 
     try:
         # Internal signal handles
-        standby = dut.xi3c_wrapper.gen_target_config.i3c.xcontroller.xcontroller_standby.xcontroller_standby_i3c
+        standby = resolve_path(dut.xi3c_wrapper, "gen_target_config.i3c.xcontroller.xcontroller_standby.xcontroller_standby_i3c")
         desc_ibi = standby.u_descriptor_ibi
 
         dut._log.info("Phase 1: Queue an IBI with 1 word of data (e.g. 2 bytes)")
@@ -2037,7 +2032,7 @@ async def test_descriptor_ibi_flush_no_data(dut):
 
     try:
         # Internal signal handles
-        standby = dut.xi3c_wrapper.gen_target_config.i3c.xcontroller.xcontroller_standby.xcontroller_standby_i3c
+        standby = resolve_path(dut.xi3c_wrapper, "gen_target_config.i3c.xcontroller.xcontroller_standby.xcontroller_standby_i3c")
         desc_ibi = standby.u_descriptor_ibi
 
         dut._log.info("Phase 1: Queue an IBI with 0 words of data")
@@ -2077,7 +2072,7 @@ async def test_descriptor_ibi_flush_max_word(dut):
 
     try:
         # Internal signal handles
-        standby = dut.xi3c_wrapper.gen_target_config.i3c.xcontroller.xcontroller_standby.xcontroller_standby_i3c
+        standby = resolve_path(dut.xi3c_wrapper, "gen_target_config.i3c.xcontroller.xcontroller_standby.xcontroller_standby_i3c")
         desc_ibi = standby.u_descriptor_ibi
 
         dut._log.info("Phase 1: Queue a standard IBI")

--- a/verification/cocotb/top/lib_i3c_top/test_ibi_multi_queue.py
+++ b/verification/cocotb/top/lib_i3c_top/test_ibi_multi_queue.py
@@ -29,7 +29,7 @@ import cocotb
 from cocotb.handle import Force, Release
 from cocotb.result import SimTimeoutError
 from cocotb.triggers import ClockCycles, RisingEdge, Timer, with_timeout
-from common import timeout_task, log_seed
+from common import timeout_task, log_seed, resolve_path
 
 # =============================================================================
 # Constants
@@ -536,7 +536,7 @@ async def test_ibi_multi_queue_flush_large_payload(dut):
     await init_ibi(i3c_controller, tb)
 
     # Internal signal handles for coverage injection
-    standby = dut.xi3c_wrapper.gen_target_config.i3c.xcontroller.gen_target_controller_standby.xcontroller_standby.xcontroller_standby_i3c
+    standby = resolve_path(dut.xi3c_wrapper, "gen_target_config.i3c.xcontroller.gen_target_controller_standby.xcontroller_standby.xcontroller_standby_i3c")
     desc_ibi = standby.u_descriptor_ibi
 
     # IBI #0 has 20 bytes payload (will be truncated to 4)

--- a/verification/cocotb/top/lib_i3c_top/test_recovery.py
+++ b/verification/cocotb/top/lib_i3c_top/test_recovery.py
@@ -21,7 +21,7 @@ VIRT_STATIC_ADDR = 0x5B
 DYNAMIC_ADDR = 0x52
 VIRT_DYNAMIC_ADDR = 0x53
 
-from common import VALID_I3C_ADDRESSES, timeout_task, log_seed
+from common import VALID_I3C_ADDRESSES, timeout_task, log_seed, resolve_path
 
 ocp_magic_string_as_bytes = [
     0x4F,  # 'O'
@@ -7956,7 +7956,7 @@ async def test_recovery_hdr_abort_per_state(dut):
 
     # Get reference to recovery receiver state_q signal
     try:
-        recovery_rx = dut.xi3c_wrapper.gen_target_config.i3c.xrecovery_handler.xrecovery_receiver
+        recovery_rx = resolve_path(dut.xi3c_wrapper, "gen_target_config.i3c.xrecovery_handler.xrecovery_receiver")
         state_sig = recovery_rx.state_q
     except AttributeError:
         dut._log.warning("Cannot access recovery_receiver.state_q -- skipping per-state test")

--- a/verification/cocotb/top/lib_i3c_top/tti_monitor.py
+++ b/verification/cocotb/top/lib_i3c_top/tti_monitor.py
@@ -13,6 +13,7 @@ on violation to fail the test.
 
 import cocotb
 from cocotb.triggers import RisingEdge, First
+from common import resolve_path
 
 
 class TtiQueueMonitor:
@@ -33,8 +34,8 @@ class TtiQueueMonitor:
         self._running = False
 
         # Resolve signal handles once
-        tti = getattr(dut, "xi3c_wrapper").gen_target_config.i3c.gen_target_tti.xtti
-        rec = getattr(dut, "xi3c_wrapper").gen_target_config.i3c.gen_target_recovery_handler.xrecovery_handler
+        tti = resolve_path(dut.xi3c_wrapper, "gen_target_config.i3c.gen_target_tti.xtti")
+        rec = resolve_path(dut.xi3c_wrapper, "gen_target_config.i3c.gen_target_recovery_handler.xrecovery_handler")
         self._rx_desc_write_r = tti.rx_desc_queue_write_r
         self._rx_data_write_r = tti.rx_data_queue_write_r
         self._recovery_pending = rec.recovery_pending


### PR DESCRIPTION
Rewrite the way types from the `csr_cfg_t` type are accessed.
The previously used form isn't accepted by all simulators. Use a more portable access pattern to improve tool compatibility.